### PR TITLE
fix(Text): dont add additional x value for lines

### DIFF
--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -283,7 +283,7 @@ class Text extends Base {
     const initialX = this.lines[0] ? this.lines[0].rect.y : 0;
 
     this.lines.forEach(line => {
-      line.rect.x += left + padding.left;
+      line.rect.x = left + padding.left;
       line.rect.y += top + padding.top - initialX;
     });
 

--- a/tests/text.test.js
+++ b/tests/text.test.js
@@ -4,6 +4,12 @@ import Text from '../src/elements/Text';
 import TextInstance from '../src/elements/TextInstance';
 import root from './utils/dummyRoot';
 
+jest.mock('@textkit/pdf-renderer', () => () =>
+  class PDFRendererMock {
+    render() {}
+  },
+);
+
 let dummyRoot;
 
 describe('Text', () => {
@@ -27,5 +33,28 @@ describe('Text', () => {
 
     expect(text.layoutEngine.layout.mock.calls).toHaveLength(1);
     expect(text.layoutEngine.layout.mock.calls[0][0].string).toBe('');
+  });
+
+  test('Should render the same rect x value for clones', async () => {
+    const text = new Text(dummyRoot, {});
+    const textInstance = new TextInstance(dummyRoot, 'sometext');
+
+    text.appendChild(textInstance);
+
+    text.getAbsoluteLayout = () => ({ top: 20, left: 20 });
+    text.layoutText(100, 100);
+
+    await text.render();
+
+    const textRectX = text.lines[0].rect.x;
+
+    const clone = text.clone();
+
+    clone.layoutText(100, 100);
+    clone.getAbsoluteLayout = () => ({ top: 20, left: 20 });
+
+    await clone.render();
+
+    expect(clone.lines[0].rect.x).toEqual(textRectX);
   });
 });


### PR DESCRIPTION
When Text nodes are cloned, the container is copied over, including x offsets for each line. For `fixed` Text elements, this means that the x value was being accumulated on top of the original rect offset which resulted in this shifting effect that gradually grows worse for each page the `fixed` element shows up on.

I don't have an exact repro jsx but it would look roughly like this:

```jsx
<Document>
  <Page>
    {/* Foo shows up fine on the first page, but is shifted to the right 
         8 pixels on subsequent pages 
    */}
    <Text style={{ padding: 8 }} fixed>Foo</Text>
     <LotsOfOtherContent />
  </Page>
</Document>
```

Before fix:
![image](https://user-images.githubusercontent.com/8746094/51868126-1de58a80-2302-11e9-933a-94e9921b9458.png)



After fix:
![image](https://user-images.githubusercontent.com/8746094/51868153-33f34b00-2302-11e9-9d6e-85f63090a835.png)

Fixes #361