### PR TITLE
Remove default underline for links

### DIFF
--- a/src/layout/resolveStyles.js
+++ b/src/layout/resolveStyles.js
@@ -10,7 +10,6 @@ import resolveMediaQueries from '../stylesheet/resolveMediaQueries';
 
 const LINK_STYLES = {
   color: 'blue',
-  textDecoration: 'underline',
 };
 
 /**

--- a/tests/layout/__snapshots__/resolveStyles.test.js.snap
+++ b/tests/layout/__snapshots__/resolveStyles.test.js.snap
@@ -12,7 +12,6 @@ Object {
         Object {
           "style": Object {
             "color": "blue",
-            "textDecoration": "underline",
           },
           "type": "LINK",
         },


### PR DESCRIPTION
Note: This PR is based on V2 branch.

I noticed that setting text-decoration: none for links is not working in v2 any more. So I removed the default underline text-decoration from the link styles.