### PR TITLE
add type string to PDFViewerProps width and height

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -165,8 +165,8 @@ declare module '@react-pdf/renderer' {
     class BlobProvider extends React.Component<BlobProviderProps> {}
 
     interface PDFViewerProps {
-      width?: number;
-      height?: number;
+      width?: number | string;
+      height?: number | string;
       style?: Style | Style[];
       className?: string;
       children?: React.ReactElement<DocumentProps>;


### PR DESCRIPTION
the official docs mention width and height of PDFViewer support both number and string