### PR TITLE
v2: Fixes for BlobProvider

### DIFF
--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -29,6 +29,9 @@ class InternalBlobProvider extends React.PureComponent {
 
   componentWillUnmount() {
     this.renderQueue.end();
+    if (this.state.url) {
+      URL.revokeObjectURL(this.state.url);
+    }
   }
 
   queueDocumentRender = () => {

--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -32,6 +32,7 @@ class InternalBlobProvider extends React.PureComponent {
   }
 
   queueDocumentRender = () => {
+    this.setState({ loading: true });
     this.renderQueue.splice(0, this.renderQueue.length, () =>
       this.state.error ? Promise.resolve() : this.instance.toBlob(),
     );

--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -21,8 +21,10 @@ class InternalBlobProvider extends React.PureComponent {
     this.renderQueue.on('success', this.onRenderSuccessful);
   }
 
-  componentDidUpdate() {
-    this.instance.updateContainer(this.props.document);
+  componentDidUpdate(prevProps) {
+    if (prevProps.document !== this.props.document) {
+      this.instance.updateContainer(this.props.document);
+    }
   }
 
   componentWillUnmount() {

--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -47,7 +47,7 @@ class InternalBlobProvider extends React.PureComponent {
     const oldBlobUrl = this.state.url;
 
     this.setState(
-      { blob, url: URL.createObjectURL(blob), loading: false },
+      { blob, url: URL.createObjectURL(blob), loading: false, error: null },
       () => URL.revokeObjectURL(oldBlobUrl),
     );
   };


### PR DESCRIPTION
A few fixes for `BlobProvider` in v2:

- Set loading: true when the document is re-rendering
- Ensure the ObjectURL is revoked when unmounting
- Clear the error when doc successfully loads
