### PR TITLE
Fixes issue #685, #1120 and #1085 - Text component hangs when its content is longer than 2 pages

### DIFF
--- a/src/elements/Text.js
+++ b/src/elements/Text.js
@@ -205,7 +205,7 @@ class Text extends Base {
 
     clone.marginTop = 0;
     clone.paddingTop = 0;
-    clone.start = slicedLineIndex;
+    clone.start = slicedLineIndex + this.start;
     clone.attributedString = this.attributedString;
 
     this.height = wrapHeight;
@@ -240,8 +240,7 @@ class Text extends Base {
     // Perform actual text rendering on document
     PDFRenderer.render(this.root.instance, [this.lines]);
     setLink(this);
-    setDestination(this)
-
+    setDestination(this);
 
     this.root.instance.restore();
   }


### PR DESCRIPTION
Fixes issue #685, #1120 and #1085. The issues can be reproduced by the below code fragment:

```
const styles = StyleSheet.create({
  body: {
    padding: 40,
  },
  footer: {
    position: 'absolute',
    fontSize: 12,
    bottom: 25,
    left: 0,
    right: 0,
    textAlign: 'center',
    color: 'grey',
  },
});

const txt = Array.from(
  { length: 120 },
  () => `
`,
)
  .map((_, index) => `Line ${index + 1}${_}`)
  .join('');

const doc = (
  <Document>
    <Page size="A4" style={styles.body}>
      <Text>{txt}</Text>
      <Text
        style={styles.footer}
        render={({ pageNumber, totalPages }) => `${pageNumber} / ${totalPages}`}
        fixed
      />
    </Page>
  </Document>
);

ReactPDF.render(doc, `${__dirname}/output.pdf`);
```


Screenshot after the fix:

![image](https://user-images.githubusercontent.com/5766490/107985659-7bf07380-6f98-11eb-9643-43310956c0cd.png)


