### PR TITLE
Pass props through from PDFViewer to iframe viewer

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -75,7 +75,7 @@ export const BlobProvider = ({ document: doc, children }) => {
   return <InternalBlobProvider document={doc}>{children}</InternalBlobProvider>;
 };
 
-export const PDFViewer = ({ className, style, children }) => {
+export const PDFViewer = ({ className, style, children, ...props }) => {
   return (
     <InternalBlobProvider document={children}>
       {({ url }) => (
@@ -83,6 +83,7 @@ export const PDFViewer = ({ className, style, children }) => {
           className={className}
           src={url}
           style={Array.isArray(style) ? flatStyles(style) : style}
+          {...props}
         />
       )}
     </InternalBlobProvider>

--- a/tests/domApi.test.js
+++ b/tests/domApi.test.js
@@ -82,6 +82,13 @@ describe('DOM API', () => {
     expect(wrapper.find('iframe')).toHaveLength(1);
   });
 
+  test('PDFViewer should pass unused props to iframe viewer', () => {
+    const wrapper = mount(
+      <PDFViewer name="PDFViewer-test-name">{doc}</PDFViewer>,
+    );
+    expect(wrapper.find('iframe').prop('name')).toEqual('PDFViewer-test-name');
+  });
+
   test('PDFDownloadLink as root should anchor tag and children', () => {
     const wrapper = mount(
       <PDFDownloadLink document={doc}>Download</PDFDownloadLink>,


### PR DESCRIPTION
This would allow arbitrary props to be passed through to the iframe viewer that `PDFViewer` returns. This lets us attach an `onLoad` event handler to the iframe, but would also allow any other props to be passed.