### PR TITLE
Enhance dynamic rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "media-engine": "^1.0.3",
     "page-wrapping": "^1.1.0",
     "react": "^16.4.1",
+    "react-fast-compare": "^2.0.4",
     "react-reconciler": "^0.19.1",
     "yoga-layout-prebuilt": "1.9.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-pdf/renderer",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "author": "Diego Muracciole <diegomuracciole@gmail.com>",
   "homepage": "https://github.com/diegomura/react-pdf#readme",

--- a/src/elements/Base.js
+++ b/src/elements/Base.js
@@ -19,6 +19,7 @@ class Base extends Node {
 
     this.root = root;
     this.style = {};
+    this.stubs = props.stubs;
     this.props = merge(
       {},
       this.constructor.defaultProps,
@@ -59,17 +60,17 @@ class Base extends Node {
 
   appendChild(child) {
     super.appendChild(child);
-    this.root.markDirty();
+    // this.root.markDirty();
   }
 
   appendChildBefore(child, beforeChild) {
     super.appendChildBefore(child, beforeChild);
-    this.root.markDirty();
+    // this.root.markDirty();
   }
 
   removeChild(child) {
     super.removeChild(child);
-    this.root.markDirty();
+    // this.root.markDirty();
   }
 
   update(newProps) {
@@ -79,7 +80,7 @@ class Base extends Node {
       Base.defaultProps,
       newProps,
     );
-    this.root.markDirty();
+    // this.root.markDirty();
   }
 
   applyProps() {
@@ -185,6 +186,7 @@ class Base extends Node {
 
     clone.copyStyle(this);
     clone.style = this.style;
+    clone.stubs = this.stubs;
 
     return clone;
   }

--- a/src/elements/Node.js
+++ b/src/elements/Node.js
@@ -127,9 +127,9 @@ class Node {
     return this.children.length === 0;
   }
 
-  markDirty() {
-    return this.layout.markDirty();
-  }
+  // markDirty() {
+  //   return this.layout.markDirty();
+  // }
 
   onAppendDynamically() {}
 

--- a/src/elements/Page.js
+++ b/src/elements/Page.js
@@ -110,52 +110,52 @@ class Page extends Base {
     }
   }
 
-  async addDynamicChild(parent, elements) {
-    if (!elements) return;
-    const children = Array.isArray(elements) ? elements : [elements];
+  // async addDynamicChild(parent, elements) {
+  //   if (!elements) return;
+  //   const children = Array.isArray(elements) ? elements : [elements];
 
-    for (let i = 0; i < children.length; i++) {
-      const child = children[i];
-      const { type, props } = child;
+  //   for (let i = 0; i < children.length; i++) {
+  //     const child = children[i];
+  //     const { type, props } = child;
 
-      if (typeof child === 'string') {
-        const instance = new TextInstance(this.root, child);
-        parent.appendChild(instance);
-      } else if (type !== Fragment) {
-        const instance = createInstance(child, this.root);
-        await instance.onAppendDynamically();
-        parent.appendChild(instance);
-        instance.applyProps();
-        await this.addDynamicChild(instance, props.children);
-      } else {
-        await this.addDynamicChild(parent, props.children);
-      }
-    }
-  }
+  //     if (typeof child === 'string') {
+  //       const instance = new TextInstance(this.root, child);
+  //       parent.appendChild(instance);
+  //     } else if (type !== Fragment) {
+  //       const instance = createInstance(child, this.root);
+  //       await instance.onAppendDynamically();
+  //       parent.appendChild(instance);
+  //       instance.applyProps();
+  //       await this.addDynamicChild(instance, props.children);
+  //     } else {
+  //       await this.addDynamicChild(parent, props.children);
+  //     }
+  //   }
+  // }
 
-  async renderDynamicNodes(props, cb) {
-    const listToExplore = this.children.slice(0);
+  // async renderDynamicNodes(props, cb) {
+  //   const listToExplore = this.children.slice(0);
 
-    while (listToExplore.length > 0) {
-      const node = listToExplore.shift();
-      const condition = cb ? cb(node) : true;
+  //   while (listToExplore.length > 0) {
+  //     const node = listToExplore.shift();
+  //     const condition = cb ? cb(node) : true;
 
-      if (condition && node.props.render) {
-        node.removeAllChilds();
-        const elements = node.props.render(props);
-        await this.addDynamicChild(node, elements);
-        if (!node.fixed) node.props.render = null;
-        continue;
-      }
+  //     if (condition && node.props.render) {
+  //       node.removeAllChilds();
+  //       const elements = node.props.render(props);
+  //       await this.addDynamicChild(node, elements);
+  //       if (!node.fixed) node.props.render = null;
+  //       continue;
+  //     }
 
-      if (node.children) {
-        listToExplore.push(...node.children);
-      }
-    }
-  }
+  //     if (node.children) {
+  //       listToExplore.push(...node.children);
+  //     }
+  //   }
+  // }
 
   async nodeWillWrap(props) {
-    await this.renderDynamicNodes(props);
+    // await this.renderDynamicNodes(props);
     this.calculateLayout();
   }
 

--- a/src/elements/Root.js
+++ b/src/elements/Root.js
@@ -2,7 +2,7 @@ import PDFDocument from '@react-pdf/pdfkit';
 
 class Root {
   constructor() {
-    this.isDirty = false;
+    // this.isDirty = false;
     this.document = null;
     this.instance = null;
   }
@@ -19,14 +19,22 @@ class Root {
     this.document = null;
   }
 
-  markDirty() {
-    this.isDirty = true;
+  // markDirty() {
+  //   this.isDirty = true;
+  // }
+
+  updateStubs() {
+    this.document.updateStubs();
+  }
+
+  async layout() {
+    await this.document.layout();
   }
 
   async render() {
     this.instance = new PDFDocument({ autoFirstPage: false });
     await this.document.render();
-    this.isDirty = false;
+    // this.isDirty = false;
   }
 }
 

--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -65,8 +65,9 @@ class Text extends Base {
       child.parent = this;
       this.children.push(child);
       this.computed = false;
+      this.container = null;
       this.attributedString = null;
-      this.markDirty();
+      // this.markDirty();
     }
   }
 
@@ -77,8 +78,9 @@ class Text extends Base {
       child.parent = null;
       this.children.splice(index, 1);
       this.computed = false;
+      this.container = null;
       this.attributedString = null;
-      this.markDirty();
+      // this.markDirty();
     }
   }
 

--- a/src/elements/TextInstance.js
+++ b/src/elements/TextInstance.js
@@ -26,7 +26,8 @@ class TextInstance {
     this.value = value;
     this.parent.computed = false;
     this.parent.container = null;
-    this.root.markDirty();
+    this.parent.attributedString = null;
+    // this.root.markDirty();
   }
 }
 

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -45,7 +45,7 @@ const getEmojiSource = () => emojiSource;
 
 const getHyphenationCallback = () => hyphenationCallback;
 
-const load = async function(fontFamily, doc) {
+const load = async function(fontFamily) {
   const font = fonts[fontFamily];
 
   // We cache the font to avoid fetching it many times
@@ -70,15 +70,6 @@ const load = async function(fontFamily, doc) {
         ),
       );
     }
-  }
-
-  // If the font wasn't added to the document yet (aka. loaded), we add it.
-  // This prevents calling `registerFont` many times for the same font.
-  // Fonts loaded state will be reset after the document is closed.
-  if (font && !font.loaded) {
-    font.loaded = true;
-    font.loading = false;
-    doc.registerFont(fontFamily, font.data);
   }
 
   if (!font && !standardFonts.includes(fontFamily)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4983,6 +4983,11 @@ react-dom@^16.5.0:
     prop-types "^15.6.2"
     scheduler "^0.13.1"
 
+react-fast-compare@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
+  integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
+
 react-is@^16.7.0, react-is@^16.8.1:
   version "16.8.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.1.tgz#a80141e246eb894824fb4f2901c0c50ef31d4cdb"


### PR DESCRIPTION
There are several motivations behind this PR:

- Support #381
- Ability to pass functions as component children
- Ability to pass parent dimensions to `render` method to create more complex layouts

Also, resolving dynamic components at the renderer level makes not having to deal with all this logic inside elements, which IMO is good.

However, having it like this will require to wrap pages twice, which can be a bit expensive time-wise. Also, it has bugs on re-renderign the document on the dom that I couldn't sort out yet.

I think we need a better API for the `pdf` function, that resolves updates (and queuing processes. See #420) in a much simpler and transparent way as it is right now. If you call an update with the same document info, it shouldn't create a new blob for ex.

Leaving this open here, but it's unclear if this is the way.