### PR TITLE
fix(core/index): lowercase stylesheet import

### DIFF
--- a/packages/react-pdf/src/index.js
+++ b/packages/react-pdf/src/index.js
@@ -2,7 +2,7 @@
 'use strict';
 
 import { PDFRenderer, createElement } from './renderer';
-import StyleSheet from './Stylesheet';
+import StyleSheet from './stylesheet';
 
 const View = 'VIEW';
 const Text = 'TEXT';


### PR DESCRIPTION
Problem:
```
➜  react-pdf git:(upstream-master) ✗ yarn example -- text               
yarn example v0.24.6
$ babel-node ./examples/index.js text
{ Error: Cannot find module './Stylesheet'
    at Function.Module._resolveFilename (module.js:470:15)
    at Function.Module._load (module.js:418:25)
    at Module.require (module.js:498:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/theophile/new/react-pdf/packages/react-pdf/lib/index.js:11:19)
    at Module._compile (module.js:571:32)
    at loader (/home/theophile/new/react-pdf/node_modules/babel-register/lib/node.js:144:5)
    at Object.require.extensions.(anonymous function) [as .js] (/home/theophile/new/react-pdf/node_modules/babel-register/lib/node.js:154:7)
    at Module.load (module.js:488:32)
    at tryModuleLoad (module.js:447:12) code: 'MODULE_NOT_FOUND' }
Done in 1.25s.
```
The culprit being [this guy](https://github.com/diegomura/react-pdf/blob/master/packages/react-pdf/src/index.js#L5)

This PR solves this import and the example are running fine again