### PR TITLE
Adds subPageNumber and subPageTotalPages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,118 +7,156 @@ declare module '@react-pdf/renderer' {
     export interface Style {
       //Flexbox
 
-      alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around',
-      alignItems?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline',
-      alignSelf?: 'auto' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch',
-      flex?: number,
-      flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse',
-      flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse',
-      flexFlow?: number,
-      flexGrow?: number,
-      flexShrink?: number,
-      flexBasis?: number,
-      justifyContent?: 'flex-start' | 'flex-end' | 'center' | 'space-around' | 'space-between' | 'space-evenly',
-      order?: number,
+      alignContent?:
+        | 'flex-start'
+        | 'flex-end'
+        | 'center'
+        | 'stretch'
+        | 'space-between'
+        | 'space-around';
+      alignItems?:
+        | 'flex-start'
+        | 'flex-end'
+        | 'center'
+        | 'stretch'
+        | 'baseline';
+      alignSelf?:
+        | 'auto'
+        | 'flex-start'
+        | 'flex-end'
+        | 'center'
+        | 'baseline'
+        | 'stretch';
+      flex?: number;
+      flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
+      flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
+      flexFlow?: number;
+      flexGrow?: number;
+      flexShrink?: number;
+      flexBasis?: number;
+      justifyContent?:
+        | 'flex-start'
+        | 'flex-end'
+        | 'center'
+        | 'space-around'
+        | 'space-between'
+        | 'space-evenly';
+      order?: number;
 
       // Layout?:never,
 
-      bottom?: number | string,
-      display?: 'flex' | 'table' | 'none',
-      left?: number | string,
-      position?: 'absolute' | 'relative',
-      right?: number | string,
-      top?: number | string,
+      bottom?: number | string;
+      display?: 'flex' | 'table' | 'none';
+      left?: number | string;
+      position?: 'absolute' | 'relative';
+      right?: number | string;
+      top?: number | string;
 
       // Dimension?:never,
 
-      height?: number | string,
-      maxHeight?: number | string,
-      maxWidth?: number | string,
-      minHeight?: number | string,
-      minWidth?: number | string,
-      width?: number | string,
+      height?: number | string;
+      maxHeight?: number | string;
+      maxWidth?: number | string;
+      minHeight?: number | string;
+      minWidth?: number | string;
+      width?: number | string;
 
       // Color?:never,
 
-      backgroundColor?: string,
-      color?: string,
-      opacity?: number,
+      backgroundColor?: string;
+      color?: string;
+      opacity?: number;
 
       // Text?:never,
 
-      fontSize?: number | string,
-      fontFamily?: string,
-      fontStyle?: string | 'normal',
-      fontWeight?: number | 'thin' | 'hairline' | 'ultralight' | 'extralight' | 'light' | 'normal' | 'medium' | 'semibold' | 'demibold' | 'bold' | 'ultrabold' | 'extrabold' | 'heavy' | 'black',
-      letterSpacing?: number | string,
-      lineHeight?: number | string,
-      maxLines?: number, //?
-      textAlign?: 'left' | 'right' | 'center' | 'justify', //?
-      textDecoration?: 'line-through' | 'underline' | 'none',
-      textDecorationColor?: string,
-      textDecorationStyle?: "dashed" | "dotted" | "solid" | string, //?
-      textIndent?: any, //?
-      textOverflow?: any, //?
-      textTransform?: 'capitalize' | 'lowercase' | 'uppercase',
+      fontSize?: number | string;
+      fontFamily?: string;
+      fontStyle?: string | 'normal';
+      fontWeight?:
+        | number
+        | 'thin'
+        | 'hairline'
+        | 'ultralight'
+        | 'extralight'
+        | 'light'
+        | 'normal'
+        | 'medium'
+        | 'semibold'
+        | 'demibold'
+        | 'bold'
+        | 'ultrabold'
+        | 'extrabold'
+        | 'heavy'
+        | 'black';
+      letterSpacing?: number | string;
+      lineHeight?: number | string;
+      maxLines?: number; //?
+      textAlign?: 'left' | 'right' | 'center' | 'justify'; //?
+      textDecoration?: 'line-through' | 'underline' | 'none';
+      textDecorationColor?: string;
+      textDecorationStyle?: 'dashed' | 'dotted' | 'solid' | string; //?
+      textIndent?: any; //?
+      textOverflow?: any; //?
+      textTransform?: 'capitalize' | 'lowercase' | 'uppercase';
 
       // Sizing/positioning?:never,
 
-      objectFit?: string,
-      objectPosition?: number | string,
-      objectPositionX?: number | string,
-      objectPositionY?: number | string,
+      objectFit?: string;
+      objectPosition?: number | string;
+      objectPositionX?: number | string;
+      objectPositionY?: number | string;
 
       // Margin/padding?:never,
 
-      margin?: number | string,
-      marginHorizontal?: number | string,
-      marginVertical?: number | string,
-      marginTop?: number | string,
-      marginRight?: number | string,
-      marginBottom?: number | string,
-      marginLeft?: number | string,
-      padding?: number | string,
-      paddingHorizontal?: number | string,
-      paddingVertical?: number | string,
-      paddingTop?: number | string,
-      paddingRight?: number | string,
-      paddingBottom?: number | string,
-      paddingLeft?: number | string,
+      margin?: number | string;
+      marginHorizontal?: number | string;
+      marginVertical?: number | string;
+      marginTop?: number | string;
+      marginRight?: number | string;
+      marginBottom?: number | string;
+      marginLeft?: number | string;
+      padding?: number | string;
+      paddingHorizontal?: number | string;
+      paddingVertical?: number | string;
+      paddingTop?: number | string;
+      paddingRight?: number | string;
+      paddingBottom?: number | string;
+      paddingLeft?: number | string;
 
       // Transformations?:never,
 
-      transform?: string,
-      transformOrigin?: number | string,
-      transformOriginX?: number | string,
-      transformOriginY?: number | string,
+      transform?: string;
+      transformOrigin?: number | string;
+      transformOriginX?: number | string;
+      transformOriginY?: number | string;
 
       // Borders?:never,
 
-      border?: number | string,
-      borderWidth?: number,
-      borderColor?: string,
-      borderStyle?: "dashed" | "dotted" | "solid",
-      borderTop?: number | string,
-      borderTopColor?: string,
-      borderTopStyle?: "dashed" | "dotted" | "solid", // ?
-      borderTopWidth?: number | string,
-      borderRight?: number | string,
-      borderRightColor?: string,
-      borderRightStyle?: "dashed" | "dotted" | "solid", //?
-      borderRightWidth?: number | string,
-      borderBottom?: number | string,
-      borderBottomColor?: string,
-      borderBottomStyle?: "dashed" | "dotted" | "solid", //?
-      borderBottomWidth?: number | string,
-      borderLeft?: number | string,
-      borderLeftColor?: string,
-      borderLeftStyle?: "dashed" | "dotted" | "solid", //?
-      borderLeftWidth?: number | string,
-      borderTopLeftRadius?: number | string,
-      borderTopRightRadius?: number | string,
-      borderBottomRightRadius?: number | string,
-      borderBottomLeftRadius?: number | string,
-      borderRadius?: number | string
+      border?: number | string;
+      borderWidth?: number;
+      borderColor?: string;
+      borderStyle?: 'dashed' | 'dotted' | 'solid';
+      borderTop?: number | string;
+      borderTopColor?: string;
+      borderTopStyle?: 'dashed' | 'dotted' | 'solid'; // ?
+      borderTopWidth?: number | string;
+      borderRight?: number | string;
+      borderRightColor?: string;
+      borderRightStyle?: 'dashed' | 'dotted' | 'solid'; //?
+      borderRightWidth?: number | string;
+      borderBottom?: number | string;
+      borderBottomColor?: string;
+      borderBottomStyle?: 'dashed' | 'dotted' | 'solid'; //?
+      borderBottomWidth?: number | string;
+      borderLeft?: number | string;
+      borderLeftColor?: string;
+      borderLeftStyle?: 'dashed' | 'dotted' | 'solid'; //?
+      borderLeftWidth?: number | string;
+      borderTopLeftRadius?: number | string;
+      borderTopRightRadius?: number | string;
+      borderBottomRightRadius?: number | string;
+      borderBottomLeftRadius?: number | string;
+      borderRadius?: number | string;
     }
 
     interface Styles {
@@ -197,7 +235,10 @@ declare module '@react-pdf/renderer' {
        */
       wrap?: boolean;
       debug?: boolean;
-      render?: (props: { pageNumber: number }) => React.ReactNode;
+      render?: (props: {
+        pageNumber: number;
+        subPageNumber: number;
+      }) => React.ReactNode;
       children?: React.ReactNode;
     }
 
@@ -248,6 +289,8 @@ declare module '@react-pdf/renderer' {
       render?: (props: {
         pageNumber: number;
         totalPages: number;
+        subPageNumber: number;
+        subPageTotalPages: number;
       }) => React.ReactNode;
       children?: React.ReactNode;
       /**
@@ -258,12 +301,12 @@ declare module '@react-pdf/renderer' {
        * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
        * @see https://react-pdf.org/advanced#orphan-&-widow-protection
        */
-      orphans?: number
+      orphans?: number;
       /**
        * Specifies the minimum number of lines in a text element that must be shown at the top of a page or its container..
        * @see https://react-pdf.org/advanced#orphan-&-widow-protection
        */
-      widows?: number
+      widows?: number;
     }
 
     /**
@@ -300,7 +343,7 @@ declare module '@react-pdf/renderer' {
       paint: (
         painter: any,
         availableWidth: number,
-        availableHeight: number
+        availableHeight: number,
       ) => null;
     }
 
@@ -411,19 +454,23 @@ declare module '@react-pdf/renderer' {
     ) => string[];
 
     const Font: {
-      register: (options: {
-        family: string;
-        src: string;
-        [key: string]: any;
-      } | {
-        family: string;
-        fonts: {
-          src: string;
-          fontStyle?: string;
-          fontWeight?: string | number;
-          [key: string]: any;
-        }[];
-      }) => void;
+      register: (
+        options:
+          | {
+              family: string;
+              src: string;
+              [key: string]: any;
+            }
+          | {
+              family: string;
+              fonts: {
+                src: string;
+                fontStyle?: string;
+                fontWeight?: string | number;
+                [key: string]: any;
+              }[];
+            },
+      ) => void;
       getEmojiSource: () => EmojiSource;
       getRegisteredFonts: () => FontInstance[];
       getRegisteredFontFamilies: () => string[];

--- a/src/elements/Document.js
+++ b/src/elements/Document.js
@@ -156,9 +156,15 @@ class Document {
 
         pageCount += subpages.length;
 
-        pages.push(...subpages);
+        subpages.forEach((sub, index) =>
+          pages.push({
+            page: sub,
+            number: index + 1,
+            count: subpages.length,
+          }),
+        );
       } else {
-        pages.push(page);
+        pages.push({ page, number: 1, count: 1 });
       }
     }
 
@@ -166,14 +172,19 @@ class Document {
   }
 
   async renderPages() {
-    this.subpages = await this.wrapPages();
+    const subpages = await this.wrapPages();
+    const normalized = subpages.map(p => p.page);
+
+    this.subpages = normalized;
 
     for (let j = 0; j < this.subpages.length; j++) {
       // Update dynamic text nodes with total pages info
       this.subpages[j].renderDynamicNodes(
         {
           pageNumber: j + 1,
-          totalPages: this.subpages.length,
+          totalPages: subpages.length,
+          subPageNumber: subpages[j].number,
+          subPageTotalPages: subpages[j].count,
         },
         node => node.name === 'Text',
       );


### PR DESCRIPTION
Hey there,

First of all: I've been using react-pdf for a long time and love it!

One thing I recently needed (both for displaying, but even more for conditional rendering) was a `pageNumber` / `totalPages` for each **Page** component rather than having only the global one.
My Document consists of ~200 <Page> components each rendering song lyrics and chords for a songbook where I need to render the credits on the last page of each subPage.

This PR adds those 2 metrics with little changes allowing them to be used in View (`subPageNumber` only)  and Text (supporting both), just like the global ones.

It'd also resolve https://github.com/diegomura/react-pdf/issues/773 and probably help to achieve https://github.com/diegomura/react-pdf/issues/315.

Haven't looked into v2 right now, so I'm not too sure how to implement it for v2 as well, but I'd be happy to take a look if that'd be helpful.

> PS: I updated the TypeScript file and Prettier automatically formatted that, thus the big change in there. I'm happy to keep the formatting unchanged and only submit the actual change in there!