### PR TITLE
feat(add-href-support): add `href` support for a <Link>

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -196,6 +196,7 @@ declare module '@react-pdf/renderer' {
        */
       debug?: boolean;
       src: string;
+      href: string;
       children?: React.ReactNode;
     }
 


### PR DESCRIPTION
href is already supported but we can't use it due to missed property in the interface