### PR TITLE
Empty the render queue immediately on unmount

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -163,6 +163,10 @@ export class CanvasViewer extends React.Component {
     }
   }
 
+  componentWillUnmount() {
+    this.renderQueue.end();
+  }
+
   queueDocumentRender(doc) {
     this.renderQueue.splice(0, this.renderQueue.length, () => {
       this.instance.updateContainer(doc);

--- a/src/dom.js
+++ b/src/dom.js
@@ -60,6 +60,10 @@ class InternalBlobProvider extends React.PureComponent {
     this.instance.updateContainer(this.props.document);
   }
 
+  componentWillUnmount() {
+    this.renderQueue.end();
+  }
+
   queueDocumentRender = () => {
     this.renderQueue.splice(0, this.renderQueue.length, () =>
       this.state.error ? Promise.resolve() : this.instance.toBlob(),


### PR DESCRIPTION
This PR helps to clean the queue on blob and canvas unmounts.
Without it I was getting console warnings:

<img width="1246" alt="screenshot" src="https://user-images.githubusercontent.com/340649/73244371-16252400-41aa-11ea-8ee6-35191da8135c.png">

`Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.`