### PR TITLE
Fix the HyphenationCallback Typescript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -276,7 +276,7 @@ declare module '@react-pdf/renderer' {
     }
 
     type HyphenationCallback = (
-      words: string[],
+      words: string,
       glyphString: { [key: string]: any },
     ) => string[];
 


### PR DESCRIPTION
According to the doc, the hyphenation callback is given the word as a
`string` and must return an `array` of `string` (`string[]` in TS).
That's how the features works according to my tests as well.

This commit fixes the type definition so as to accept the right type for
`word` (`string`).