### PR TITLE
Support streaming output for nodejs

### DIFF
--- a/packages/react-pdf-node/src/index.js
+++ b/packages/react-pdf-node/src/index.js
@@ -1,15 +1,18 @@
 import fs from 'fs';
 import path from 'path';
-import { PDFRenderer, createElement, pdf } from '@react-pdf/core';
+import { createElement, pdf, PDFRenderer } from '@react-pdf/core';
 
 export default {
-  async render(element, filePath, callback) {
+  async renderToStream(element) {
     const container = createElement('ROOT');
     const node = PDFRenderer.createContainer(container);
 
     PDFRenderer.updateContainer(element, node, null);
 
-    const output = await pdf(container).toBuffer();
+    return await pdf(container).toBuffer();
+  },
+  async renderToFile(element, filePath, callback) {
+    const output = await this.renderToStream(element);
     const stream = fs.createWriteStream(filePath);
     output.pipe(stream);
 
@@ -21,10 +24,13 @@ export default {
         resolve(output);
 
         console.log(
-          `📝  PDF successfuly exported on ${path.resolve(filePath)}`,
+          `📝  PDF successfully exported on ${path.resolve(filePath)}`,
         );
       });
       stream.on('error', reject);
     });
+  },
+  async render(element, filePath, callback) {
+    return await this.renderToFile(element, filePath, callback);
   },
 };


### PR DESCRIPTION
Closes https://github.com/diegomura/react-pdf/issues/152

This adds support for streaming the PDF response. As a result it can be directly used by subsequent node calls, instead of having to write a file and reading it again.

I made the renderToStream a first class citizen, with the `renderToFile` effectively using that stream. To prevent future confusion, the `render` method directs to the `renderToFile` method. However since it may confuse people, that method might need deprecation/removal in the future.