### PR TITLE
Duplicate Id's removed from typings

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -98,7 +98,6 @@ declare module '@react-pdf/renderer' {
         subPageNumber: number;
       }) => React.ReactNode;
       children?: React.ReactNode;
-      id?: string;
     }
 
     /**
@@ -151,7 +150,6 @@ declare module '@react-pdf/renderer' {
         subPageTotalPages: number;
       }) => React.ReactNode;
       children?: React.ReactNode;
-      id?: string;
       /**
        * Override the default hyphenation-callback
        * @see https://react-pdf.org/fonts#registerhyphenationcallback


### PR DESCRIPTION
There are duplicate keys `id` in `ViewProps` & `TextProps`. This PR resolves it.