### PR TITLE
Bad returning type for methods: on, removeListener

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -490,9 +490,9 @@ declare module '@react-pdf/renderer' {
       toString: () => string;
       toBlob: () => Promise<Blob>;
       toBuffer: () => Promise<NodeJS.ReadableStream>;
-      on: (event: 'change', callback: () => void): void;
+      on: (event: 'change', callback: () => void) => void;
       updateContainer: (document: React.ReactElement<any>) => void;
-      removeListener: (event: 'change', callback: () => void): void;
+      removeListener: (event: 'change', callback: () => void) => void;
     };
 
     const renderToStream: (


### PR DESCRIPTION
Fixed error in type declaration of `pdf` function.

Returning type of methods `on` and `removeListener` was declared not as function returning value.

This PR fixes it.