### PR TITLE
fix react import typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 declare module '@react-pdf/renderer' {
-  import React from 'react';
+  import * as React from 'react';
 
   namespace ReactPDF {
     interface Style {


### PR DESCRIPTION
Importing and using `Document` from `@react-pdf/renderer` throws this Typescript error: 
`TS2605: JSX element type 'Document' is not a constructor function for JSX elements.`

Looking at `@react-pdf`'s declaration file, I noticed that it tries to import the default export exported by `react`. `react` has no default export.

A workaround for this problem would be to enable `allowSyntheticDefaultImports` in the project's `tsconfig.json` file, but it's a workaround. 

This PR would fix the Typescript error without needing to enable `allowSyntheticDefaultImports`.