### PR TITLE
Fix email links

### DIFF
--- a/src/utils/url.js
+++ b/src/utils/url.js
@@ -1,4 +1,4 @@
-const PROTOCOL_REGEXP = /^(http|https|ftp|ftps|mailto)\:\/\//i;
+const PROTOCOL_REGEXP = /^(http|https|ftp|ftps|mailto)/i;
 
 export const getURL = value => {
   if (typeof value === 'string' && !value.match(PROTOCOL_REGEXP)) {

--- a/tests/url.test.js
+++ b/tests/url.test.js
@@ -15,4 +15,9 @@ describe('getURL', () => {
     const url = 'https://react-pdf.org';
     expect(getURL(url)).toEqual('https://react-pdf.org');
   });
+
+  test('should support mailto protocol', () => {
+    const url = 'mailto:test@example.com';
+    expect(getURL(url)).toEqual('mailto:test@example.com');
+  });
 });


### PR DESCRIPTION
This fixes using `mailto` src's on links. The mailto protocol does not contain `://`, so the previous Regex was causing mailto link srcs like `mailto:test@example.com` to show up as `http://mailto:test@example.com`