### PR TITLE
Fix font Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -263,8 +263,8 @@ declare module '@react-pdf/renderer' {
 
     interface FontDescriptor {
       family: string;
-      fontStyle: FontStyle;
-      fontWeight: FontWeight;
+      fontStyle?: FontStyle;
+      fontWeight?: FontWeight;
     }
 
     interface RegisteredFont {
@@ -284,13 +284,15 @@ declare module '@react-pdf/renderer' {
       register: (options: {
         family: string;
         src: string;
-        fonts?: {
+        [key: string]: any;
+      } | {
+        family: string;
+        fonts: {
           src: string;
-          fontStyle: string;
-          fontWeight: string | number;
+          fontStyle?: string;
+          fontWeight?: string | number;
           [key: string]: any;
         }[];
-        [key: string]: any;
       }) => void;
       getEmojiSource: () => EmojiSource;
       getRegisteredFonts: () => FontInstance[];


### PR DESCRIPTION
According to the documentation, `fontStyle` and `fontWeight` have default values, so they must be optional in `FontDescriptor` and `register -> fonts`.
The `register` function also accepts two distinct possibilities : either passing `src` or `fonts`.

This commit fixes the type definitions so that the doc examples can be correct in a Typescript project.

These types (particularly `register`) can probably be made stricter by removing the `[key: string]: any;` clause.