### PR TITLE
TypeScript: Add id prop

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -150,6 +150,7 @@ declare module '@react-pdf/renderer' {
     class Document extends React.Component<DocumentProps> {}
 
     interface NodeProps {
+      id?: string;
       style?: Style | Style[];
       /**
        * Render component in all wrapped pages.


### PR DESCRIPTION
First of all, thanks for this great project. I really love it.

I want to use the fancy go-to functionally introduced here (#744)  with TypeScript. Unfortunately I'm not able to do this because the id prop is missing here:

https://github.com/diegomura/react-pdf/blob/ea026ae1167ceaec0c9dc906e7df42617c06e12f/index.d.ts#L152

This small PR is a small merge for you but will have much impact on my project. :-) My branch is based on your V2 branch so it can be merged easily.