### PR TITLE
Add a document component for meta data.

### DIFF
--- a/examples/dom-bindings/src/App.js
+++ b/examples/dom-bindings/src/App.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import './App.css';
 
-import { Document } from 'react-pdf-dom';
-import { View, Text, Page, StyleSheet } from 'react-pdf';
+import { Document as Pdf } from 'react-pdf-dom';
+import { View, Text, Page, Document, StyleSheet } from 'react-pdf';
 
 const styles = StyleSheet.create({
   container: {
@@ -23,32 +23,34 @@ class App extends Component {
           <h2>Welcome to React PDF</h2>
         </div>
         <p className="App-intro">
-          <Document height="100%" width="100%">
-            <Page size="A4">
-              <View style={styles.container}>
-                <Text>
-                  Text
-                </Text>
-                <View style={styles.block}>
+          <Pdf height="100%" width="100%">
+            <Document>
+              <Page size="A4">
+                <View style={styles.container}>
                   <Text>
-                    More text
+                    Text
                   </Text>
+                  <View style={styles.block}>
+                    <Text>
+                      More text
+                    </Text>
+                  </View>
                 </View>
-              </View>
-            </Page>
-            <Page size="A4">
-              <View style={styles.container}>
-                <Text>
-                  Text
-                </Text>
-                <View style={styles.block}>
+              </Page>
+              <Page size="A4">
+                <View style={styles.container}>
                   <Text>
-                    More text
+                    Text
                   </Text>
+                  <View style={styles.block}>
+                    <Text>
+                      More text
+                    </Text>
+                  </View>
                 </View>
-              </View>
-            </Page>
-          </Document>
+              </Page>
+            </Document>
+          </Pdf>
         </p>
       </div>
     );

--- a/examples/dom-bindings/src/App.js
+++ b/examples/dom-bindings/src/App.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import './App.css';
 
-import { Document as Pdf } from 'react-pdf-dom';
-import { View, Text, Page, Document, StyleSheet } from 'react-pdf';
+import { Document } from 'react-pdf-dom';
+import { View, Text, Page, StyleSheet } from 'react-pdf';
 
 const styles = StyleSheet.create({
   container: {
@@ -23,34 +23,32 @@ class App extends Component {
           <h2>Welcome to React PDF</h2>
         </div>
         <p className="App-intro">
-          <Pdf height="100%" width="100%">
-            <Document>
-              <Page size="A4">
-                <View style={styles.container}>
+          <Document height="100%" width="100%">
+            <Page size="A4">
+              <View style={styles.container}>
+                <Text>
+                  Text
+                </Text>
+                <View style={styles.block}>
                   <Text>
-                    Text
+                    More text
                   </Text>
-                  <View style={styles.block}>
-                    <Text>
-                      More text
-                    </Text>
-                  </View>
                 </View>
-              </Page>
-              <Page size="A4">
-                <View style={styles.container}>
+              </View>
+            </Page>
+            <Page size="A4">
+              <View style={styles.container}>
+                <Text>
+                  Text
+                </Text>
+                <View style={styles.block}>
                   <Text>
-                    Text
+                    More text
                   </Text>
-                  <View style={styles.block}>
-                    <Text>
-                      More text
-                    </Text>
-                  </View>
                 </View>
-              </Page>
-            </Document>
-          </Pdf>
+              </View>
+            </Page>
+          </Document>
         </p>
       </div>
     );

--- a/examples/simple/example.js
+++ b/examples/simple/example.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactPDF, { Page, View, Text, StyleSheet } from 'react-pdf';
+import ReactPDF, { Page, View, Text, StyleSheet, Document } from 'react-pdf';
 import lorem from './lorem';
 
 const styles = StyleSheet.create({
@@ -14,18 +14,20 @@ const styles = StyleSheet.create({
 });
 
 const doc = (
-  <Page size="A4">
-    <View style={styles.container}>
-      <Text>
-        Text
-      </Text>
-      <View style={styles.block}>
+  <Document>
+    <Page size="A4">
+      <View style={styles.container}>
         <Text>
-          {lorem}
+          Text
         </Text>
+        <View style={styles.block}>
+          <Text>
+            {lorem}
+          </Text>
+        </View>
       </View>
-    </View>
-  </Page>
+    </Page>
+  </Document>
 );
 
 ReactPDF.render(doc, `${__dirname}/example.pdf`);

--- a/packages/react-pdf-dom/src/Document.js
+++ b/packages/react-pdf-dom/src/Document.js
@@ -1,6 +1,7 @@
 /* global URL */
 import React, { Component, PropTypes } from 'react';
 import { PDFRenderer, Document, createElement, pdf } from 'react-pdf';
+import omit from 'lodash/fp/omit';
 
 class Container extends Component {
   static displayName = 'Document';
@@ -27,7 +28,9 @@ class Container extends Component {
     this.mountNode = PDFRenderer.createContainer(this.container);
 
     PDFRenderer.updateContainer(
-      <Document>{this.props.children}</Document>,
+      <Document {...omit(['height', 'width', 'children'], this.props)}>
+        {this.props.children}
+      </Document>,
       this.mountNode,
       this,
     );
@@ -38,7 +41,9 @@ class Container extends Component {
 
   componentDidUpdate() {
     PDFRenderer.updateContainer(
-      <Document>{this.props.children}</Document>,
+      <Document {...omit(['height', 'width', 'children'], this.props)}>
+        {this.props.children}
+      </Document>,
       this.mountNode,
       this,
     );

--- a/packages/react-pdf-dom/src/Document.js
+++ b/packages/react-pdf-dom/src/Document.js
@@ -1,8 +1,10 @@
 /* global URL */
 import React, { Component, PropTypes } from 'react';
-import { PDFRenderer, createElement, pdf } from 'react-pdf';
+import { PDFRenderer, Document, createElement, pdf } from 'react-pdf';
 
-class Document extends Component {
+class Container extends Component {
+  static displayName = 'Document';
+
   container = createElement('ROOT');
 
   static propTypes = {
@@ -23,18 +25,23 @@ class Document extends Component {
 
   componentDidMount() {
     this.mountNode = PDFRenderer.createContainer(this.container);
-    PDFRenderer.updateContainer(this.props.children, this.mountNode, this);
-    this.renderer.toBlob(this.container);
 
+    PDFRenderer.updateContainer(
+      <Document>{this.props.children}</Document>,
+      this.mountNode,
+      this,
+    );
+
+    this.renderer.toBlob(this.container);
     this.embed.src = URL.createObjectURL(this.renderer.toBlob(this.container));
   }
 
-  onSuccess() {
-    this.setState({});
-  }
-
   componentDidUpdate() {
-    PDFRenderer.updateContainer(this.props.children, this.mountNode, this);
+    PDFRenderer.updateContainer(
+      <Document>{this.props.children}</Document>,
+      this.mountNode,
+      this,
+    );
   }
 
   componentWillUnmount() {
@@ -55,4 +62,4 @@ class Document extends Component {
   }
 }
 
-export default Document;
+export default Container;

--- a/packages/react-pdf-dom/src/Document.js
+++ b/packages/react-pdf-dom/src/Document.js
@@ -3,7 +3,7 @@ import React, { Component, PropTypes } from 'react';
 import { PDFRenderer, createElement, pdf } from 'react-pdf';
 
 class Document extends Component {
-  container = createElement('DOCUMENT');
+  container = createElement('ROOT');
 
   static propTypes = {
     children: PropTypes.node,

--- a/packages/react-pdf/src/elements/Catalog.js
+++ b/packages/react-pdf/src/elements/Catalog.js
@@ -1,0 +1,5 @@
+import Base from './Base';
+
+class Catalog extends Base {}
+
+export default Catalog;

--- a/packages/react-pdf/src/elements/index.js
+++ b/packages/react-pdf/src/elements/index.js
@@ -1,3 +1,4 @@
+import Catalog from './Catalog';
 import Text from './Text';
 import View from './View';
 import Page from './Page';
@@ -7,8 +8,12 @@ function createElement(type, props) {
   let instance;
 
   switch (type) {
+    case 'ROOT':
+      instance = new Catalog();
+      return instance;
     case 'DOCUMENT':
       instance = new Document();
+      instance.applyProps(props);
       return instance;
     case 'PAGE':
       instance = new Page();
@@ -16,8 +21,6 @@ function createElement(type, props) {
       return instance;
     case 'TEXT':
       instance = new Text();
-      // console.log(instance);
-      // instance.applyProps(props);
       return instance;
     case 'VIEW':
       instance = new View();

--- a/packages/react-pdf/src/index.js
+++ b/packages/react-pdf/src/index.js
@@ -5,6 +5,7 @@ import renderer, {
   View,
   Text,
   Page,
+  Document,
   createElement,
 } from './renderer';
 import StyleSheet from './Stylesheet';
@@ -17,6 +18,7 @@ export {
   View,
   Text,
   Page,
+  Document,
   StyleSheet,
   createElement,
 };

--- a/packages/react-pdf/src/pdf/index.js
+++ b/packages/react-pdf/src/pdf/index.js
@@ -134,7 +134,6 @@ function pdf() {
   function traverseTree(input) {
     const pages = [];
     let pageCount = 0;
-    let curPage;
 
     function getValueOf(instance) {
       return instance.valueOf();
@@ -146,7 +145,7 @@ function pdf() {
 
         if (value.Type === 'Page') {
           pages.push(value);
-          curPage = pageCount++;
+          pageCount++;
         }
 
         loopItem(child);
@@ -218,8 +217,6 @@ ${offsets[offsets.length - 1]}
     const {
       pages,
     } = traverseTree(input);
-
-    console.log(pages);
 
     pages.forEach(({ width, height }) => {
       refs.pageList.push(

--- a/packages/react-pdf/src/pdf/index.js
+++ b/packages/react-pdf/src/pdf/index.js
@@ -141,7 +141,7 @@ function pdf() {
     }
 
     function loopItem(item) {
-      input.children.forEach(child => {
+      item.children.forEach(child => {
         const value = getValueOf(child);
 
         if (value.Type === 'Page') {
@@ -149,7 +149,7 @@ function pdf() {
           curPage = pageCount++;
         }
 
-        traverseTree(child);
+        loopItem(child);
       });
     }
 
@@ -218,6 +218,8 @@ ${offsets[offsets.length - 1]}
     const {
       pages,
     } = traverseTree(input);
+
+    console.log(pages);
 
     pages.forEach(({ width, height }) => {
       refs.pageList.push(

--- a/packages/react-pdf/src/renderer.js
+++ b/packages/react-pdf/src/renderer.js
@@ -31,7 +31,7 @@ const PDFRenderer = ReactFiberReconciler({
     props,
     rootContainerInstance,
     hostContext,
-    internalInstanceHandle,
+    internalInstanceHandle
   ) {
     return createElement(type, props);
   },
@@ -54,7 +54,7 @@ const PDFRenderer = ReactFiberReconciler({
     oldProps,
     newProps,
     rootContainerInstance,
-    internalInstanceHandle,
+    internalInstanceHandle
   ) {
     // noop
   },
@@ -64,7 +64,7 @@ const PDFRenderer = ReactFiberReconciler({
     type,
     newProps,
     rootContainerInstance,
-    internalInstanceHandle,
+    internalInstanceHandle
   ) {
     // noop
   },
@@ -81,7 +81,7 @@ const PDFRenderer = ReactFiberReconciler({
     text,
     rootContainerInstance,
     hostContext,
-    internalInstanceHandle,
+    internalInstanceHandle
   ) {
     return createElement('TEXT', { content: 'TEXT' });
   },
@@ -119,7 +119,7 @@ const PDFRenderer = ReactFiberReconciler({
 
 const ReactPDFFiberRenderer = {
   render(element, filePath) {
-    const container = createElement('DOCUMENT');
+    const container = createElement('ROOT');
 
     const node = PDFRenderer.createContainer(container);
     PDFRenderer.updateContainer(element, node, null);
@@ -135,7 +135,7 @@ const ReactPDFFiberRenderer = {
         if (err) throw new Error(`PDF-react 'Error writing file: ${err}'`);
         fs.close(fd, function() {
           console.log(
-            `📝  PDF successfuly exported on ${path.resolve(filePath)}`,
+            `📝  PDF successfuly exported on ${path.resolve(filePath)}`
           );
         });
       });
@@ -149,6 +149,7 @@ const ReactPDFFiberRenderer = {
 const View = 'VIEW';
 const Text = 'TEXT';
 const Page = 'PAGE';
+const Document = 'DOCUMENT';
 
 export {
   ReactPDFFiberRenderer as default,
@@ -156,5 +157,6 @@ export {
   View,
   Text,
   Page,
+  Document,
   createElement,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,0 @@
-'use strict';
-
-import renderer from './renderer';
-
-export default renderer;


### PR DESCRIPTION
This also include a stupid mistake within tree traversal :)

This was needed for including fonts and other meta data within the PDF file. Needs to be always the root of the tree.