### PR TITLE
Import error fix - Fix for issue #266

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "presets": [
     ["env", {
       "loose": true,
-      "modules": false,
       "targets": {
         "node": "8.11.3",
         "browsers": ["last 2 versions", "IE 11"]


### PR DESCRIPTION
This will fix #266 
Removing `"modules": false,` will default modules to `"commonjs"`