### PR TITLE
Fix indentation in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ const MyDocument = () => (
       <View style={styles.section}>
         <Text>Section #1</Text>
       </View>
-    <View style={styles.section}>
-      <Text>Section #2</Text>
-    </View>
-  </Page>
-</Document>
+      <View style={styles.section}>
+        <Text>Section #2</Text>
+      </View>
+    </Page>
+  </Document>
 );
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Nitpicky change, but valid nonetheless!