### PR TITLE
Parse translate y coordinate properly

### DIFF
--- a/src/render/applyTransformations.js
+++ b/src/render/applyTransformations.js
@@ -15,7 +15,7 @@ const getRotation = transform => {
 
 const getTranslateX = transform => {
   const matchX = /translateX\((-?\d+\.?d*)\)/g.exec(transform);
-  const matchGeneric = /translate\((-?\d+\.?d*).*,?\s*(-?\d+\.?d*).*\)/g.exec(
+  const matchGeneric = /translate\((-?\d+\.?d*).*(,|\s)\s*(-?\d+\.?d*).*\)/g.exec(
     transform,
   );
 
@@ -27,12 +27,12 @@ const getTranslateX = transform => {
 
 const getTranslateY = transform => {
   const matchY = /translateY\((-?\d+\.?\d*)\)/g.exec(transform);
-  const matchGeneric = /translate\((-?\d+\.?\d*).*,?\s*(-?\d+\.?\d*).*\)/g.exec(
+  const matchGeneric = /translate\((-?\d+\.?\d*).*(,|\s)\s*(-?\d+\.?\d*).*\)/g.exec(
     transform,
   );
 
   if (matchY && matchY[1]) return matchY[1];
-  if (matchGeneric && matchGeneric[2]) return matchGeneric[2];
+  if (matchGeneric && matchGeneric[3]) return matchGeneric[3];
 
   return 0;
 };


### PR DESCRIPTION
There is an issue with the current implementation of parsing a `translate`  y coordinate.

### Before fix
<img width="347" alt="Snímek obrazovky 2019-12-12 v 15 36 16" src="https://user-images.githubusercontent.com/340649/70721918-b3112800-1cf6-11ea-9180-6200678eab0c.png">

https://rubular.com/r/VIZRKzIziTxc0e
https://rubular.com/r/VIZRKzIziTxc0e

The second match should be `20` and not `0`

![Snímek obrazovky 2019-12-12 v 15 46 08](https://user-images.githubusercontent.com/340649/70722006-cfad6000-1cf6-11ea-8fa9-5ccf523d6143.png)

### After fix
<img width="340" alt="Snímek obrazovky 2019-12-12 v 15 37 07" src="https://user-images.githubusercontent.com/340649/70722103-fc617780-1cf6-11ea-967d-03da869b86a3.png">

https://rubular.com/r/P5KdsVsnjfCGJ6
https://rubular.com/r/c1LHkIUrLyL9rl

![Snímek obrazovky 2019-12-12 v 15 46 21](https://user-images.githubusercontent.com/340649/70722147-100cde00-1cf7-11ea-901d-1cae626b9c4a.png)

