### PR TITLE
Allow setting "table" as display type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,7 @@ declare module '@react-pdf/renderer' {
       // Layout?:never,
 
       bottom?: number | string,
-      display?: 'flex' | 'none',
+      display?: 'flex' | 'table' | 'none',
       left?: number | string,
       position?: 'absolute' | 'relative',
       right?: number | string,


### PR DESCRIPTION
Actually, TypeScritp does not allow to set "table" as a display value. However, testing it with `//@ts-ignore` results in a fully working feature.