### PR TITLE
Run Travis only on the osx image for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: node_js
+
 node_js:
  - '7'
  - '6'
+
+os:
+ - osx
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This is because yoga-layout needs to compile itself first before we can use it, and the dependencies to do so are not default available on linux.

For now I only enabled osx, in the future we need to do the same for windows and linux.