### PR TITLE
fix(v2): Fix adding custom fonts of different weights

### DIFF
--- a/packages/font/src/font.js
+++ b/packages/font/src/font.js
@@ -27,7 +27,7 @@ class FontSource {
     this.src = src;
     this.fontFamily = fontFamily;
     this.fontStyle = fontStyle || 'normal';
-    this.fontWeight = 400;
+    this.fontWeight = fontWeight || 400;
 
     this.data = null;
     this.loading = false;


### PR DESCRIPTION
This bug meant that it was not possible to add fonts with different fontWeight, all fonts were registered with fontWeight 400.