### PR TITLE
Make rendering async using queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "is-url": "^1.2.4",
     "media-engine": "^1.0.3",
     "page-wrapping": "^1.1.0",
+    "queue": "^6.0.1",
     "ramda": "^0.26.1",
     "react": "^16.8.6",
     "react-reconciler": "^0.20.4",

--- a/src/elements/Base.js
+++ b/src/elements/Base.js
@@ -71,17 +71,14 @@ class Base extends Node {
 
   appendChild(child) {
     super.appendChild(child);
-    this.root.markDirty();
   }
 
   appendChildBefore(child, beforeChild) {
     super.appendChildBefore(child, beforeChild);
-    this.root.markDirty();
   }
 
   removeChild(child) {
     super.removeChild(child);
-    this.root.markDirty();
   }
 
   update(newProps) {
@@ -90,7 +87,6 @@ class Base extends Node {
       Base.defaultProps,
       newProps,
     ]);
-    this.root.markDirty();
   }
 
   applyProps() {

--- a/src/elements/Node.js
+++ b/src/elements/Node.js
@@ -127,10 +127,6 @@ class Node {
     return this.children.length === 0;
   }
 
-  markDirty() {
-    return this.layout.markDirty();
-  }
-
   onAppendDynamically() {}
 
   get position() {

--- a/src/elements/Root.js
+++ b/src/elements/Root.js
@@ -2,7 +2,6 @@ import PDFDocument from '@react-pdf/pdfkit';
 
 class Root {
   constructor() {
-    this.isDirty = false;
     this.document = null;
     this.instance = null;
   }
@@ -19,14 +18,9 @@ class Root {
     this.document = null;
   }
 
-  markDirty() {
-    this.isDirty = true;
-  }
-
   async render() {
     this.instance = new PDFDocument({ autoFirstPage: false });
     await this.document.render();
-    this.isDirty = false;
   }
 }
 

--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -67,7 +67,6 @@ class Text extends Base {
       this.children.push(child);
       this.computed = false;
       this.attributedString = null;
-      this.markDirty();
     }
   }
 
@@ -79,7 +78,6 @@ class Text extends Base {
       this.children.splice(index, 1);
       this.computed = false;
       this.attributedString = null;
-      this.markDirty();
     }
   }
 

--- a/src/elements/TextInstance.js
+++ b/src/elements/TextInstance.js
@@ -26,7 +26,6 @@ class TextInstance {
     this.value = value;
     this.parent.computed = false;
     this.parent.container = null;
-    this.root.markDirty();
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,10 @@
+import * as R from 'ramda';
 import BlobStream from 'blob-stream';
+
+import Font from './font';
 import PDFRenderer from './renderer';
 import StyleSheet from './stylesheet';
 import { createInstance } from './elements';
-import Font from './font';
 import { version } from '../package.json';
 
 const View = 'VIEW';
@@ -14,38 +16,68 @@ const Image = 'IMAGE';
 const Document = 'DOCUMENT';
 const Canvas = 'CANVAS';
 
+const createInstances = (node, root) => {
+  const instance = createInstance(node, root);
+
+  if (node.children) {
+    for (let i = 0; i < node.children.length; i++) {
+      instance.appendChild(createInstances(node.children[i], root));
+    }
+  }
+
+  return instance;
+};
+
+const createRootInstance = doc => {
+  const instance = createInstance(doc);
+
+  for (let i = 0; i < doc.children.length; i++) {
+    instance.appendChild(createInstances(doc.children[i], instance));
+  }
+
+  return instance;
+};
+
 const pdf = input => {
-  const container = createInstance({ type: 'ROOT' });
+  const container = { type: 'ROOT', isDirty: true, children: [] };
   const mountNode = PDFRenderer.createContainer(container);
 
   if (input) updateContainer(input);
 
-  function callOnRender(params = {}) {
-    if (container.document.props.onRender) {
-      const layoutData = container.document.getLayoutData();
-      container.document.props.onRender({ ...params, layoutData });
+  const callOnRender = (instance, params = {}) => {
+    if (instance.document.props.onRender) {
+      const layoutData = instance.document.getLayoutData();
+      instance.document.props.onRender({ ...params, layoutData });
     }
-  }
+  };
 
-  function isDirty() {
+  const isDirty = () => {
     return container.isDirty;
-  }
+  };
 
-  function updateContainer(doc) {
+  const updateContainer = doc => {
     PDFRenderer.updateContainer(doc, mountNode, null);
-  }
+  };
 
-  async function toBlob() {
-    await container.render();
+  const render = async () => {
+    const doc = R.clone(container);
+    const root = createRootInstance(doc);
+    await root.render();
+    container.isDirty = false;
+    return root;
+  };
 
-    const stream = container.instance.pipe(BlobStream());
+  const toBlob = async () => {
+    const root = await render();
+
+    const stream = root.instance.pipe(BlobStream());
 
     return new Promise((resolve, reject) => {
       stream.on('finish', () => {
         try {
           const blob = stream.toBlob('application/pdf');
 
-          callOnRender({ blob });
+          callOnRender(root, { blob });
 
           resolve(blob);
         } catch (error) {
@@ -55,42 +87,44 @@ const pdf = input => {
 
       stream.on('error', reject);
     });
-  }
+  };
 
-  function toBuffer() {
-    callOnRender();
+  // function toBuffer() {
+  //   callOnRender();
 
-    container.render();
+  //   container.render();
 
-    return container.instance;
-  }
+  //   return container.instance;
+  // }
 
-  function toString() {
-    let result = '';
-    container.render();
+  // function toString() {
+  //   let result = '';
+  //   container.render();
 
-    return new Promise((resolve, reject) => {
-      try {
-        container.instance.on('data', function(buffer) {
-          result += buffer;
-        });
+  //   return new Promise((resolve, reject) => {
+  //     try {
+  //       container.instance.on('data', function(buffer) {
+  //         result += buffer;
+  //       });
 
-        container.instance.on('end', function() {
-          callOnRender({ string: result });
-          resolve(result);
-        });
-      } catch (error) {
-        reject(error);
-      }
-    });
-  }
+  //       container.instance.on('end', function() {
+  //         callOnRender({ string: result });
+  //         resolve(result);
+  //       });
+  //     } catch (error) {
+  //       reject(error);
+  //     }
+  //   });
+  // }
 
   return {
     isDirty,
+    // render,
+    container,
     updateContainer,
-    toBuffer,
+    // toBuffer,
     toBlob,
-    toString,
+    // toString,
   };
 };
 

--- a/src/utils/propsEqual.js
+++ b/src/utils/propsEqual.js
@@ -1,3 +1,5 @@
+const WHITELISTED_PROPS = ['render', 'onRender', 'paint'];
+
 const propsEqual = (a, b) => {
   const oldPropsKeys = Object.keys(a);
   const newPropsKeys = Object.keys(b);
@@ -9,7 +11,7 @@ const propsEqual = (a, b) => {
   for (let i = 0; i < oldPropsKeys.length; i++) {
     const propName = oldPropsKeys[i];
 
-    if (propName === 'render') {
+    if (WHITELISTED_PROPS.includes(propName)) {
       if (!a[propName] !== !b[propName]) {
         return false;
       }
@@ -30,7 +32,10 @@ const propsEqual = (a, b) => {
 
     if (
       propName === 'children' &&
-      (typeof a[propName] === 'string' || typeof b[propName] === 'string')
+      (typeof a[propName] === 'string' ||
+        typeof b[propName] === 'string' ||
+        typeof a[propName] === 'number' ||
+        typeof b[propName] === 'number')
     ) {
       return a[propName] === b[propName];
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5209,6 +5209,13 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+queue@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.1.tgz#abd5a5b0376912f070a25729e0b6a7d565683791"
+  integrity sha512-AJBQabRCCNr9ANq8v77RJEv73DPbn55cdTb+Giq4X0AVnNVZvMHlYp7XlQiN+1npCZj1DuSmaA2hYVUUDgxFDg==
+  dependencies:
+    inherits "~2.0.3"
+
 raf@^3.4.0:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"


### PR DESCRIPTION
This should fix #420 (and probably #476).

This is still a WIP. I would like to hear any thoughts! 

The main issue this PR tries to solve is `Root` container being shared between successive renders. Because of how react reconciler works, there must be a shared container (there is a `supportsMutation` param that I couldn't make it work with `false`). This meant that the element instances could change while a rendering was in progress (because of a new update), causing all sort of naughty issues. For the DOM this is not a problem, since most changes are atomic and sync, but react-pdf is different in this way. We first gather all changes and then trigger an async rendering. Any new render can be triggered before the current ends!

In the past, the container instance was `Root`. What this PR does is changing that. Now, the container is a plain object (very similar to a React element), considered now as the only "source of truth" of the PDF document. Every-time the document changes in the DOM, it queues a new render by cloning this object and running it asynchronously. By using a queue, we can actually perform some optimizations, like preventing intermediate renders to happen and therefore increasing performance. Also, we ensure only one render runs a time, and each render is independent from the others.

There are still some things to tackle, such as testing in Node and erasing some dead code. Also fixing tests. Even though it adds some complexity to the rendering process, and it doesn't use react-reconciler as it is supposed to, it fixes many problems.