### PR TITLE
Add IE target in babel config

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,6 +6,7 @@ module.exports = {
         loose: true,
         targets: {
           node: '8.11.3',
+          ie: '11',
         },
       },
     ],
@@ -14,6 +15,6 @@ module.exports = {
   plugins: [
     '@babel/plugin-transform-runtime',
     '@babel/plugin-proposal-class-properties',
-    '@babel/plugin-proposal-optional-chaining'
+    '@babel/plugin-proposal-optional-chaining',
   ],
 };


### PR DESCRIPTION
<img width="1198" alt="Snímek obrazovky 2020-10-26 v 18 06 51" src="https://user-images.githubusercontent.com/340649/97204186-117fb180-17b6-11eb-89d7-c104e426f8a7.png">

It looks like the only target in V2 packages is node. This works ok for all modern browsers but fails on older Edge and IE browsers.