### PR TITLE
ensure backward compatibility with height and width props

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -61,7 +61,7 @@ export class Document extends Component {
   }
 
   render() {
-    const { className, width, height, style } = this.props;
+    const { className, width = null, height = null, style } = this.props;
 
     return (
       <iframe
@@ -69,7 +69,11 @@ export class Document extends Component {
         ref={container => {
           this.embed = container;
         }}
-        style={Array.isArray(style) ? flatStyles(style) : style}
+        style={
+          Array.isArray(style)
+            ? { width, height, ...flatStyles(style) }
+            : { width, height, ...style }
+        }
       />
     );
   }


### PR DESCRIPTION
in this PR, I ensure users from previous version of `@react-pdf/renderer` (from version alpha 14 and below) to be able to keep their code that has `width` and `height` props to their `<Document />` component.

I put `width` and `height` before `style`, because users from previous package version (by my assumption) would not have `style` props defined. So that if migrating users defined `style` after they upgraded, the defined `style` will have its effect, the spread operator will replace the `width` and `height` from props.

###### **p.s.** this is my first contribution to github community, please let me know if my PR's quality standard is not enough or something went wrong. thank you :) ######