### PR TITLE
Protect against parentInstance not being a node when unmounting

### DIFF
--- a/packages/react-pdf/src/renderer.js
+++ b/packages/react-pdf/src/renderer.js
@@ -91,7 +91,9 @@ const PDFRenderer = ReactFiberReconciler({
     },
 
     removeChildFromContainer(parentInstance, child) {
-      parentInstance.removeChild(child);
+      if (parentInstance.removeChild) {
+        parentInstance.removeChild(child);
+      }
     },
 
     commitTextUpdate(textInstance, oldText, newText) {


### PR DESCRIPTION
Fixes #182 