### PR TITLE
Fix Image invalid dimensions warning message

### DIFF
--- a/src/elements/Image.js
+++ b/src/elements/Image.js
@@ -2,7 +2,7 @@ import Yoga from 'yoga-layout';
 
 import Base from './Base';
 import warning from '../utils/warning';
-import { resolveImage } from '../utils/image';
+import { resolveImage, getDimensionsWarningMessage } from '../utils/image';
 import { resolveObjectFit } from '../utils/objectFit';
 import { setDestination } from '../utils/url';
 
@@ -160,12 +160,8 @@ class Image extends Base {
             { width, height },
           );
       } else {
-        warning(
-          false,
-          `Image with src '${
-            this.props.src
-          }' skipped due to invalid dimensions`,
-        );
+        const message = getDimensionsWarningMessage(this.src);
+        warning(false, message);
       }
     }
 

--- a/src/utils/image.js
+++ b/src/utils/image.js
@@ -200,3 +200,35 @@ export const resolveImage = (src, { cache = true, ...options } = {}) => {
 
   return image;
 };
+
+export const getDimensionsWarningMessage = source => {
+  const { uri } = source;
+  const baseWarningReason = 'skipped due to invalid dimensions';
+  const genericWarningMessage = () => `Image ${baseWarningReason}`;
+  const regularUrlWarningMessage = uri =>
+    `Image with src '${uri}' ${baseWarningReason}`;
+  const base64DataUrlWarningMessage = extension =>
+    `${extension} Image with base64 data URI ${baseWarningReason}`;
+
+  if (!source || !uri) {
+    return genericWarningMessage();
+  }
+
+  if (typeof source === 'string') {
+    return regularUrlWarningMessage(source);
+  }
+
+  if (typeof source !== 'object') {
+    return genericWarningMessage();
+  }
+
+  if (!isCompatibleBase64(source)) {
+    return regularUrlWarningMessage(uri);
+  }
+
+  const startIndex = 'data:image/'.length;
+  const endIndex = uri.indexOf(';base64');
+  const extension = uri.substring(startIndex, endIndex).toUpperCase();
+
+  return base64DataUrlWarningMessage(extension);
+};


### PR DESCRIPTION
# What's the purpose of this pull request?

This pull request fixes the invalid dimensions warning message. The way the warning message is constructed makes it display an `undefined` `src` in some cases such as when the user instantiates the Image component as follows.

Instead of:
```js
<Image src='https://mysite.com/image.png' />
```

Instantiate it like this:
```js
<Image source='https://mysite.com/image.png' />
```

If the later form was used, in case an invalid dimensions warning was to be displayed, it would read like this: **Warning: Image with src 'undefined' skipped due to invalid dimensions**

This pull request fixes this by displaying 3 kinds of warning messages:
1. **Generic message**: `Image skipped due to invalid dimensions`
2. **URL or local file path message**: `Image with src '../local/path/image.png' skipped due to invalid dimensions` or `Image with src 'https://external.com/path/image.png' skipped due to invalid dimensions`
3. **Base64 data url message**: `PNG Image with base64 data URI skipped due to invalid dimensions`

# How can I test these changes?

1. Add to a `Document` an `Image` component and set it's `source` to [this big-sized image](https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/3/24/1427200702924/A-big-bang---but-not-the--009.jpg).
2. Render the document that contains that `Image`
3. Check the console. There should be presented a warning that reads " **Warning: Image with src 'undefined' skipped due to invalid dimensions**"
4. `git checkout fix/undefined-src-in-invalid-image-dimensions-warning`
5. Reload the server where the Document is being rendered

If everything works correctly, the message now should read "**Warning: Image with src 'https://static.guim.co.uk/sys-images/Guardian/Pix/pictures/2015/3/24/1427200702924/A-big-bang---but-not-the--009.jpg' skipped due to invalid dimensions**"

This same test can be made using either a path to a local file or a base64 encoded string. If a base64 encoded string is provided, the message should be "**Warning: PNG Image with base64 data URI skipped due to invalid dimensions**", where "PNG" will be replaced by the extension of the image described by the base64 encoded string.