### PR TITLE
Render elements in JSX order

### DIFF
--- a/src/elements/Base.js
+++ b/src/elements/Base.js
@@ -220,15 +220,8 @@ class Base extends Node {
   }
 
   async renderChildren() {
-    const absoluteChilds = this.children.filter(child => child.absolute);
-    const nonAbsoluteChilds = this.children.filter(child => !child.absolute);
-
-    for (let i = 0; i < nonAbsoluteChilds.length; i++) {
-      await nonAbsoluteChilds[i].render();
-    }
-
-    for (let i = 0; i < absoluteChilds.length; i++) {
-      await absoluteChilds[i].render();
+    for (let i = 0; i < this.children.length; i++) {
+      await this.children[i].render();
     }
   }
 }


### PR DESCRIPTION
Since `zIndex` is not supported, rendering absolute elements first restricts the kind of things that can be done with the lib. For this reason we are going to stick to the JSX order for the elements