### PR TITLE
Fix page size on test

### DIFF
--- a/tests/layout.test.js
+++ b/tests/layout.test.js
@@ -132,8 +132,8 @@ describe('Layout', () => {
 
   test('Absolute elements should be placed with percent left', async () => {
     const size = { width: 600, height: 800 };
-    const doc = new Document(dummyRoot, { size });
-    const page = new Page(dummyRoot, { wrap: false });
+    const doc = new Document(dummyRoot, {});
+    const page = new Page(dummyRoot, { size, wrap: false });
     const view = new View(dummyRoot, {
       style: { position: 'absolute', left: '10%' },
     });


### PR DESCRIPTION
Fix the test 'Absolute elements should be placed with percent left'
The page size was wrongly passed to `Document` instead of` Page`,

The test passed before only because the page size is A4 (595.28 vs 841.89) and
10% of 595.28 is 59.528 and internally the Yoga rounds to 60, the same as 10% of 600 (see #548 )