### PR TITLE
Fix error handling for undefined src prop of <Image>

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -209,10 +209,16 @@ declare module '@react-pdf/renderer' {
 
     type HTTPMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-    type SourceObject =
+    type BaseSourceObject =
       | string
+      | Buffer
       | { data: Buffer; format: 'png' | 'jpg' }
-      | { uri: string; method: HTTPMethod; body: any; headers: any };
+      | { uri: string; method: HTTPMethod; body: any; headers: any }
+      | undefined;
+
+    type SourceObject =
+      | BaseSourceObject
+      | (() => BaseSourceObject | Promise<BaseSourceObject>);
 
     interface BaseImageProps extends NodeProps {
       debug?: boolean;

--- a/src/elements/Image.js
+++ b/src/elements/Image.js
@@ -139,7 +139,7 @@ class Image extends Base {
     // Clip path to keep image inside border radius
     this.clip();
 
-    if (this.image.data) {
+    if (this.image && this.image.data) {
       const { width, height, xOffset, yOffset } = resolveObjectFit(
         this.style.objectFit,
         this.width - padding.left - padding.right,
@@ -167,6 +167,11 @@ class Image extends Base {
           }' skipped due to invalid dimensions`,
         );
       }
+    } else {
+      warning(
+        false,
+        `Image skipped because src prop is ${this.props.src}`,
+      );
     }
 
     this.root.instance.restore();


### PR DESCRIPTION
This pull request does two things:

1. Show relevant warning message instead of `Cannot read property 'data' of null` when rendering `<Image src={undefined} />`
2. Make TypeScript types consistent with `src` prop specification

According to [`react-pdf.org`](https://react-pdf.org/components#image), default value of `src` prop is `undefined`. Indeed `undefined` is necessary when `src` receives value from Promise. I also found that [`resolveImage()`](https://github.com/diegomura/react-pdf/blob/ee0b35b7e2c57e96d675a3d08cb1042d6c528802/src/utils/image.js#L175) accepts `Buffer` as `src` argument which is not described in `react-pdf.org`. So I added relevant types.