### PR TITLE
update typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ declare module '@react-pdf/renderer' {
       position?: 'absolute' | 'relative';
       right?: number | string;
       top?: number | string;
+      overflow?: 'hidden';
 
       // Dimension?:never,
 
@@ -94,7 +95,7 @@ declare module '@react-pdf/renderer' {
       textDecorationColor?: string;
       textDecorationStyle?: 'dashed' | 'dotted' | 'solid' | string; //?
       textIndent?: any; //?
-      textOverflow?: any; //?
+      textOverflow?: 'ellipsis';
       textTransform?: 'capitalize' | 'lowercase' | 'uppercase';
 
       // Sizing/positioning?:never,


### PR DESCRIPTION
It seems like the typings were out of date. In the code bases, I was only able to find references to:

overflow: 'hidden'
and textOverflow: 'ellipsis'
Not sure, if there are other options allowed as well.


**Sorry, about that I closed the PR, thinking I could just reopen it again.**