### PR TITLE
update typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ declare module '@react-pdf/renderer' {
       position?: 'absolute' | 'relative';
       right?: number | string;
       top?: number | string;
+      overflow?: 'hidden';
 
       // Dimension?:never,
 
@@ -94,7 +95,7 @@ declare module '@react-pdf/renderer' {
       textDecorationColor?: string;
       textDecorationStyle?: 'dashed' | 'dotted' | 'solid' | string; //?
       textIndent?: any; //?
-      textOverflow?: any; //?
+      textOverflow?: 'ellipsis';
       textTransform?: 'capitalize' | 'lowercase' | 'uppercase';
 
       // Sizing/positioning?:never,

--- a/index.d.ts
+++ b/index.d.ts
@@ -299,9 +299,10 @@ declare module '@react-pdf/renderer' {
       }) => React.ReactNode;
       children?: React.ReactNode;
       /**
-       * How much hyphenated breaks should be avoided.
+       * Override the default hyphenation-callback
+       * @see https://react-pdf.org/fonts#registerhyphenationcallback
        */
-      hyphenationCallback?: number;
+      hyphenationCallback?: HyphenationCallback;
       /**
        * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
        * @see https://react-pdf.org/advanced#orphan-&-widow-protection

--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -26,7 +26,8 @@ class Text extends Base {
     this.attributedString = null;
     this.layoutOptions = {
       hyphenationPenalty: props.hyphenationPenalty,
-      hyphenationCallback: Font.getHyphenationCallback(),
+      hyphenationCallback:
+        props.hyphenationCallback || Font.getHyphenationCallback(),
       shrinkWhitespaceFactor: { before: -0.5, after: -0.5 },
     };
 
@@ -240,8 +241,7 @@ class Text extends Base {
     // Perform actual text rendering on document
     PDFRenderer.render(this.root.instance, [this.lines]);
     setLink(this);
-    setDestination(this)
-
+    setDestination(this);
 
     this.root.instance.restore();
   }

--- a/tests/text.test.js
+++ b/tests/text.test.js
@@ -6,7 +6,7 @@ import Text from '../src/elements/Text';
 import TextInstance from '../src/elements/TextInstance';
 import * as urlUtils from '../src/utils/url';
 
-jest.mock('@react-pdf/textkit/renderers/pdf', () => ({ render: () => { } }));
+jest.mock('@react-pdf/textkit/renderers/pdf', () => ({ render: () => {} }));
 
 let dummyRoot;
 
@@ -194,5 +194,27 @@ describe('Text', () => {
     await text.render();
 
     expect(setDestinationSpy).toHaveBeenCalledWith(text);
+  });
+
+  test('should allow hyphenation-callback to be overriden', async () => {
+    const page = new Page(dummyRoot, {});
+    const hyphenationCallbackSpy = jest
+      .fn()
+      .mockReturnValue(['really', 'long', 'text']);
+    const text = new Text(dummyRoot, {
+      hyphenationCallback: hyphenationCallbackSpy,
+    });
+
+    page.appendChild(text);
+    text.appendChild(new TextInstance(dummyRoot, 'reallylongtext'));
+    text.layoutText(50, 200); // Force to wrap in many lines
+    text.applyProps();
+
+    await text.render();
+
+    expect(text.lines[0].string).toEqual('really');
+    expect(text.lines[1].string).toEqual('long');
+    expect(text.lines[2].string).toEqual('text');
+    expect(hyphenationCallbackSpy).toHaveBeenCalledWith('reallylongtext');
   });
 });


### PR DESCRIPTION
It seems like the typings were out of date. In the code bases, I was only able to find references to:
- `overflow: 'hidden'` 
- and `textOverflow: 'ellipsis'`

Not sure, if there are other options allowed as well.