### PR TITLE
Fixing borderRight type for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -102,7 +102,7 @@ declare module '@react-pdf/renderer' {
       borderTopColor?: string,
       borderTopStyle?: "dashed" | "dotted" | "solid", // ?
       borderTopWidth?: number | string,
-      borderRight?: string,
+      borderRight?: number | string,
       borderRightColor?: string,
       borderRightStyle?: "dashed" | "dotted" | "solid", //?
       borderRightWidth?: number | string,


### PR DESCRIPTION
We've used `borderRight: 1` and it seemed to work correctly. So is this maybe an oversight from https://github.com/diegomura/react-pdf/commit/d978f2460014f8915ff740100b49a121fc37178e? 

