### PR TITLE
Children should inherit text transform

### DIFF
--- a/examples/resume/Header.js
+++ b/examples/resume/Header.js
@@ -13,6 +13,7 @@ const styles = StyleSheet.create({
   detailColumn: {
     flexDirection: 'column',
     flexGrow: 9,
+    textTransform: 'uppercase',
   },
   linkColumn: {
     flexDirection: 'column',
@@ -22,13 +23,11 @@ const styles = StyleSheet.create({
   },
   name: {
     fontSize: 24,
-    textTransform: 'uppercase',
     fontFamily: 'Lato Bold',
   },
   subtitle: {
     fontSize: 10,
     justifySelf: 'flex-end',
-    textTransform: 'uppercase',
     fontFamily: 'Lato',
   },
   link: {

--- a/src/stylesheet/inherit.js
+++ b/src/stylesheet/inherit.js
@@ -9,6 +9,7 @@ export const inheritedProperties = [
   'textDecoration',
   'lineHeight',
   'textAlign',
+  'textTransform',
   'visibility',
   'wordSpacing',
 ];

--- a/tests/stylesInherit.test.js
+++ b/tests/stylesInherit.test.js
@@ -80,6 +80,10 @@ describe('Styles inherit', () => {
   test('Should inherit word spacing', shouldInherit('wordSpacing', 10));
   test('Should inherit letter spacing', shouldInherit('letterSpacing', 10));
   test(
+    'Should inherit text transform',
+    shouldInherit('textTransform', 'uppercase'),
+  );
+  test(
     'Should inherit text decoration',
     shouldInherit('textDecoration', 'underline'),
   );


### PR DESCRIPTION
I found out that `text-transform` isn't inheritable propery in React PDF. But it should be (See [W3C info](https://www.w3.org/TR/CSS21/propidx.html)).

I updated `resume` example to debug this error (moved `textTranform` from each child to whole `detailColumn`):

### Before:
![before](https://user-images.githubusercontent.com/206567/71472906-ecad5d00-27e5-11ea-9a3f-8a0bf92034b8.png)

### After:
![Xnip2019-12-26_13-35-36](https://user-images.githubusercontent.com/206567/71472857-b4a61a00-27e5-11ea-82f8-07c363f2193f.jpg)