### PR TITLE
TypeScript: Add ID property to BaseImageProps interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -219,6 +219,7 @@ declare module '@react-pdf/renderer' {
       cache?: boolean;
       safePath?: string;
       allowDangerousPaths?: boolean;
+      id?: string;
     }
 
     interface ImageWithSrcProp extends BaseImageProps {


### PR DESCRIPTION
Hi @diegomura,
I need ID on img tag to create a link to it.
You haven't this property in BaseImageProps TS interface so I have added it.
Please could you accept my PR or write any suggestions :)

Lucas