### PR TITLE
Updated Font.Register src param in examples

### DIFF
--- a/examples/images/index.js
+++ b/examples/images/index.js
@@ -35,10 +35,10 @@ const styles = StyleSheet.create({
   },
 });
 
-Font.register(
-  'https://fonts.gstatic.com/s/oswald/v13/Y_TKV6o8WovbUd3m_X9aAA.ttf',
-  { family: 'Oswald' },
-);
+Font.register({
+    family: 'Oswald',
+    src: 'https://fonts.gstatic.com/s/oswald/v13/Y_TKV6o8WovbUd3m_X9aAA.ttf',
+});
 
 const doc = (
   <Document>

--- a/examples/pageWrap/index.js
+++ b/examples/pageWrap/index.js
@@ -64,7 +64,10 @@ const styles = StyleSheet.create({
   },
 });
 
-Font.register(`${__dirname}/fonts/Roboto-Regular.ttf`, { family: 'Roboto' });
+Font.register({
+  family: 'Roboto',
+  src: `${__dirname}/fonts/Roboto-Regular.ttf`,
+});
 
 const Subtitle = ({ children, ...props }) => (
   <Text style={styles.subtitle} {...props}>

--- a/examples/resume/index.js
+++ b/examples/resume/index.js
@@ -56,17 +56,21 @@ const styles = StyleSheet.create({
   },
 });
 
-Font.register(`${__dirname}/fonts/fonts/Open_Sans/OpenSans-Regular.ttf`, {
+Font.register( {
   family: 'Open Sans',
+  src: `${__dirname}/fonts/fonts/Open_Sans/OpenSans-Regular.ttf`,
 });
-Font.register(`${__dirname}/fonts/fonts/Lato/Lato-Regular.ttf`, {
+Font.register( {
   family: 'Lato',
+  src: `${__dirname}/fonts/fonts/Lato/Lato-Regular.ttf`,
 });
-Font.register(`${__dirname}/fonts/fonts/Lato/Lato-Italic.ttf`, {
+Font.register( {
   family: 'Lato Italic',
+  src: `${__dirname}/fonts/fonts/Lato/Lato-Italic.ttf`,
 });
-Font.register(`${__dirname}/fonts/fonts/Lato/Lato-Bold.ttf`, {
+Font.register( {
   family: 'Lato Bold',
+  src: `${__dirname}/fonts/fonts/Lato/Lato-Bold.ttf`,
 });
 
 const Resume = props => (

--- a/examples/text/index.js
+++ b/examples/text/index.js
@@ -56,10 +56,9 @@ const styles = StyleSheet.create({
   },
 });
 
-Font.register(`${__dirname}/fonts/Roboto-Regular.ttf`, { family: 'Roboto' });
+Font.register({ family: 'Roboto', src: `${__dirname}/fonts/Roboto-Regular.ttf` });
 Font.register(
-  'https://fonts.gstatic.com/s/oswald/v13/Y_TKV6o8WovbUd3m_X9aAA.ttf',
-  { family: 'Oswald' },
+  { family: 'Oswald', src: 'https://fonts.gstatic.com/s/oswald/v13/Y_TKV6o8WovbUd3m_X9aAA.ttf' },
 );
 
 const doc = (


### PR DESCRIPTION
I've updated the params in Font.Register as recommended by the error message, which was pretty annoying since I wanted to quickly test the App examples and could not get any output.

The examples 'just work' now.

