### PR TITLE
TypeScript: Add ID property to ViewProps & TextProps interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -199,6 +199,7 @@ declare module '@react-pdf/renderer' {
       debug?: boolean;
       render?: (props: { pageNumber: number }) => React.ReactNode;
       children?: React.ReactNode;
+      id?: string;
     }
 
     /**
@@ -250,6 +251,7 @@ declare module '@react-pdf/renderer' {
         totalPages: number;
       }) => React.ReactNode;
       children?: React.ReactNode;
+      id?: string;
       /**
        * How much hyphenated breaks should be avoided.
        */


### PR DESCRIPTION
Hi @diegomura - sorry that I didn't add it in the previous Pull Request, but I've realized that I need ID props also on View and Page components to Link to them internally.