### PR TITLE
Add font-weight and font-style support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -230,6 +230,21 @@ declare module '@react-pdf/renderer' {
       | 'ultrabold'
       | 'heavy';
 
+    interface FontSource {
+      src: string;
+      fontFamily: string;
+      fontStyle: FontStyle;
+      fontWeight: number;
+      data: any;
+      loading: boolean;
+      options: any;
+    }
+
+    interface FontInstance {
+      family: string;
+      sources: FontSource[];
+    }
+
     interface EmojiSource {
       url: string;
       format: string;
@@ -261,7 +276,8 @@ declare module '@react-pdf/renderer' {
         [key: string]: any;
       }) => void;
       getEmojiSource: () => EmojiSource;
-      getRegisteredFonts: () => string[];
+      getRegisteredFonts: () => FontInstance[];
+      getRegisteredFontFamilies: () => string[];
       registerEmojiSource: (emojiSource: EmojiSource) => void;
       registerHyphenationCallback: (
         hyphenationCallback: HyphenationCallback,

--- a/index.d.ts
+++ b/index.d.ts
@@ -94,7 +94,7 @@ declare module '@react-pdf/renderer' {
     type SourceObject =
       | string
       | { data: Buffer; format: 'png' | 'jpg' }
-      | { uri: string; method: HTTPMethod, body: any, headers: any }
+      | { uri: string; method: HTTPMethod; body: any; headers: any };
 
     interface BaseImageProps extends NodeProps {
       debug?: boolean;
@@ -216,9 +216,29 @@ declare module '@react-pdf/renderer' {
      */
     class PDFDownloadLink extends React.Component<PDFDownloadLinkProps> {}
 
+    type FontStyle = 'normal' | 'italic' | 'oblique';
+
+    type FontWeight =
+      | number
+      | 'thin'
+      | 'ultralight'
+      | 'light'
+      | 'normal'
+      | 'medium'
+      | 'semibold'
+      | 'bold'
+      | 'ultrabold'
+      | 'heavy';
+
     interface EmojiSource {
       url: string;
       format: string;
+    }
+
+    interface FontDescriptor {
+      family: string;
+      fontStyle: FontStyle;
+      fontWeight: FontWeight;
     }
 
     interface RegisteredFont {
@@ -235,10 +255,11 @@ declare module '@react-pdf/renderer' {
     ) => string[];
 
     const Font: {
-      register: (
-        src: string,
-        options: { family: string; [key: string]: any },
-      ) => void;
+      register: (options: {
+        family: string;
+        src: string;
+        [key: string]: any;
+      }) => void;
       getEmojiSource: () => EmojiSource;
       getRegisteredFonts: () => string[];
       registerEmojiSource: (emojiSource: EmojiSource) => void;
@@ -246,9 +267,9 @@ declare module '@react-pdf/renderer' {
         hyphenationCallback: HyphenationCallback,
       ) => void;
       getHyphenationCallback: () => HyphenationCallback;
-      getFont: (fontFamily: string) => RegisteredFont | undefined;
+      getFont: (fontDescriptor: FontDescriptor) => RegisteredFont | undefined;
       load: (
-        fontFamily: string,
+        fontDescriptor: FontDescriptor,
         document: React.ReactElement<DocumentProps>,
       ) => Promise<void>;
       clear: () => void;

--- a/src/elements/Document.js
+++ b/src/elements/Document.js
@@ -55,7 +55,7 @@ class Document {
       const node = listToExplore.shift();
 
       if (node.style && node.style.fontFamily) {
-        promises.push(Font.load(node.style.fontFamily, this.root.instance));
+        promises.push(Font.load(node.style, this.root.instance));
       }
 
       if (node.children) {

--- a/src/font/emoji.js
+++ b/src/font/emoji.js
@@ -1,0 +1,12 @@
+let emojiSource;
+
+export const registerEmojiSource = ({ url, format = 'png' }) => {
+  emojiSource = { url, format };
+};
+
+export const getEmojiSource = () => emojiSource;
+
+export default {
+  registerEmojiSource,
+  getEmojiSource,
+};

--- a/src/font/font.js
+++ b/src/font/font.js
@@ -1,0 +1,121 @@
+import isUrl from 'is-url';
+import fontkit from '@react-pdf/fontkit';
+import fetch from 'cross-fetch';
+
+import { processFontWeight } from '../stylesheet/transformFontWeight';
+
+const fetchFont = async (src, options) => {
+  const response = await fetch(src, options);
+
+  const buffer = await (response.buffer
+    ? response.buffer()
+    : response.arrayBuffer());
+
+  return buffer.constructor.name === 'Buffer' ? buffer : Buffer.from(buffer);
+};
+
+const throwInvalidUrl = src => {
+  throw new Error(
+    `Invalid font url: ${src}. If you use relative url please replace it with absolute one (ex. /font.ttf -> http://localhost:3000/font.ttf)`,
+  );
+};
+
+class FontSource {
+  constructor(src, fontFamily, fontStyle, fontWeight, options) {
+    this.src = src;
+    this.fontFamily = fontFamily;
+    this.fontStyle = fontStyle || 'normal';
+    this.fontWeight = processFontWeight(fontWeight) || 400;
+
+    this.data = null;
+    this.loaded = false;
+    this.loading = false;
+    this.options = options;
+  }
+
+  async load() {
+    if (isUrl(this.src)) {
+      const { headers, body, method = 'GET' } = this.options;
+      const data = await fetchFont(this.src, { method, body, headers });
+      this.data = fontkit.create(data);
+    } else {
+      if (BROWSER) throwInvalidUrl(this.src); // Can't load a non-url font in browser
+
+      this.data = await new Promise((resolve, reject) =>
+        fontkit.open(this.src, (err, data) =>
+          err ? reject(err) : resolve(data),
+        ),
+      );
+    }
+  }
+
+  register(doc) {
+    this.loaded = true;
+    this.loading = false;
+
+    // TODO: Should be different for each style?
+    doc.registerFont(this.fontFamily, this.data);
+  }
+}
+
+class Font {
+  static create(family) {
+    return new Font(family);
+  }
+
+  constructor(family) {
+    this.family = family;
+    this.sources = [];
+  }
+
+  register({ src, fontWeight, fontStyle, ...options }) {
+    this.sources.push(
+      new FontSource(src, this.fontFamily, fontStyle, fontWeight, options),
+    );
+  }
+
+  resolve(descriptor) {
+    const { fontWeight = 400, fontStyle = 'normal' } = descriptor;
+    const styleSources = this.sources.filter(s => s.fontStyle === fontStyle);
+
+    // Weight resolution. https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Fallback_weights
+    const exactFit = styleSources.find(s => s.fontWeight === fontWeight);
+
+    if (exactFit) return exactFit;
+
+    let res;
+
+    if (fontWeight >= 400 && fontWeight <= 500) {
+      const leftOffset = styleSources.filter(s => s.fontWeight <= fontWeight);
+      const rightOffset = styleSources.filter(s => s.fontWeight > 500);
+      const fit = styleSources.filter(
+        s => s.fontWeight >= fontWeight && s.fontWeight < 500,
+      );
+
+      res = fit[0] || leftOffset[leftOffset.length - 1] || rightOffset[0];
+    }
+
+    const lt = styleSources.filter(s => s.fontWeight < fontWeight);
+    const gt = styleSources.filter(s => s.fontWeight > fontWeight);
+
+    if (fontWeight < 400) {
+      res = lt[lt.length - 1] || gt[0];
+    }
+
+    if (fontWeight > 500) {
+      res = gt[0] || lt[lt.length - 1];
+    }
+
+    if (!res) {
+      throw new Error(
+        `Could not resolve font for ${
+          this.fontFamily
+        }, fontWeight ${fontWeight}`,
+      );
+    }
+
+    return res;
+  }
+}
+
+export default Font;

--- a/src/font/font.js
+++ b/src/font/font.js
@@ -28,7 +28,6 @@ class FontSource {
     this.fontWeight = processFontWeight(fontWeight) || 400;
 
     this.data = null;
-    this.loaded = false;
     this.loading = false;
     this.options = options;
   }
@@ -47,14 +46,8 @@ class FontSource {
         ),
       );
     }
-  }
 
-  register(doc) {
-    this.loaded = true;
     this.loading = false;
-
-    // TODO: Should be different for each style?
-    doc.registerFont(this.fontFamily, this.data);
   }
 }
 

--- a/src/font/hyphenation.js
+++ b/src/font/hyphenation.js
@@ -1,0 +1,12 @@
+let hyphenationCallback;
+
+export const registerHyphenationCallback = callback => {
+  hyphenationCallback = callback;
+};
+
+export const getHyphenationCallback = () => hyphenationCallback;
+
+export default {
+  registerHyphenationCallback,
+  getHyphenationCallback,
+};

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -34,7 +34,9 @@ const register = (src, data) => {
   }
 };
 
-const getRegisteredFonts = () => Object.keys(fonts);
+const getRegisteredFonts = () => fonts;
+
+const getRegisteredFontFamilies = () => Object.keys(fonts);
 
 const getFont = descriptor => {
   const { fontFamily } = descriptor;
@@ -80,6 +82,7 @@ const clear = function() {
 export default {
   register,
   getRegisteredFonts,
+  getRegisteredFontFamilies,
   getFont,
   load,
   clear,

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -2,17 +2,29 @@ import font from './font';
 import emoji from './emoji';
 import standardFonts from './standard';
 import hyphenation from './hyphenation';
+import warning from '../utils/warning';
 
 let fonts = {};
 
 const register = (src, data) => {
+  if (typeof src === 'object') {
+    data = src;
+  } else {
+    warning(
+      false,
+      'Font.register will not longer accept the font source as first argument. Please move it into the data object. For more info refer to https://react-pdf.org/fonts',
+    );
+
+    data.src = src;
+  }
+
   const { family } = data;
 
   if (!fonts[family]) {
     fonts[family] = font.create(family);
   }
 
-  fonts[family].register({ src, ...data });
+  fonts[family].register(data);
 };
 
 const getRegisteredFonts = () => Object.keys(fonts);

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -62,20 +62,13 @@ const load = async function(descriptor, doc) {
   // We cache the font to avoid fetching it many times
   if (!font.data && !font.loading) {
     await font.load();
-
-    // If the font wasn't added to the document yet (aka. loaded), we add it.
-    // This prevents calling `registerFont` many times for the same font.
-    // Fonts loaded state will be reset after the document is closed.
-    if (!font.loaded) {
-      font.register(doc);
-    }
   }
 };
 
 const reset = function() {
   for (const font in fonts) {
     if (fonts.hasOwnProperty(font)) {
-      fonts[font].loaded = false;
+      fonts[font].data = null;
     }
   }
 };

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -1,90 +1,50 @@
-import isUrl from 'is-url';
-import fetch from 'cross-fetch';
-import fontkit from '@react-pdf/fontkit';
-
+import font from './font';
+import emoji from './emoji';
 import standardFonts from './standard';
+import hyphenation from './hyphenation';
 
 let fonts = {};
-let emojiSource;
-let hyphenationCallback;
 
-const fetchFont = async (src, options) => {
-  const response = await fetch(src, options);
+const register = (src, data) => {
+  const { family } = data;
 
-  const buffer = await (response.buffer
-    ? response.buffer()
-    : response.arrayBuffer());
+  if (!fonts[family]) {
+    fonts[family] = font.create(family);
+  }
 
-  return buffer.constructor.name === 'Buffer' ? buffer : Buffer.from(buffer);
-};
-
-const register = (src, { family, ...otherOptions }) => {
-  fonts[family] = {
-    src,
-    loaded: false,
-    loading: false,
-    data: null,
-    ...otherOptions,
-  };
-};
-
-const registerHyphenationCallback = callback => {
-  hyphenationCallback = callback;
-};
-
-const registerEmojiSource = ({ url, format = 'png' }) => {
-  emojiSource = { url, format };
+  fonts[family].register({ src, ...data });
 };
 
 const getRegisteredFonts = () => Object.keys(fonts);
 
-const getFont = family => fonts[family];
+const getFont = descriptor => {
+  const { fontFamily } = descriptor;
+  const isStandard = standardFonts.includes(fontFamily);
 
-const getEmojiSource = () => emojiSource;
+  if (isStandard) return standardFonts[fontFamily];
 
-const getHyphenationCallback = () => hyphenationCallback;
-
-const load = async function(fontFamily, doc) {
-  const font = getFont(fontFamily);
-
-  // We cache the font to avoid fetching it many times
-  if (font && !font.data && !font.loading) {
-    font.loading = true;
-
-    if (isUrl(font.src)) {
-      const { src, headers, body, method = 'GET' } = font;
-      const data = await fetchFont(src, { headers, method, body });
-      font.data = fontkit.create(data);
-    } else {
-      if (BROWSER) {
-        throw new Error(
-          `Invalid font url: ${
-            font.src
-          }. If you use relative url please replace it with absolute one (ex. /font.ttf -> http://localhost:3000/font.ttf)`,
-        );
-      }
-
-      font.data = await new Promise((resolve, reject) =>
-        fontkit.open(font.src, (err, data) =>
-          err ? reject(err) : resolve(data),
-        ),
-      );
-    }
-  }
-
-  // If the font wasn't added to the document yet (aka. loaded), we add it.
-  // This prevents calling `registerFont` many times for the same font.
-  // Fonts loaded state will be reset after the document is closed.
-  if (font && !font.loaded) {
-    font.loaded = true;
-    font.loading = false;
-    doc.registerFont(fontFamily, font.data);
-  }
-
-  if (!font && !standardFonts.includes(fontFamily)) {
+  if (!fonts[fontFamily]) {
     throw new Error(
       `Font family not registered: ${fontFamily}. Please register it calling Font.register() method.`,
     );
+  }
+
+  return fonts[fontFamily].resolve(descriptor);
+};
+
+const load = async function(descriptor, doc) {
+  const font = getFont(descriptor);
+
+  // We cache the font to avoid fetching it many times
+  if (!font.data && !font.loading) {
+    await font.load();
+
+    // If the font wasn't added to the document yet (aka. loaded), we add it.
+    // This prevents calling `registerFont` many times for the same font.
+    // Fonts loaded state will be reset after the document is closed.
+    if (!font.loaded) {
+      font.register(doc);
+    }
   }
 };
 
@@ -102,13 +62,11 @@ const clear = function() {
 
 export default {
   register,
-  getEmojiSource,
   getRegisteredFonts,
-  registerEmojiSource,
-  registerHyphenationCallback,
-  getHyphenationCallback,
   getFont,
   load,
   clear,
   reset,
+  ...emoji,
+  ...hyphenation,
 };

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -24,7 +24,14 @@ const register = (src, data) => {
     fonts[family] = font.create(family);
   }
 
-  fonts[family].register(data);
+  // Bulk loading
+  if (data.fonts) {
+    for (let i = 0; i < data.fonts.length; i++) {
+      fonts[family].register({ family, ...data.fonts[i] });
+    }
+  } else {
+    fonts[family].register(data);
+  }
 };
 
 const getRegisteredFonts = () => Object.keys(fonts);

--- a/src/font/index.js
+++ b/src/font/index.js
@@ -40,7 +40,7 @@ const getFont = descriptor => {
   const { fontFamily } = descriptor;
   const isStandard = standardFonts.includes(fontFamily);
 
-  if (isStandard) return standardFonts[fontFamily];
+  if (isStandard) return null;
 
   if (!fonts[fontFamily]) {
     throw new Error(
@@ -52,6 +52,11 @@ const getFont = descriptor => {
 };
 
 const load = async function(descriptor, doc) {
+  const { fontFamily } = descriptor;
+  const isStandard = standardFonts.includes(fontFamily);
+
+  if (isStandard) return;
+
   const font = getFont(descriptor);
 
   // We cache the font to avoid fetching it many times

--- a/src/stylesheet/transformFontWeight.js
+++ b/src/stylesheet/transformFontWeight.js
@@ -14,8 +14,6 @@ const FONT_WEIGHTS = {
 export const isFontWeightStyle = key => key.match(/^fontWeight/);
 
 export const processFontWeight = value => {
-  console.log(value);
-
   if (!value) return FONT_WEIGHTS.normal;
   if (typeof value === 'number') return value;
   return FONT_WEIGHTS[value.toLowerCase()];

--- a/src/stylesheet/transformFontWeight.js
+++ b/src/stylesheet/transformFontWeight.js
@@ -1,0 +1,22 @@
+// https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping
+const FONT_WEIGHTS = {
+  thin: 100,
+  ultralight: 200,
+  light: 300,
+  normal: 400,
+  medium: 500,
+  semibold: 600,
+  bold: 700,
+  ultrabold: 800,
+  heavy: 900,
+};
+
+export const isFontWeightStyle = key => key.match(/^fontWeight/);
+
+export const processFontWeight = value => {
+  console.log(value);
+
+  if (!value) return FONT_WEIGHTS.normal;
+  if (typeof value === 'number') return value;
+  return FONT_WEIGHTS[value.toLowerCase()];
+};

--- a/src/stylesheet/transformFontWeight.js
+++ b/src/stylesheet/transformFontWeight.js
@@ -1,14 +1,19 @@
 // https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Common_weight_name_mapping
 const FONT_WEIGHTS = {
   thin: 100,
+  hairline: 100,
   ultralight: 200,
+  extralight: 200,
   light: 300,
   normal: 400,
   medium: 500,
   semibold: 600,
+  demibold: 600,
   bold: 700,
   ultrabold: 800,
+  extrabold: 800,
   heavy: 900,
+  black: 900,
 };
 
 export const isFontWeightStyle = key => key.match(/^fontWeight/);

--- a/src/stylesheet/transformStyles.js
+++ b/src/stylesheet/transformStyles.js
@@ -2,6 +2,7 @@ import yogaValue from './yogaValue';
 import parseScalar from './transformUnits';
 import { isBorderStyle, processBorders } from './borders';
 import { isBoxModelStyle, processBoxModel } from './boxModel';
+import { isFontWeightStyle, processFontWeight } from './transformFontWeight';
 import { isObjectPositionStyle, processObjectPosition } from './objectPosition';
 import {
   isTransformOriginStyle,
@@ -190,6 +191,8 @@ const transformStyles = style => {
       resolved = processObjectPosition(key, value);
     } else if (isTransformOriginStyle(key, value)) {
       resolved = processTransformOrigin(key, value);
+    } else if (isFontWeightStyle(key, value)) {
+      resolved = processFontWeight(value);
     } else {
       resolved = value;
     }

--- a/src/utils/attributedString.js
+++ b/src/utils/attributedString.js
@@ -28,6 +28,8 @@ export const getFragments = instance => {
     color = 'black',
     backgroundColor,
     fontFamily = 'Helvetica',
+    fontWeight,
+    fontStyle,
     fontSize = 18,
     textAlign = 'left',
     position,
@@ -44,7 +46,7 @@ export const getFragments = instance => {
 
   instance.children.forEach(child => {
     if (child.value !== null && child.value !== undefined) {
-      const obj = Font.getFont(fontFamily);
+      const obj = Font.getFont({ fontFamily, fontWeight, fontStyle });
       const font = obj ? obj.data : fontFamily;
       const string = transformText(child.value, textTransform);
 

--- a/tests/document.test.js
+++ b/tests/document.test.js
@@ -83,8 +83,8 @@ describe('Document', () => {
     await doc.render();
 
     expect(Font.load.mock.calls).toHaveLength(2);
-    expect(Font.load.mock.calls[0][0]).toBe('Courier');
-    expect(Font.load.mock.calls[1][0]).toBe('Helvetica');
+    expect(Font.load.mock.calls[0][0].fontFamily).toBe('Courier');
+    expect(Font.load.mock.calls[1][0].fontFamily).toBe('Helvetica');
   });
 
   test('Should trigger available images loading', async () => {

--- a/tests/font.test.js
+++ b/tests/font.test.js
@@ -46,7 +46,6 @@ describe('Font', () => {
 
     const font = Font.getFont(descriptor);
 
-    expect(font.loaded).toBeTruthy();
     expect(font.loading).toBeFalsy();
     expect(font.data).toBeTruthy();
   });
@@ -61,7 +60,6 @@ describe('Font', () => {
 
     const font = Font.getFont(descriptor);
 
-    expect(font.loaded).toBeTruthy();
     expect(font.loading).toBeFalsy();
     expect(font.data).toBeTruthy();
   });
@@ -121,7 +119,6 @@ describe('Font', () => {
 
     const font = Font.getFont(descriptor);
 
-    expect(font.loaded).toBeTruthy();
     expect(font.loading).toBeFalsy();
     expect(font.data).toBeTruthy();
   });

--- a/tests/font.test.js
+++ b/tests/font.test.js
@@ -20,14 +20,14 @@ describe('Font', () => {
   });
 
   test('should be able to register font families', () => {
-    Font.register('src', { family: 'MyFont' });
-    Font.register('src', { family: 'MyOtherFont' });
+    Font.register({ family: 'MyFont', src: 'src' });
+    Font.register({ family: 'MyOtherFont', src: 'src' });
 
     expect(Font.getRegisteredFonts()).toEqual(['MyFont', 'MyOtherFont']);
   });
 
   test('should be able to clear registered fonts', () => {
-    Font.register('src', { family: 'MyFont' });
+    Font.register({ family: 'MyFont', src: 'src' });
 
     expect(Font.getRegisteredFonts()).toEqual(['MyFont']);
 
@@ -36,13 +36,30 @@ describe('Font', () => {
     expect(Font.getRegisteredFonts()).toEqual([]);
   });
 
+  test.skip('should show warning when old register API used', async () => {
+    fetch.once(localFont);
+
+    const descriptor = { fontFamily: 'Oswald' };
+
+    Font.register({ family: 'Oswald', src: oswaldUrl });
+    await Font.load(descriptor, dummyRoot.instance);
+
+    const font = Font.getFont(descriptor);
+
+    expect(font.loaded).toBeTruthy();
+    expect(font.loading).toBeFalsy();
+    expect(font.data).toBeTruthy();
+  });
+
   test('should be able to load font from url', async () => {
     fetch.once(localFont);
 
-    Font.register(oswaldUrl, { family: 'Oswald' });
-    await Font.load('Oswald', dummyRoot.instance);
+    const descriptor = { fontFamily: 'Oswald' };
 
-    const font = Font.getFont('Oswald');
+    Font.register({ family: 'Oswald', src: oswaldUrl });
+    await Font.load(descriptor, dummyRoot.instance);
+
+    const font = Font.getFont(descriptor);
 
     expect(font.loaded).toBeTruthy();
     expect(font.loading).toBeFalsy();
@@ -52,8 +69,10 @@ describe('Font', () => {
   test('should fetch remote font using GET method by default', async () => {
     fetch.once(localFont);
 
-    Font.register(oswaldUrl, { family: 'Oswald' });
-    await Font.load('Oswald', dummyRoot.instance);
+    const descriptor = { fontFamily: 'Oswald' };
+
+    Font.register({ family: 'Oswald', src: oswaldUrl });
+    await Font.load(descriptor, dummyRoot.instance);
 
     expect(fetch.mock.calls[0][1].method).toBe('GET');
   });
@@ -61,8 +80,10 @@ describe('Font', () => {
   test('Should fetch remote font using passed method', async () => {
     fetch.once(localFont);
 
-    Font.register(oswaldUrl, { family: 'Oswald', method: 'POST' });
-    await Font.load('Oswald', dummyRoot.instance);
+    const descriptor = { fontFamily: 'Oswald' };
+
+    Font.register({ family: 'Oswald', src: oswaldUrl, method: 'POST' });
+    await Font.load(descriptor, dummyRoot.instance);
 
     expect(fetch.mock.calls[0][1].method).toBe('POST');
   });
@@ -70,10 +91,11 @@ describe('Font', () => {
   test('Should fetch remote font using passed headers', async () => {
     fetch.once(localFont);
 
+    const descriptor = { fontFamily: 'Oswald' };
     const headers = { Authorization: 'Bearer qwerty' };
 
-    Font.register(oswaldUrl, { family: 'Oswald', headers });
-    await Font.load('Oswald', dummyRoot.instance);
+    Font.register({ family: 'Oswald', src: oswaldUrl, headers });
+    await Font.load(descriptor, dummyRoot.instance);
 
     expect(fetch.mock.calls[0][1].headers).toBe(headers);
   });
@@ -81,20 +103,23 @@ describe('Font', () => {
   test('Should fetch remote font using passed body', async () => {
     fetch.once(localFont);
 
+    const descriptor = { fontFamily: 'Oswald' };
     const body = 'qwerty';
 
-    Font.register(oswaldUrl, { family: 'Oswald', body });
-    await Font.load('Oswald', dummyRoot.instance);
+    Font.register({ family: 'Oswald', src: oswaldUrl, body });
+    await Font.load(descriptor, dummyRoot.instance);
 
     expect(fetch.mock.calls[0][1].body).toBe(body);
   });
 
   test('should be able to load a font from file', async () => {
-    Font.register(`${__dirname}/assets/font.ttf`, { family: 'Roboto' });
+    Font.register({ family: 'Roboto', src: `${__dirname}/assets/font.ttf` });
 
-    await Font.load('Roboto', dummyRoot.instance);
+    const descriptor = { fontFamily: 'Roboto' };
 
-    const font = Font.getFont('Roboto');
+    await Font.load(descriptor, dummyRoot.instance);
+
+    const font = Font.getFont(descriptor);
 
     expect(font.loaded).toBeTruthy();
     expect(font.loading).toBeFalsy();
@@ -125,11 +150,11 @@ describe('Font', () => {
 
   describe('invalid url', () => {
     test('should throw `no such file or directory` error', async () => {
-      Font.register('/roboto.ttf', { family: 'Roboto' });
+      Font.register({ family: 'Roboto', src: '/roboto.ttf' });
 
-      expect(Font.load('Roboto', dummyRoot.instance)).rejects.toThrow(
-        'no such file or directory',
-      );
+      expect(
+        Font.load({ fontFamily: 'Roboto' }, dummyRoot.instance),
+      ).rejects.toThrow('no such file or directory');
     });
 
     describe('in browser', () => {
@@ -142,11 +167,11 @@ describe('Font', () => {
       });
 
       test('should throw `Invalid font url` error', async () => {
-        Font.register('/roboto.ttf', { family: 'Roboto' });
+        Font.register({ family: 'Roboto', src: '/roboto.ttf' });
 
-        expect(Font.load('Roboto', dummyRoot.instance)).rejects.toThrow(
-          'Invalid font url',
-        );
+        expect(
+          Font.load({ fontFamily: 'Roboto' }, dummyRoot.instance),
+        ).rejects.toThrow('Invalid font url');
       });
     });
   });

--- a/tests/styleShorthands.test.js
+++ b/tests/styleShorthands.test.js
@@ -159,4 +159,68 @@ describe('shorthands', () => {
     expect(stylesheet.transformOriginX).toBe('50%');
     expect(stylesheet.transformOriginY).toBe('50%');
   });
+
+  test('should process font-weight thin shorthand', () => {
+    const stylesheet1 = StyleSheet.resolve({ fontWeight: 'thin' });
+    const stylesheet2 = StyleSheet.resolve({ fontWeight: 'hairline' });
+
+    expect(stylesheet1.fontWeight).toBe(100);
+    expect(stylesheet2.fontWeight).toBe(100);
+  });
+
+  test('should process font-weight ultralight shorthand', () => {
+    const stylesheet1 = StyleSheet.resolve({ fontWeight: 'ultralight' });
+    const stylesheet2 = StyleSheet.resolve({ fontWeight: 'extralight' });
+
+    expect(stylesheet1.fontWeight).toBe(200);
+    expect(stylesheet2.fontWeight).toBe(200);
+  });
+
+  test('should process font-weight light shorthand', () => {
+    const stylesheet = StyleSheet.resolve({ fontWeight: 'light' });
+
+    expect(stylesheet.fontWeight).toBe(300);
+  });
+
+  test('should process font-weight normal shorthand', () => {
+    const stylesheet = StyleSheet.resolve({ fontWeight: 'normal' });
+
+    expect(stylesheet.fontWeight).toBe(400);
+  });
+
+  test('should process font-weight medium shorthand', () => {
+    const stylesheet = StyleSheet.resolve({ fontWeight: 'medium' });
+
+    expect(stylesheet.fontWeight).toBe(500);
+  });
+
+  test('should process font-weight semibold shorthand', () => {
+    const stylesheet1 = StyleSheet.resolve({ fontWeight: 'semibold' });
+    const stylesheet2 = StyleSheet.resolve({ fontWeight: 'demibold' });
+
+    expect(stylesheet1.fontWeight).toBe(600);
+    expect(stylesheet2.fontWeight).toBe(600);
+  });
+
+  test('should process font-weight bold shorthand', () => {
+    const stylesheet = StyleSheet.resolve({ fontWeight: 'bold' });
+
+    expect(stylesheet.fontWeight).toBe(700);
+  });
+
+  test('should process font-weight ultrabold shorthand', () => {
+    const stylesheet1 = StyleSheet.resolve({ fontWeight: 'ultrabold' });
+    const stylesheet2 = StyleSheet.resolve({ fontWeight: 'extraBold' });
+
+    expect(stylesheet1.fontWeight).toBe(800);
+    expect(stylesheet2.fontWeight).toBe(800);
+  });
+
+  test('should process font-weight heavy shorthand', () => {
+    const stylesheet1 = StyleSheet.resolve({ fontWeight: 'heavy' });
+    const stylesheet2 = StyleSheet.resolve({ fontWeight: 'black' });
+
+    expect(stylesheet1.fontWeight).toBe(900);
+    expect(stylesheet2.fontWeight).toBe(900);
+  });
 });

--- a/tests/stylesInherit.test.js
+++ b/tests/stylesInherit.test.js
@@ -10,9 +10,7 @@ describe('Styles inherit', () => {
     dummyRoot = root.reset();
   });
 
-  const shouldInherit = attribute => async () => {
-    const value = 'Courier';
-
+  const shouldInherit = (attribute, value) => async () => {
     const doc = new Document(dummyRoot, {});
     const page = new Page(dummyRoot, {});
     const parent = new View(dummyRoot, { style: { [attribute]: value } });
@@ -50,9 +48,9 @@ describe('Styles inherit', () => {
     expect(child2.style[attribute]).not.toBe(value);
   };
 
-  const shouldOverride = (attribute, value) => async () => {
-    const parentValue = 'Courier';
-    const childValue = 'Helvetica';
+  const shouldOverride = (attribute, value1, value2) => async () => {
+    const parentValue = value1 || 'Courier';
+    const childValue = value2 || 'Helvetica';
 
     const doc = new Document(dummyRoot, {});
     const page = new Page(dummyRoot, {});
@@ -71,23 +69,26 @@ describe('Styles inherit', () => {
     expect(child2.style[attribute]).toBe(childValue);
   };
 
-  test('Should inherit color', shouldInherit('color'));
-  test('Should inherit opacity', shouldInherit('opacity'));
-  test('Should inherit font size', shouldInherit('fontSize'));
-  test('Should inherit text align', shouldInherit('textAlign'));
-  test('Should inherit visibility', shouldInherit('visibility'));
-  test('Should inherit font weight', shouldInherit('fontWeight'));
-  test('Should inherit line height', shouldInherit('lineHeight'));
-  test('Should inherit font family', shouldInherit('fontFamily'));
-  test('Should inherit word spacing', shouldInherit('wordSpacing'));
-  test('Should inherit letter spacing', shouldInherit('letterSpacing'));
-  test('Should inherit text decoration', shouldInherit('textDecoration'));
+  test('Should inherit color', shouldInherit('color', 'red'));
+  test('Should inherit opacity', shouldInherit('opacity', 0.5));
+  test('Should inherit font size', shouldInherit('fontSize', 12));
+  test('Should inherit text align', shouldInherit('textAlign', 'center'));
+  test('Should inherit visibility', shouldInherit('visibility', 'none'));
+  test('Should inherit font weight', shouldInherit('fontWeight', 700));
+  test('Should inherit line height', shouldInherit('lineHeight', 12));
+  test('Should inherit font family', shouldInherit('fontFamily', 'Courier'));
+  test('Should inherit word spacing', shouldInherit('wordSpacing', 10));
+  test('Should inherit letter spacing', shouldInherit('letterSpacing', 10));
+  test(
+    'Should inherit text decoration',
+    shouldInherit('textDecoration', 'underline'),
+  );
 
   test('Should override color', shouldOverride('color'));
   test('Should override font size', shouldOverride('fontSize'));
   test('Should override text align', shouldOverride('textAlign'));
   test('Should override visibility', shouldOverride('visibility'));
-  test('Should override font weight', shouldOverride('fontWeight'));
+  test('Should override font weight', shouldOverride('fontWeight', 700, 100));
   test('Should override line height', shouldOverride('lineHeight'));
   test('Should override font family', shouldOverride('fontFamily'));
   test('Should override word spacing', shouldOverride('wordSpacing'));


### PR DESCRIPTION
## What this PR do

This adds the ability to setup font-styles and font-weights when registering fonts:

```js
Font.register(`http://localhost:3000/Roboto-Regular.ttf`, {
  family: 'Roboto'
})

Font.register(`http://localhost:3000/Roboto-Bold.ttf`, {
  family: 'Roboto',
  fontWeight: 'bold'
})

Font.register(`http://localhost:3000/Roboto-Italic.ttf`, {
  family: 'Roboto',
  fontWeight: 'normal',
  fontStyle: 'italic'
})

Font.register(`http://localhost:3000/Roboto-BoldItalic.ttf`, {
  family: 'Roboto',
  fontWeight: 'bold',
  fontStyle: 'italic'
})
```

When rendering, react-pdf will choose the appropriate font in the [same way the web does](https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Fallback_weights).

## "Bulk" font loading

Since we now support referring to different font files by using the same fontFamily value, IMO would be cool to be able to load one fontFamily in one `register` call:

```js
Font.register({
  family: 'Roboto',
  fonts: [
    {  
      src: 'http://localhost:3000/Roboto-Regular.ttf',
      fontWeight: 'normal', // Default, does not have to be specified
      fontStyle: 'normal',  // Default, does not have to be specified
    },
    {  
      src: 'http://localhost:3000/Roboto-Bold.ttf',
      fontWeight: 'bold' // Also accepts numeric values, ex. 700
    },
    {  
      src: 'http://localhost:3000/Roboto-Italic.ttf',
      fontStyle: 'italic'
    },
    {  
      src: 'http://localhost:3000/Roboto-BoldItalic.ttf',
      fontStyle: 'italic',
      fontWeight: 'bold',
    },
  ]
})
```

Other options such as `method`, `headers` and `body` that we currently support should still work for each font.

## Change register API

We currently pass the font src in the first argument to `Font.register`, and all other options into the second. To achieve the latter point (and if we want to support CSS `@font-face` attribute in the future) it would be cool to have the API like this:

```js
Font.register({
  src: '...',
  fontStyle: 'normal',
  fontWeight: 'bold'
})
```

We should still support the current API, by showing a deprecated warning


### TODO
- [x] Add font-weight and font-style support
- [x] Bulk loading
- [x] Change register API
- [x] Update docs
- [x] Update REPL example
- [x] Update typings
- [x] Check typings correctness 
- [x] Fix old tests
- [x] Add new tests


@DuncanMacWeb inputs?

Fixes #402 