### PR TITLE
Easier Contributions.

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,14 @@
+tasks:
+  - name: Auto Build
+    init: |
+      yarn install
+      gp sync-done boot
+    command: yarn watch
+
+  - name: Fractals Example
+    init: |
+      gp sync-await boot
+      yarn example -- fractals
+    command: gp open examples/fractals/output.pdf
+    openMode: split-right
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
       <img src="https://img.shields.io/badge/styled_with-prettier-ff69b4.svg" />
     </a>
     <a href="https://app.fossa.com/projects/git%2Bgithub.com%2Ftaylorudell%2Freact-pdf?ref=badge_shield" alt="FOSSA Status"><img src="https://app.fossa.com/api/projects/git%2Bgithub.com%2Ftaylorudell%2Freact-pdf.svg?type=shield"/></a>
+    <a href="https://gitpod.io/from-referrer/"><img src="https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod" alt="Gitpod Ready-to-Code"/></a>
   </p>
 </p>
 
@@ -139,6 +140,17 @@ Then, run `yarn example -- <example-name>`
 ```sh
 yarn example -- fractals
 ```
+
+## Online One-click setup for contributing and running examples online
+
+You can use Gitpod(An Online Open-source VS-Code like IDE which is free for Open-source) for contributing to this project or running the examples online. With a single click it will start a workspace and automatically:
+
+- clone the `react-pdf` repo.
+- install all the dependencies.
+- run `yarn watch`.
+- build the `fractals` example and open it.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Contributors
 


### PR DESCRIPTION
Hi. 

I work for Gitpod(an online Open Source VS Code like IDE which is free for Open Source) and we're currently on a mission to simplify contributors/maintainers onboarding for cool Open Source projects. 

This Pr adds Gitpod config to the repo to fully automate the dev setup for this project i.e with this config anyone interested in contributing to this project would be able to start a workspace where it will automatically:

- clone the `react-pdf` repo.
- install all the dependencies.
- run `yarn watch`.
- build the `fractals` example and open it.

This way anyone interested in contributing can start straight away without any friction.

This is how it looks:

![image](https://user-images.githubusercontent.com/46004116/95663161-42c17600-0b56-11eb-9dfa-6e8b998ff682.png)

You can give it a try on my fork of the repo via the following link:
 
https://gitpod.io/#https://github.com/nisarhassan12/react-pdf-1

A lot of projects out there are already using Gitpod to simplify contributors/maintainers onboarding experience some of them are:

 -  https://github.com/freeCodeCamp/freeCodeCamp
 -  https://github.com/facebook/docusaurus
 -  https://github.com/mozilla/pdf.js/
-  https://github.com/gatsbyjs/gatsby/
-  https://github.com/mobxjs/mobx/

You can find a brief list of them at https://contribute.dev

![image](https://user-images.githubusercontent.com/46004116/95669000-7622f580-0b94-11eb-967c-9bb2a0f71fff.png)

Please let me know if there is anything that can be improved. I would like to help.