### PR TITLE
expose InternalBlobProvider

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -177,4 +177,5 @@ export default {
   BlobProvider,
   createInstance,
   PDFDownloadLink,
+  InternalBlobProvider
 };


### PR DESCRIPTION
This is useful for custom download operations, like doing file writes in the cordova environment