### PR TITLE
docs: bring back access to Style type

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -15,6 +15,8 @@ declare module '@react-pdf/renderer' {
     interface Styles {
       [key: string]: Style;
     }
+    
+    type Style = Style;
 
     interface OnRenderProps {
       blob?: Blob;


### PR DESCRIPTION
After migration to version 2, the access to the `Style` type is missing.

If we want to reference it we have to now use a hack, such as `typeof myStyles.myStyle` which is not ideal.

This PR exposes `Style` as `ReactPDF.Style`.