### PR TITLE
Return bytes in buffer if no file passed

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "page-wrapping": "^1.1.0",
     "react": "^16.8.3",
     "react-reconciler": "^0.20.1",
+    "stream-to-array": "2.3.0",
     "yoga-layout-prebuilt": "^1.9.3"
   },
   "devDependencies": {

--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import util from 'util';
 import toArray from 'stream-to-array';
 import {
   pdf,
@@ -27,15 +26,15 @@ export const renderToStream = function(element) {
 export const renderToFile = function(element, filePath, callback) {
   if(arguments.length === 1 || typeof filePath === 'function'){
     return new Promise((resolve, reject)=>{
-       const output = toBuffer(pdf(element).toBuffer())
-            .then((data) => {
-              if(typeof filePath === 'function'){
-                filePath(data);
-              }
-              return data;
-            })
-            .catch(reject);
-       resolve(output);
+        const output = toBuffer(pdf(element).toBuffer())
+          .then((data) => {
+            if(typeof filePath === 'function'){
+              filePath(data);
+            }
+            return data;
+          })
+          .catch(reject);
+        resolve(output);
     })
   }
   const output = renderToStream(element);


### PR DESCRIPTION
ReactPDF.render returns a buffer when only passed an element or an element and a callback.

```javascript
cont buffer = ReactPDF.render(<MyDocument />);
```