### PR TITLE
Add missing styles type for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,6 +95,9 @@ declare module '@react-pdf/renderer' {
       // Borders?:never,
 
       border?: number | string,
+      borderWidth?: number,
+      borderColor?: string,
+      borderStyle?: "dashed" | "dotted" | "solid",
       borderTop?: number | string,
       borderTopColor?: string,
       borderTopStyle?: "dashed" | "dotted" | "solid", // ?

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ declare module '@react-pdf/renderer' {
       letterSpacing?: number, //?
       lineHeight?: number,
       maxLines?: number, //?
-      textAlign?: 'left' | 'right', //?
+      textAlign?: 'left' | 'right' | 'center' | 'justify', //?
       textDecoration?: 'line-through' | 'underline',
       textDecorationColor?: string,
       textDecorationStyle?: "dashed" | "dotted" | "solid" | string, //?

--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ declare module '@react-pdf/renderer' {
       lineHeight?: number,
       maxLines?: number, //?
       textAlign?: 'left' | 'right' | 'center' | 'justify', //?
-      textDecoration?: 'line-through' | 'underline',
+      textDecoration?: 'line-through' | 'underline' | 'none',
       textDecorationColor?: string,
       textDecorationStyle?: "dashed" | "dotted" | "solid" | string, //?
       textIndent?: any, //?


### PR DESCRIPTION
This PR adds missing values for `textAlign` and `textDecoration` and also adds `borderWidth`, `borderColor` and `borderStyle`.