### PR TITLE
Alias yoga-layout-prebuilt to yoga-layout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,7 @@
 module.exports = {
   testRegex: 'tests/.*?(test)\\.js$',
   setupFiles: ['<rootDir>tests/utils/setupTests.js'],
+  moduleNameMapper: {
+    'yoga-layout': 'yoga-layout-prebuilt',
+  },
 };

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "react-dom": "^16.5.0",
     "rimraf": "^2.6.1",
     "rollup": "^0.52.2",
+    "rollup-plugin-alias": "^1.5.1",
     "rollup-plugin-babel": "^2.7.1",
     "rollup-plugin-bundle-size": "^1.0.2",
     "rollup-plugin-ignore": "^1.0.3",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,12 @@ import sourceMaps from 'rollup-plugin-sourcemaps';
 import bundleSize from 'rollup-plugin-bundle-size';
 import ignore from 'rollup-plugin-ignore';
 import json from 'rollup-plugin-json';
+import alias from 'rollup-plugin-alias';
 import pkg from './package.json';
+
+const moduleAliases = {
+  'yoga-layout': 'yoga-layout-prebuilt',
+};
 
 const cjs = {
   exports: 'named',
@@ -48,7 +53,7 @@ const babelConfig = ({ browser }) => ({
   ],
 });
 
-const commonPlugins = [json(), sourceMaps(), nodeResolve(), bundleSize()];
+const commonPlugins = [json(), sourceMaps(), alias(moduleAliases), nodeResolve(), bundleSize()];
 
 const configBase = {
   globals: { react: 'React' },

--- a/src/elements/Image.js
+++ b/src/elements/Image.js
@@ -1,4 +1,4 @@
-import Yoga from 'yoga-layout-prebuilt';
+import Yoga from 'yoga-layout';
 import warning from 'fbjs/lib/warning';
 import Base from './Base';
 import { resolveImage } from '../utils/image';

--- a/src/elements/Node.js
+++ b/src/elements/Node.js
@@ -1,4 +1,4 @@
-import Yoga from 'yoga-layout-prebuilt';
+import Yoga from 'yoga-layout';
 import upperFirst from '../utils/upperFirst';
 import matchPercent from '../utils/matchPercent';
 

--- a/src/elements/Page.js
+++ b/src/elements/Page.js
@@ -1,5 +1,5 @@
 import { Fragment } from 'react';
-import Yoga from 'yoga-layout-prebuilt';
+import Yoga from 'yoga-layout';
 import warning from 'fbjs/lib/warning';
 import Base from './Base';
 import TextInstance from './TextInstance';

--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -1,4 +1,4 @@
-import Yoga from 'yoga-layout-prebuilt';
+import Yoga from 'yoga-layout';
 import createPDFRenderer from '@textkit/pdf-renderer';
 import Base from './Base';
 import Font from '../font';

--- a/src/stylesheet/yogaValue.js
+++ b/src/stylesheet/yogaValue.js
@@ -1,4 +1,4 @@
-import Yoga from 'yoga-layout-prebuilt';
+import Yoga from 'yoga-layout';
 
 const yogaValue = (prop, value) => {
   const isAlignType = prop =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5354,6 +5354,13 @@ rimraf@2, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@~2.6.2:
   dependencies:
     glob "^7.0.5"
 
+rollup-plugin-alias@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-alias/-/rollup-plugin-alias-1.5.1.tgz#80cce3a967befda5b09c86abc14a043a78035b46"
+  integrity sha512-pQTYBRNfLedoVOO7AYHNegIavEIp4jKTga5jUi1r//KYgHKGWgG4qJXYhbcWKt2k1FwGlR5wCYoY+IFkme0t4A==
+  dependencies:
+    slash "^2.0.0"
+
 rollup-plugin-babel@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-babel/-/rollup-plugin-babel-2.7.1.tgz#16528197b0f938a1536f44683c7a93d573182f57"
@@ -5610,6 +5617,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@0.0.4:
   version "0.0.4"


### PR DESCRIPTION
This seems a cleaner way of using yoga-layout-prebuilt — it’s _really_ yoga-layout so it would be nicer to import yoga-layout but have the build system take care of turning that into yoga-layout-prebuilt for us. Should have thought of this for #364 really.