### PR TITLE
Allow user to supply their own Yoga implementation

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -153,9 +153,30 @@ const browserProdConfig = {
   plugins: browserConfig.plugins.concat(terser()),
 };
 
+const browserCustomConfig = {
+  ...configBase,
+  input: './src/custom-dom.js',
+  output: [
+    getESM({ file: 'dist/react-pdf.browser-custom.es.js' }),
+    getCJS({ file: 'dist/react-pdf.browser-custom.cjs.js' }),
+  ],
+  plugins: [...getPlugins({ browser: true }), ignore(['fs', 'path', 'url'])],
+};
+
+const browserCustomProdConfig = {
+  ...browserConfig,
+  output: [
+    getESM({ file: 'dist/react-pdf.browser-custom.es.min.js' }),
+    getCJS({ file: 'dist/react-pdf.browser-custom.cjs.min.js' }),
+  ],
+  plugins: browserConfig.plugins.concat(terser()),
+};
+
 export default [
   serverConfig,
   serverProdConfig,
   browserConfig,
   browserProdConfig,
+  browserCustomConfig,
+  browserCustomProdConfig,
 ];

--- a/src/custom-dom.js
+++ b/src/custom-dom.js
@@ -1,0 +1,163 @@
+/* eslint-disable no-unused-vars */
+import React from 'react';
+
+import warning from './utils/warning';
+import createReactPDFIndex from './index';
+
+export default function createReactPDFDom(Yoga) {
+  const {
+    pdf,
+    View,
+    Text,
+    Link,
+    Page,
+    Font,
+    Note,
+    Image,
+    Canvas,
+    version,
+    StyleSheet,
+    PDFRenderer,
+    createInstance,
+    Document: PDFDocument,
+  } = createReactPDFIndex(Yoga);
+
+  const flatStyles = stylesArray =>
+    stylesArray.reduce((acc, style) => ({ ...acc, ...style }), {});
+
+  const Document = ({ children, ...props }) => {
+    return <PDFDocument {...props}>{children}</PDFDocument>;
+  };
+
+  class InternalBlobProvider extends React.PureComponent {
+    state = { blob: null, url: null, loading: true, error: null };
+
+    constructor(props) {
+      super(props);
+
+      // Create new root container for this render
+      this.instance = pdf();
+    }
+
+    componentDidMount() {
+      this.renderDocument();
+      this.onDocumentUpdate();
+    }
+
+    componentDidUpdate() {
+      this.renderDocument();
+
+      if (this.instance.isDirty() && !this.state.error) {
+        this.onDocumentUpdate();
+      }
+    }
+
+    renderDocument() {
+      this.instance.updateContainer(this.props.document);
+    }
+
+    onDocumentUpdate() {
+      const oldBlobUrl = this.state.url;
+
+      this.instance
+        .toBlob()
+        .then(blob => {
+          this.setState(
+            { blob, url: URL.createObjectURL(blob), loading: false },
+            () => URL.revokeObjectURL(oldBlobUrl),
+          );
+        })
+        .catch(error => {
+          this.setState({ error });
+          console.error(error);
+          throw error;
+        });
+    }
+
+    render() {
+      return this.props.children(this.state);
+    }
+  }
+
+  const BlobProvider = ({ document: doc, children }) => {
+    if (!doc) {
+      warning(false, 'You should pass a valid document to BlobProvider');
+      return null;
+    }
+
+    return (
+      <InternalBlobProvider document={doc}>{children}</InternalBlobProvider>
+    );
+  };
+
+  const PDFViewer = ({ className, style, children, innerRef, ...props }) => {
+    return (
+      <InternalBlobProvider document={children}>
+        {({ url }) => (
+          <iframe
+            className={className}
+            ref={innerRef}
+            src={url}
+            style={Array.isArray(style) ? flatStyles(style) : style}
+            {...props}
+          />
+        )}
+      </InternalBlobProvider>
+    );
+  };
+
+  const PDFDownloadLink = ({
+    document: doc,
+    className,
+    style,
+    children,
+    fileName = 'document.pdf',
+  }) => {
+    if (!doc) {
+      warning(false, 'You should pass a valid document to PDFDownloadLink');
+      return null;
+    }
+
+    const downloadOnIE = blob => () => {
+      if (window.navigator.msSaveBlob) {
+        window.navigator.msSaveBlob(blob, fileName);
+      }
+    };
+
+    return (
+      <InternalBlobProvider document={doc}>
+        {params => (
+          <a
+            className={className}
+            download={fileName}
+            href={params.url}
+            onClick={downloadOnIE(params.blob)}
+            style={Array.isArray(style) ? flatStyles(style) : style}
+          >
+            {typeof children === 'function' ? children(params) : children}
+          </a>
+        )}
+      </InternalBlobProvider>
+    );
+  };
+
+  return {
+    pdf,
+    View,
+    Text,
+    Link,
+    Page,
+    Font,
+    Note,
+    Image,
+    Canvas,
+    version,
+    Document,
+    PDFViewer,
+    StyleSheet,
+    PDFRenderer,
+    BlobProvider,
+    createInstance,
+    PDFDownloadLink,
+  };
+}

--- a/src/dom.js
+++ b/src/dom.js
@@ -1,9 +1,10 @@
 /* eslint-disable no-unused-vars */
 import React from 'react';
+import Yoga from 'yoga-layout';
 
 import warning from '../src/utils/warning';
-
-import {
+import createReactPDF from './index';
+const {
   pdf,
   View,
   Text,
@@ -17,8 +18,8 @@ import {
   StyleSheet,
   PDFRenderer,
   createInstance,
-  Document as PDFDocument,
-} from './index';
+  Document: PDFDocument,
+} = createReactPDF(Yoga);
 
 const flatStyles = stylesArray =>
   stylesArray.reduce((acc, style) => ({ ...acc, ...style }), {});
@@ -157,7 +158,7 @@ export {
   StyleSheet,
   PDFRenderer,
   createInstance,
-} from './index';
+};
 
 export default {
   pdf,

--- a/src/elements/Base.js
+++ b/src/elements/Base.js
@@ -114,7 +114,7 @@ class Base extends Node {
       height: size.height,
     };
 
-    const ownStyles = StyleSheet(this.Yoga).resolve(
+    const ownStyles = StyleSheet({ current: this.Yoga }).resolve(
       this.props.style,
       container,
     );

--- a/src/elements/Base.js
+++ b/src/elements/Base.js
@@ -15,7 +15,7 @@ import { inheritedProperties } from '../stylesheet/inherit';
 
 class Base extends Node {
   constructor(root, props) {
-    super();
+    super(root ? root.Yoga : null);
 
     this.root = root;
     this.style = {};
@@ -114,7 +114,10 @@ class Base extends Node {
       height: size.height,
     };
 
-    const ownStyles = StyleSheet.resolve(this.props.style, container);
+    const ownStyles = StyleSheet(this.Yoga).resolve(
+      this.props.style,
+      container,
+    );
 
     const inheritedStyles = this.parent
       ? pick(inheritedProperties, this.parent.style)

--- a/src/elements/Image.js
+++ b/src/elements/Image.js
@@ -1,5 +1,3 @@
-import Yoga from 'yoga-layout';
-
 import Base from './Base';
 import warning from '../utils/warning';
 import { resolveImage } from '../utils/image';
@@ -45,32 +43,32 @@ class Image extends Base {
     if (!this.image) return { width: 0, height: 0 };
 
     if (
-      widthMode === Yoga.MEASURE_MODE_EXACTLY &&
-      heightMode === Yoga.MEASURE_MODE_UNDEFINED
+      widthMode === this.Yoga.MEASURE_MODE_EXACTLY &&
+      heightMode === this.Yoga.MEASURE_MODE_UNDEFINED
     ) {
       const scaledHeight = width / this.ratio;
       return { height: Math.min(pageArea, scaledHeight) };
     }
 
     if (
-      heightMode === Yoga.MEASURE_MODE_EXACTLY &&
-      (widthMode === Yoga.MEASURE_MODE_AT_MOST ||
-        widthMode === Yoga.MEASURE_MODE_UNDEFINED)
+      heightMode === this.Yoga.MEASURE_MODE_EXACTLY &&
+      (widthMode === this.Yoga.MEASURE_MODE_AT_MOST ||
+        widthMode === this.Yoga.MEASURE_MODE_UNDEFINED)
     ) {
       return { width: Math.min(height * this.ratio, width) };
     }
 
     if (
-      widthMode === Yoga.MEASURE_MODE_EXACTLY &&
-      heightMode === Yoga.MEASURE_MODE_AT_MOST
+      widthMode === this.Yoga.MEASURE_MODE_EXACTLY &&
+      heightMode === this.Yoga.MEASURE_MODE_AT_MOST
     ) {
       const scaledHeight = width / this.ratio;
       return { height: Math.min(height, pageArea, scaledHeight) };
     }
 
     if (
-      widthMode === Yoga.MEASURE_MODE_AT_MOST &&
-      heightMode === Yoga.MEASURE_MODE_AT_MOST
+      widthMode === this.Yoga.MEASURE_MODE_AT_MOST &&
+      heightMode === this.Yoga.MEASURE_MODE_AT_MOST
     ) {
       if (this.ratio > 1) {
         return {

--- a/src/elements/Node.js
+++ b/src/elements/Node.js
@@ -1,14 +1,13 @@
-import Yoga from 'yoga-layout';
-
 import upperFirst from '../utils/upperFirst';
 import matchPercent from '../utils/matchPercent';
 
 class Node {
-  constructor() {
+  constructor(Yoga) {
+    Object.defineProperty(this, 'Yoga', { enumerable: false, value: Yoga });
     this.parent = null;
     this.children = [];
     this.computed = false;
-    this.layout = Yoga.Node.createDefault();
+    this.layout = Yoga ? Yoga.Node.createDefault() : null;
   }
 
   appendChild(child) {
@@ -138,11 +137,11 @@ class Node {
   cleanup() {
     this.children.forEach(c => c.cleanup());
     this.layout.unsetMeasureFunc();
-    Yoga.Node.destroy(this.layout);
+    this.Yoga.Node.destroy(this.layout);
   }
 
   get position() {
-    return this.layout.getPositionType() === Yoga.POSITION_TYPE_ABSOLUTE
+    return this.layout.getPositionType() === this.Yoga.POSITION_TYPE_ABSOLUTE
       ? 'absolute'
       : 'relative';
   }
@@ -188,51 +187,51 @@ class Node {
   }
 
   get paddingTop() {
-    return this.layout.getComputedPadding(Yoga.EDGE_TOP) || 0;
+    return this.layout.getComputedPadding(this.Yoga.EDGE_TOP) || 0;
   }
 
   get paddingRight() {
-    return this.layout.getComputedPadding(Yoga.EDGE_RIGHT) || 0;
+    return this.layout.getComputedPadding(this.Yoga.EDGE_RIGHT) || 0;
   }
 
   get paddingBottom() {
-    return this.layout.getComputedPadding(Yoga.EDGE_BOTTOM) || 0;
+    return this.layout.getComputedPadding(this.Yoga.EDGE_BOTTOM) || 0;
   }
 
   get paddingLeft() {
-    return this.layout.getComputedPadding(Yoga.EDGE_LEFT) || 0;
+    return this.layout.getComputedPadding(this.Yoga.EDGE_LEFT) || 0;
   }
 
   get marginTop() {
-    return this.layout.getComputedMargin(Yoga.EDGE_TOP) || 0;
+    return this.layout.getComputedMargin(this.Yoga.EDGE_TOP) || 0;
   }
 
   get marginRight() {
-    return this.layout.getComputedMargin(Yoga.EDGE_RIGHT) || 0;
+    return this.layout.getComputedMargin(this.Yoga.EDGE_RIGHT) || 0;
   }
 
   get marginBottom() {
-    return this.layout.getComputedMargin(Yoga.EDGE_BOTTOM) || 0;
+    return this.layout.getComputedMargin(this.Yoga.EDGE_BOTTOM) || 0;
   }
 
   get marginLeft() {
-    return this.layout.getComputedMargin(Yoga.EDGE_LEFT) || 0;
+    return this.layout.getComputedMargin(this.Yoga.EDGE_LEFT) || 0;
   }
 
   get borderTopWidth() {
-    return this.layout.getComputedBorder(Yoga.EDGE_TOP) || 0;
+    return this.layout.getComputedBorder(this.Yoga.EDGE_TOP) || 0;
   }
 
   get borderRightWidth() {
-    return this.layout.getComputedBorder(Yoga.EDGE_RIGHT) || 0;
+    return this.layout.getComputedBorder(this.Yoga.EDGE_RIGHT) || 0;
   }
 
   get borderBottomWidth() {
-    return this.layout.getComputedBorder(Yoga.EDGE_BOTTOM) || 0;
+    return this.layout.getComputedBorder(this.Yoga.EDGE_BOTTOM) || 0;
   }
 
   get borderLeftWidth() {
-    return this.layout.getComputedBorder(Yoga.EDGE_LEFT) || 0;
+    return this.layout.getComputedBorder(this.Yoga.EDGE_LEFT) || 0;
   }
 
   get padding() {
@@ -256,25 +255,25 @@ class Node {
   set position(value) {
     this.layout.setPositionType(
       value === 'absolute'
-        ? Yoga.POSITION_TYPE_ABSOLUTE
-        : Yoga.POSITION_TYPE_RELATIVE,
+        ? this.Yoga.POSITION_TYPE_ABSOLUTE
+        : this.Yoga.POSITION_TYPE_RELATIVE,
     );
   }
 
   set top(value) {
-    this.setPosition(Yoga.EDGE_TOP, value);
+    this.setPosition(this.Yoga.EDGE_TOP, value);
   }
 
   set left(value) {
-    this.setPosition(Yoga.EDGE_LEFT, value);
+    this.setPosition(this.Yoga.EDGE_LEFT, value);
   }
 
   set right(value) {
-    this.setPosition(Yoga.EDGE_RIGHT, value);
+    this.setPosition(this.Yoga.EDGE_RIGHT, value);
   }
 
   set bottom(value) {
-    this.setPosition(Yoga.EDGE_BOTTOM, value);
+    this.setPosition(this.Yoga.EDGE_BOTTOM, value);
   }
 
   set width(value) {
@@ -302,35 +301,35 @@ class Node {
   }
 
   set paddingTop(value) {
-    this.setPadding(Yoga.EDGE_TOP, value);
+    this.setPadding(this.Yoga.EDGE_TOP, value);
   }
 
   set paddingRight(value) {
-    this.setPadding(Yoga.EDGE_RIGHT, value);
+    this.setPadding(this.Yoga.EDGE_RIGHT, value);
   }
 
   set paddingBottom(value) {
-    this.setPadding(Yoga.EDGE_BOTTOM, value);
+    this.setPadding(this.Yoga.EDGE_BOTTOM, value);
   }
 
   set paddingLeft(value) {
-    this.setPadding(Yoga.EDGE_LEFT, value);
+    this.setPadding(this.Yoga.EDGE_LEFT, value);
   }
 
   set marginTop(value) {
-    this.setMargin(Yoga.EDGE_TOP, value);
+    this.setMargin(this.Yoga.EDGE_TOP, value);
   }
 
   set marginRight(value) {
-    this.setMargin(Yoga.EDGE_RIGHT, value);
+    this.setMargin(this.Yoga.EDGE_RIGHT, value);
   }
 
   set marginBottom(value) {
-    this.setMargin(Yoga.EDGE_BOTTOM, value);
+    this.setMargin(this.Yoga.EDGE_BOTTOM, value);
   }
 
   set marginLeft(value) {
-    this.setMargin(Yoga.EDGE_LEFT, value);
+    this.setMargin(this.Yoga.EDGE_LEFT, value);
   }
 
   set padding(value) {
@@ -348,19 +347,19 @@ class Node {
   }
 
   set borderTopWidth(value) {
-    this.setBorder(Yoga.EDGE_TOP, value);
+    this.setBorder(this.Yoga.EDGE_TOP, value);
   }
 
   set borderRightWidth(value) {
-    this.setBorder(Yoga.EDGE_RIGHT, value);
+    this.setBorder(this.Yoga.EDGE_RIGHT, value);
   }
 
   set borderBottomWidth(value) {
-    this.setBorder(Yoga.EDGE_BOTTOM, value);
+    this.setBorder(this.Yoga.EDGE_BOTTOM, value);
   }
 
   set borderLeftWidth(value) {
-    this.setBorder(Yoga.EDGE_LEFT, value);
+    this.setBorder(this.Yoga.EDGE_LEFT, value);
   }
 }
 

--- a/src/elements/Page.js
+++ b/src/elements/Page.js
@@ -1,5 +1,4 @@
 import { Fragment } from 'react';
-import Yoga from 'yoga-layout';
 
 import Base from './Base';
 import Ruler from '../mixins/ruler';
@@ -101,7 +100,7 @@ class Page extends Base {
 
   setPadding(edge, value) {
     const dimension =
-      edge === Yoga.EDGE_TOP || edge === Yoga.EDGE_BOTTOM
+      edge === this.Yoga.EDGE_TOP || edge === this.Yoga.EDGE_BOTTOM
         ? this.size.height
         : this.size.width;
 

--- a/src/elements/Root.js
+++ b/src/elements/Root.js
@@ -1,8 +1,13 @@
 import PDFDocument from '@react-pdf/pdfkit';
 
 class Root {
-  constructor(_, Yoga) {
-    Object.defineProperty(this, 'Yoga', { enumerable: false, value: Yoga });
+  constructor(_, yogaRef) {
+    Object.defineProperty(this, 'Yoga', {
+      enumerable: false,
+      get() {
+        return yogaRef.current;
+      },
+    });
     this.isDirty = false;
     this.document = null;
     this.instance = null;

--- a/src/elements/Root.js
+++ b/src/elements/Root.js
@@ -1,7 +1,8 @@
 import PDFDocument from '@react-pdf/pdfkit';
 
 class Root {
-  constructor() {
+  constructor(_, Yoga) {
+    Object.defineProperty(this, 'Yoga', { enumerable: false, value: Yoga });
     this.isDirty = false;
     this.document = null;
     this.instance = null;

--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -1,4 +1,3 @@
-import Yoga from 'yoga-layout';
 import PDFRenderer from '@react-pdf/textkit/renderers/pdf';
 import AttributedString from '@react-pdf/textkit/attributedString';
 
@@ -139,13 +138,13 @@ class Text extends Base {
   }
 
   measureText(width, widthMode, height, heightMode) {
-    if (widthMode === Yoga.MEASURE_MODE_EXACTLY) {
+    if (widthMode === this.Yoga.MEASURE_MODE_EXACTLY) {
       this.layoutText(width, height);
 
       return { height: this.linesHeight };
     }
 
-    if (widthMode === Yoga.MEASURE_MODE_AT_MOST) {
+    if (widthMode === this.Yoga.MEASURE_MODE_AT_MOST) {
       this.layoutText(width, height);
 
       return {

--- a/src/elements/YogaContext.js
+++ b/src/elements/YogaContext.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+const YogaContext = React.createContext();
+
+export default YogaContext;
+
+export function provideYoga(Yoga, children) {
+  return React.createElement(
+    YogaContext.Provider,
+    {
+      value: Yoga,
+    },
+    children,
+  );
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
+import Yoga from 'yoga-layout';
 import BlobStream from 'blob-stream';
 import PDFRenderer from './renderer';
-import StyleSheet from './stylesheet';
+import createStyleSheet from './stylesheet';
 import { createInstance } from './elements';
 import Font from './font';
 import { version } from '../package.json';
@@ -15,7 +16,7 @@ const Document = 'DOCUMENT';
 const Canvas = 'CANVAS';
 
 const pdf = input => {
-  const container = createInstance({ type: 'ROOT' });
+  const container = createInstance({ type: 'ROOT', props: Yoga });
   const mountNode = PDFRenderer.createContainer(container);
 
   if (input) updateContainer(input);
@@ -95,6 +96,7 @@ const pdf = input => {
   };
 };
 
+const StyleSheet = createStyleSheet(Yoga);
 export {
   version,
   PDFRenderer,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-import Yoga from 'yoga-layout';
 import BlobStream from 'blob-stream';
 import PDFRenderer from './renderer';
 import createStyleSheet from './stylesheet';
@@ -15,7 +14,7 @@ const Image = 'IMAGE';
 const Document = 'DOCUMENT';
 const Canvas = 'CANVAS';
 
-const pdf = input => {
+const pdf = Yoga => input => {
   const container = createInstance({ type: 'ROOT', props: Yoga });
   const mountNode = PDFRenderer.createContainer(container);
 
@@ -96,20 +95,22 @@ const pdf = input => {
   };
 };
 
-const StyleSheet = createStyleSheet(Yoga);
-export {
-  version,
-  PDFRenderer,
-  View,
-  Text,
-  Link,
-  Page,
-  Font,
-  Note,
-  Image,
-  Document,
-  Canvas,
-  StyleSheet,
-  createInstance,
-  pdf,
-};
+export default function createReactPDF(Yoga) {
+  const StyleSheet = createStyleSheet(Yoga);
+  return {
+    version,
+    PDFRenderer,
+    View,
+    Text,
+    Link,
+    Page,
+    Font,
+    Note,
+    Image,
+    Document,
+    Canvas,
+    StyleSheet,
+    createInstance,
+    pdf: pdf(Yoga),
+  };
+}

--- a/src/index.js
+++ b/src/index.js
@@ -14,8 +14,8 @@ const Image = 'IMAGE';
 const Document = 'DOCUMENT';
 const Canvas = 'CANVAS';
 
-const pdf = Yoga => input => {
-  const container = createInstance({ type: 'ROOT', props: Yoga });
+const pdf = yogaRef => input => {
+  const container = createInstance({ type: 'ROOT', props: yogaRef });
   const mountNode = PDFRenderer.createContainer(container);
 
   if (input) updateContainer(input);
@@ -95,8 +95,8 @@ const pdf = Yoga => input => {
   };
 };
 
-export default function createReactPDF(Yoga) {
-  const StyleSheet = createStyleSheet(Yoga);
+export default function createReactPDF(yogaRef) {
+  const StyleSheet = createStyleSheet(yogaRef);
   return {
     version,
     PDFRenderer,
@@ -111,6 +111,6 @@ export default function createReactPDF(Yoga) {
     Canvas,
     StyleSheet,
     createInstance,
-    pdf: pdf(Yoga),
+    pdf: pdf(yogaRef),
   };
 }

--- a/src/node.js
+++ b/src/node.js
@@ -16,7 +16,7 @@ const {
   StyleSheet,
   PDFRenderer,
   createInstance,
-} = createReactPDF(Yoga);
+} = createReactPDF({ current: Yoga });
 
 export const renderToStream = async function(element) {
   const instance = pdf(element);

--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,7 @@
+import Yoga from 'yoga-layout';
 import fs from 'fs';
-import {
+import createReactPDF from './index';
+const {
   pdf,
   View,
   Text,
@@ -14,7 +16,7 @@ import {
   StyleSheet,
   PDFRenderer,
   createInstance,
-} from './index';
+} = createReactPDF(Yoga);
 
 export const renderToStream = async function(element) {
   const instance = pdf(element);
@@ -73,7 +75,7 @@ export {
   StyleSheet,
   PDFRenderer,
   createInstance,
-} from './index';
+};
 
 export default {
   pdf,

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -3,7 +3,7 @@
 import ReactFiberReconciler from 'react-reconciler';
 import {
   unstable_scheduleCallback as schedulePassiveEffects,
-  unstable_cancelCallback as cancelPassiveEffects
+  unstable_cancelCallback as cancelPassiveEffects,
 } from 'scheduler';
 
 import { createInstance } from './elements';

--- a/src/stylesheet/index.js
+++ b/src/stylesheet/index.js
@@ -40,12 +40,12 @@ const resolveMediaQueries = (input, container) => {
   return result;
 };
 
-const resolve = (styles, container) => {
+const resolve = Yoga => (styles, container) => {
   if (!styles) return null;
 
   styles = flatten(styles);
   styles = resolveMediaQueries(styles, container);
-  styles = transformStyles(styles, container);
+  styles = transformStyles(styles, container, Yoga);
 
   return styles;
 };
@@ -58,10 +58,12 @@ const absoluteFillObject = {
   right: 0,
 };
 
-export default {
-  hairlineWidth: 1,
-  create,
-  resolve,
-  flatten,
-  absoluteFillObject,
-};
+export default function createStyleSheet(Yoga) {
+  return {
+    hairlineWidth: 1,
+    create,
+    resolve: resolve(Yoga),
+    flatten,
+    absoluteFillObject,
+  };
+}

--- a/src/stylesheet/index.js
+++ b/src/stylesheet/index.js
@@ -40,12 +40,12 @@ const resolveMediaQueries = (input, container) => {
   return result;
 };
 
-const resolve = Yoga => (styles, container) => {
+const resolve = yogaRef => (styles, container) => {
   if (!styles) return null;
 
   styles = flatten(styles);
   styles = resolveMediaQueries(styles, container);
-  styles = transformStyles(styles, container, Yoga);
+  styles = transformStyles(styles, container, yogaRef.current);
 
   return styles;
 };
@@ -58,11 +58,11 @@ const absoluteFillObject = {
   right: 0,
 };
 
-export default function createStyleSheet(Yoga) {
+export default function createStyleSheet(yogaRef) {
   return {
     hairlineWidth: 1,
     create,
-    resolve: resolve(Yoga),
+    resolve: resolve(yogaRef),
     flatten,
     absoluteFillObject,
   };

--- a/src/stylesheet/transformStyles.js
+++ b/src/stylesheet/transformStyles.js
@@ -109,7 +109,7 @@ const styleShorthands = {
 };
 
 // Expand the shorthand properties to isolate every declaration from the others.
-const expandStyles = style => {
+const expandStyles = (style, Yoga) => {
   if (!style) return style;
 
   const propsArray = Object.keys(style);
@@ -133,7 +133,7 @@ const expandStyles = style => {
       case 'alignItems':
       case 'alignContent':
       case 'order':
-        resolvedStyle[key] = yogaValue(key, value);
+        resolvedStyle[key] = yogaValue(key, value, Yoga);
         break;
       case 'textAlignVertical':
         resolvedStyle.verticalAlign = value === 'center' ? 'middle' : value;
@@ -173,8 +173,8 @@ const expandStyles = style => {
   return resolvedStyle;
 };
 
-const transformStyles = (style, container) => {
-  const expandedStyles = expandStyles(style);
+const transformStyles = (style, container, Yoga) => {
+  const expandedStyles = expandStyles(style, Yoga);
   const propsArray = Object.keys(expandedStyles);
   const resolvedStyle = {};
 

--- a/src/stylesheet/yogaValue.js
+++ b/src/stylesheet/yogaValue.js
@@ -1,6 +1,4 @@
-import Yoga from 'yoga-layout';
-
-const yogaValue = (prop, value) => {
+const yogaValue = (prop, value, Yoga) => {
   const isAlignType = prop =>
     prop === 'alignItems' || prop === 'alignContent' || prop === 'alignSelf';
 

--- a/tests/attributedString.test.js
+++ b/tests/attributedString.test.js
@@ -1,8 +1,13 @@
+import root from './utils/dummyRoot';
 import Text from '../src/elements/Text';
 import TextInstance from '../src/elements/TextInstance';
 import { getAttributedString } from '../src/utils/attributedString';
 
+let dummyRoot;
 describe('attributedString', () => {
+  beforeEach(() => {
+    dummyRoot = root.reset();
+  });
   test('Should get emtpy attributed string if no instance passed', () => {
     const attributedString = getAttributedString();
 
@@ -10,7 +15,7 @@ describe('attributedString', () => {
   });
 
   test('Should get attributed string from single text node', () => {
-    const text = new Text(null, {});
+    const text = new Text(dummyRoot, {});
     const instance = new TextInstance(null, 'Hey');
 
     text.appendChild(instance);
@@ -22,8 +27,8 @@ describe('attributedString', () => {
   });
 
   test('Should get attributed string with inline texts', () => {
-    const root = new Text(null, {});
-    const inline = new Text(null, {});
+    const root = new Text(dummyRoot, {});
+    const inline = new Text(dummyRoot, {});
     const instance1 = new TextInstance(null, 'Hey');
     const instance2 = new TextInstance(null, 'Ho');
     const instance3 = new TextInstance(null, 'Lets go');
@@ -42,7 +47,7 @@ describe('attributedString', () => {
   });
 
   test('Should set backgroundColor to attributed string', () => {
-    const text = new Text(null, {});
+    const text = new Text(dummyRoot, {});
     const instance = new TextInstance(null, 'Hey');
 
     text.style = { backgroundColor: 'red' }; // Simulate parent stlyes computing
@@ -54,7 +59,7 @@ describe('attributedString', () => {
   });
 
   test('Should set opacity to attributed string', () => {
-    const text = new Text(null, {});
+    const text = new Text(dummyRoot, {});
     const instance = new TextInstance(null, 'Hey');
 
     text.style = { opacity: 0.4 }; // Simulate parent stlyes computing
@@ -66,7 +71,7 @@ describe('attributedString', () => {
   });
 
   test('Should set zero opacity to attributed string', () => {
-    const text = new Text(null, {});
+    const text = new Text(dummyRoot, {});
     const instance = new TextInstance(null, 'Hey');
 
     text.style = { opacity: 0 }; // Simulate parent stlyes computing

--- a/tests/domApi.test.js
+++ b/tests/domApi.test.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import warning from '../src/utils/warning';
-import { pdf } from '../src/index';
 import {
+  pdf,
   PDFDownloadLink,
   PDFViewer,
   BlobProvider,
@@ -12,7 +12,17 @@ import {
   View,
 } from '../src/dom';
 
-jest.mock('../src/index');
+// replace pdf in return value of index.default with mocked version
+jest.mock('../src/index', () => {
+  const actual = jest.requireActual('../src/index');
+  return {
+    ...actual,
+    default: Yoga => ({
+      ...actual.default(Yoga),
+      pdf: jest.fn(() => {}),
+    }),
+  };
+});
 jest.mock('../src/utils/warning');
 
 class Blob {}

--- a/tests/elements.test.js
+++ b/tests/elements.test.js
@@ -1,6 +1,11 @@
+import root from './utils/dummyRoot';
 import { createInstance } from '../src/elements';
 
+let dummyRoot;
 describe('Elements', () => {
+  beforeEach(() => {
+    dummyRoot = root.reset();
+  });
   test('Should create root instance', async () => {
     const instance = createInstance({ type: 'ROOT' });
     expect(instance.name).toBe('Root');
@@ -22,12 +27,12 @@ describe('Elements', () => {
   });
 
   test('Should create image instance', async () => {
-    const instance = createInstance({ type: 'IMAGE' });
+    const instance = createInstance({ type: 'IMAGE' }, dummyRoot);
     expect(instance.name).toBe('Image');
   });
 
   test('Should create text instance', async () => {
-    const instance = createInstance({ type: 'TEXT' });
+    const instance = createInstance({ type: 'TEXT' }, dummyRoot);
     expect(instance.name).toBe('Text');
   });
 

--- a/tests/flattenStyles.test.js
+++ b/tests/flattenStyles.test.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from '../src';
+import { StyleSheet } from '../src/node';
 
 describe('flatten styles', () => {
   test('should return object from an object', () => {

--- a/tests/flexboxAttributes.test.js
+++ b/tests/flexboxAttributes.test.js
@@ -1,5 +1,5 @@
 import Yoga from 'yoga-layout-prebuilt';
-import { StyleSheet } from '../src';
+import { StyleSheet } from '../src/node';
 
 describe('flexbox attributes', () => {
   const assertFlexbox = (attribute, value, expectedValue) => {

--- a/tests/mediaQueries.test.js
+++ b/tests/mediaQueries.test.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from '../src';
+import { StyleSheet } from '../src/node';
 
 describe('media queries', () => {
   test('should resolve max-height media queries on narrow container', () => {

--- a/tests/node.test.js
+++ b/tests/node.test.js
@@ -1,8 +1,13 @@
+import root from './utils/dummyRoot';
 import Node from '../src/elements/Node';
 
+let dummyRoot;
 describe('Node', () => {
+  beforeEach(() => {
+    dummyRoot = root.reset();
+  });
   test('Should get correct position', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.position = 'absolute';
 
@@ -12,7 +17,7 @@ describe('Node', () => {
   });
 
   test('Should get correct coordinates', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.top = 20;
     node.left = 40;
@@ -24,7 +29,7 @@ describe('Node', () => {
   });
 
   test('Should get correct dimensions', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.width = 20;
     node.height = 40;
@@ -36,8 +41,8 @@ describe('Node', () => {
   });
 
   test('Should get integer percentage dimensions', () => {
-    const base = new Node();
-    const child = new Node();
+    const base = new Node(dummyRoot.Yoga);
+    const child = new Node(dummyRoot.Yoga);
 
     base.appendChild(child);
 
@@ -53,8 +58,8 @@ describe('Node', () => {
   });
 
   test('Should get float percentage dimensions', () => {
-    const base = new Node();
-    const child = new Node();
+    const base = new Node(dummyRoot.Yoga);
+    const child = new Node(dummyRoot.Yoga);
 
     base.appendChild(child);
 
@@ -70,7 +75,7 @@ describe('Node', () => {
   });
 
   test('Should get correct min/max dimensions', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.minWidth = 20;
     node.minHeight = 40;
@@ -86,7 +91,7 @@ describe('Node', () => {
   });
 
   test('Should get correct padding', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.paddingTop = 10;
     node.paddingRight = 20;
@@ -102,8 +107,8 @@ describe('Node', () => {
   });
 
   test('Should append child correctly', () => {
-    const base = new Node();
-    const child = new Node();
+    const base = new Node(dummyRoot.Yoga);
+    const child = new Node(dummyRoot.Yoga);
 
     base.appendChild(child);
 
@@ -115,9 +120,9 @@ describe('Node', () => {
   });
 
   test('Should append child before correctly', () => {
-    const base = new Node();
-    const child1 = new Node();
-    const child2 = new Node();
+    const base = new Node(dummyRoot.Yoga);
+    const child1 = new Node(dummyRoot.Yoga);
+    const child2 = new Node(dummyRoot.Yoga);
 
     base.appendChild(child1);
     base.appendChildBefore(child2, child1);
@@ -133,9 +138,9 @@ describe('Node', () => {
   });
 
   test('Should remove child correctly', () => {
-    const base = new Node();
-    const child1 = new Node();
-    const child2 = new Node();
+    const base = new Node(dummyRoot.Yoga);
+    const child1 = new Node(dummyRoot.Yoga);
+    const child2 = new Node(dummyRoot.Yoga);
 
     base.appendChild(child1);
     base.appendChild(child2);
@@ -151,7 +156,7 @@ describe('Node', () => {
   });
 
   test('Should get correct margin', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.marginTop = 10;
     node.marginRight = 20;
@@ -167,7 +172,7 @@ describe('Node', () => {
   });
 
   test('Should get correct border', () => {
-    const node = new Node();
+    const node = new Node(dummyRoot.Yoga);
 
     node.borderTopWidth = 10;
     node.borderRightWidth = 20;
@@ -183,8 +188,8 @@ describe('Node', () => {
   });
 
   test('Should copy position correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.position = 'absolute';
 
@@ -195,8 +200,8 @@ describe('Node', () => {
   });
 
   test('Should copy coordinates correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.top = 20;
     node.left = 40;
@@ -209,8 +214,8 @@ describe('Node', () => {
   });
 
   test('Should copy dimensions correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.width = 20;
     node.height = 40;
@@ -223,8 +228,8 @@ describe('Node', () => {
   });
 
   test('Should copy min/max dimensions correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.minWidth = 20;
     node.minHeight = 40;
@@ -241,8 +246,8 @@ describe('Node', () => {
   });
 
   test('Should copy padding correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.paddingTop = 10;
     node.paddingRight = 20;
@@ -259,8 +264,8 @@ describe('Node', () => {
   });
 
   test('Should copy margin correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.marginTop = 10;
     node.marginRight = 20;
@@ -277,8 +282,8 @@ describe('Node', () => {
   });
 
   test('Should copy borders correctly', () => {
-    const node = new Node();
-    const clone = new Node();
+    const node = new Node(dummyRoot.Yoga);
+    const clone = new Node(dummyRoot.Yoga);
 
     node.borderTopWidth = 10;
     node.borderRightWidth = 20;
@@ -295,9 +300,9 @@ describe('Node', () => {
   });
 
   test('Should get absolute layout correctly', () => {
-    const parent = new Node();
-    const child1 = new Node();
-    const child2 = new Node();
+    const parent = new Node(dummyRoot.Yoga);
+    const child1 = new Node(dummyRoot.Yoga);
+    const child2 = new Node(dummyRoot.Yoga);
 
     parent.width = 100;
     parent.height = 100;
@@ -324,10 +329,10 @@ describe('Node', () => {
   });
 
   test('Should get absolute layout correctly for cloned nodes', () => {
-    const parent = new Node();
-    const child = new Node();
-    const cloneParent = new Node();
-    const cloneChild = new Node();
+    const parent = new Node(dummyRoot.Yoga);
+    const child = new Node(dummyRoot.Yoga);
+    const cloneParent = new Node(dummyRoot.Yoga);
+    const cloneChild = new Node(dummyRoot.Yoga);
 
     parent.width = 100;
     parent.height = 100;

--- a/tests/pdf.test.js
+++ b/tests/pdf.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { pdf, Document, Page, Text } from '../src/index';
+import { pdf, Document, Page, Text } from '../src/node';
 
 describe('pdf', () => {
   test('Should create empty pdf instance', () => {

--- a/tests/styleShorthands.test.js
+++ b/tests/styleShorthands.test.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from '../src';
+import { StyleSheet } from '../src/node';
 
 describe('shorthands', () => {
   test('should process margin shorthand', () => {

--- a/tests/stylesExpansion.test.js
+++ b/tests/stylesExpansion.test.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from '../src';
+import { StyleSheet } from '../src/node';
 
 describe('attribute expansion', () => {
   const expand = (stylesheet, expected) => {

--- a/tests/unitsConversion.test.js
+++ b/tests/unitsConversion.test.js
@@ -1,4 +1,4 @@
-import { StyleSheet } from '../src';
+import { StyleSheet } from '../src/node';
 
 describe('units conversion', () => {
   test('Should transform width in dimensions', () => {

--- a/tests/utils/dummyRoot.js
+++ b/tests/utils/dummyRoot.js
@@ -1,3 +1,5 @@
+import Yoga from 'yoga-layout';
+
 export default {
   reset: () => {
     const instance = {};
@@ -46,9 +48,11 @@ export default {
     instance.text = jest.fn().mockReturnValue(instance);
     instance.font = jest.fn().mockReturnValue(instance);
 
-    return {
+    const root = {
       instance,
       markDirty: jest.fn(),
     };
+    Object.defineProperty(root, 'Yoga', { enumerable: false, value: Yoga });
+    return root;
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5765,6 +5765,14 @@ scheduler@^0.13.6:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.14.0:
+  version "0.14.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.14.0.tgz#b392c23c9c14bfa2933d4740ad5603cc0d59ea5b"
+  integrity sha512-9CgbS06Kki2f4R9FjLSITjZo5BZxPsryiRNyL3LpvrM9WxcVmhlqAOc9E+KQbeI2nqej4JIIbOsfdL51cNb4Iw==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"


### PR DESCRIPTION
# What
This would allow to use yoga-dom instead of yoga-layout-prebuilt.
It currently does not work because yoga-dom does not expose all the things react-pdf needs but it's a start.

# How
Remove dependence on yoga from all except entrypoint files. Entrypoint files import yoga and pass it to root node from where other nodes load it.

# How to use
There is new build browser-custom. Import `@react-pdf/renderer/dist/react-pdf.browser-custom.es.js` that instead of `@react-pdf/renderer` (you can probably set this as alias in webpack)

This build exposes single default export - function which takes Yoga and returns everything that is ordinarily exported from `@react-pdf/renderer`

# Tests
I did not add new tests but made sure that old ones pass.