### PR TITLE
Check image extension with buffer

### DIFF
--- a/packages/react-pdf/src/utils/image.js
+++ b/packages/react-pdf/src/utils/image.js
@@ -39,8 +39,6 @@ export const fetchImage = src => {
           return reject(error);
         }
 
-        let extension = '';
-
         const isPng =
           body[0] === 137 &&
           body[1] === 80 &&
@@ -53,6 +51,7 @@ export const fetchImage = src => {
 
         const isJpg = body[0] === 255 && body[1] === 216 && body[2] === 255;
 
+        let extension = '';
         if (isPng) {
           extension = 'png';
         } else if (isJpg) {

--- a/packages/react-pdf/src/utils/image.js
+++ b/packages/react-pdf/src/utils/image.js
@@ -27,7 +27,6 @@ export const fetchImage = src => {
     );
   }
 
-  const extension = src.split('.').pop();
   return new Promise((resolve, reject) => {
     request(
       {
@@ -39,6 +38,26 @@ export const fetchImage = src => {
         if (error) {
           return reject(error);
         }
+
+        let extension = '';
+
+        const isPng =
+          body[0] === 137 &&
+          body[1] === 80 &&
+          body[2] === 78 &&
+          body[3] === 71 &&
+          body[4] === 13 &&
+          body[5] === 10 &&
+          body[6] === 26 &&
+          body[7] === 10;
+
+        const isJpg = body[0] === 255 && body[1] === 216 && body[2] === 255;
+
+        if (isPng) {
+          extension = 'png';
+        } else if (isJpg) {
+          extension = 'jpg';
+        } else reject(new Error('Not valid image extension'));
 
         const image = getImage(body, extension);
         return resolve(image);


### PR DESCRIPTION
The previous check was weak and did not check the actual extension (format) of the file. Now the test is done using a buffer.

This solves the problem when the image extension specified in the title does not match the actual format.