### PR TITLE
Fixing tests by stubing system date

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react": "^7.0.1",
     "husky": "^0.13.2",
     "lint-staged": "^3.4.2",
+    "mockdate": "^2.0.1",
     "prettier": "^1.3.1"
   },
   "dependencies": {

--- a/packages/react-pdf/specs/__snapshots__/pageSpec.js.snap
+++ b/packages/react-pdf/specs/__snapshots__/pageSpec.js.snap
@@ -6,7 +6,7 @@ exports[`<Page /> Should render given background color 1`] = `
 9 0 obj
 <<
 /Keywords ()
-/CreationDate (D:20170422014110)
+/CreationDate (D:20151131210000)
 /Creator (react-pdf)
 /Producer (react-pdf)
 >>
@@ -94,7 +94,7 @@ exports[`<Page /> Should render given size 1`] = `
 1 0 obj
 <<
 /Keywords ()
-/CreationDate (D:20170422014110)
+/CreationDate (D:20151131210000)
 /Creator (react-pdf)
 /Producer (react-pdf)
 >>
@@ -182,7 +182,7 @@ exports[`<Page /> Should render landscape page 1`] = `
 17 0 obj
 <<
 /Keywords ()
-/CreationDate (D:20170422014110)
+/CreationDate (D:20151131210000)
 /Creator (react-pdf)
 /Producer (react-pdf)
 >>

--- a/packages/react-pdf/specs/__snapshots__/pageSpec.js.snap
+++ b/packages/react-pdf/specs/__snapshots__/pageSpec.js.snap
@@ -6,7 +6,7 @@ exports[`<Page /> Should render given background color 1`] = `
 9 0 obj
 <<
 /Keywords ()
-/CreationDate (D:20151131210000)
+/CreationDate (D:20160101000000)
 /Creator (react-pdf)
 /Producer (react-pdf)
 >>
@@ -94,7 +94,7 @@ exports[`<Page /> Should render given size 1`] = `
 1 0 obj
 <<
 /Keywords ()
-/CreationDate (D:20151131210000)
+/CreationDate (D:20160101000000)
 /Creator (react-pdf)
 /Producer (react-pdf)
 >>
@@ -182,7 +182,7 @@ exports[`<Page /> Should render landscape page 1`] = `
 17 0 obj
 <<
 /Keywords ()
-/CreationDate (D:20151131210000)
+/CreationDate (D:20160101000000)
 /Creator (react-pdf)
 /Producer (react-pdf)
 >>

--- a/packages/react-pdf/specs/pageSpec.js
+++ b/packages/react-pdf/specs/pageSpec.js
@@ -3,6 +3,15 @@ import { Document, Page } from '../src';
 import render from './testRenderer';
 
 describe('<Page />', () => {
+  beforeEach(() => {
+    const DATE_TO_USE = new Date('2016');
+    const _Date = Date;
+    global.Date = jest.fn(() => DATE_TO_USE);
+    global.Date.UTC = _Date.UTC;
+    global.Date.parse = _Date.parse;
+    global.Date.now = _Date.now;
+  });
+
   const page = (props = {}) => (
     <Document>
       <Page {...props} />

--- a/packages/react-pdf/specs/pageSpec.js
+++ b/packages/react-pdf/specs/pageSpec.js
@@ -1,15 +1,11 @@
 import React from 'react';
 import { Document, Page } from '../src';
+import MockDate from 'mockdate';
 import render from './testRenderer';
 
 describe('<Page />', () => {
   beforeEach(() => {
-    const DATE_TO_USE = new Date('2016');
-    const _Date = Date;
-    global.Date = jest.fn(() => DATE_TO_USE);
-    global.Date.UTC = _Date.UTC;
-    global.Date.parse = _Date.parse;
-    global.Date.now = _Date.now;
+    MockDate.set(new Date('2016', '1', '1'));
   });
 
   const page = (props = {}) => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3199,6 +3199,10 @@ minimist@^0.1.0:
   dependencies:
     minimist "0.0.8"
 
+mockdate@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-2.0.1.tgz#51bc309e2c4396600d56b6c23a6a0f4182943a36"
+
 modify-values@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.0.tgz#e2b6cdeb9ce19f99317a53722f3dbf5df5eaaab2"


### PR DESCRIPTION
According to jest snapshot testing documentation
(https://facebook.github.io/jest/docs/snapshot-testing.html) tests
should be deterministic that means that every time they run should
return the same result, but that was not posible with the previous
approach because date was changing every time tests runs, by stubbing
the date, tests can be deterministic again.