### PR TITLE
Added missing style type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -115,6 +115,7 @@ declare module '@react-pdf/renderer' {
       borderTopRightRadius?: number | string,
       borderBottomRightRadius?: number | string,
       borderBottomLeftRadius?: number | string,
+      borderRadius?: number | string
     }
 
     interface Styles {


### PR DESCRIPTION
It seems like last commit with Typescript types had missing borderRadius property. This commits add it.  