### PR TITLE
Fixed module path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "homepage": "https://github.com/diegomura/react-pdf#readme",
   "repository": "git@github.com:diegomura/react-pdf.git",
   "main": "dist/react-pdf.cjs.js",
-  "module": "dist/react-pdf.esm.js",
+  "module": "dist/react-pdf.es.js",
   "browser": {
     "./dist/react-pdf.es.js": "./dist/react-pdf.browser.es.js",
     "./dist/react-pdf.cjs.js": "./dist/react-pdf.browser.cjs.js"


### PR DESCRIPTION
If you import package as `es` module you'll receive `cjs` module version instead of `es`. Most likely it's just a typo in module path definition in `package.json`. This PR solves this issue:

<img width="859" alt="screen shot 2018-08-05 at 16 01 18" src="https://user-images.githubusercontent.com/950216/43686131-3cc2c4cc-98c9-11e8-884f-8976119cf2fa.png">
