### PR TITLE
Don’t call hasGlyphForCodePoint if font is null

### DIFF
--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -20,9 +20,9 @@ const getOrCreateFont = name => {
 const getFallbackFont = () => getOrCreateFont('Helvetica');
 
 const shouldFallbackToFont = (codePoint, font) =>
-  !IGNORED_CODE_POINTS.includes(codePoint) &&
-  (font && !font.hasGlyphForCodePoint(codePoint)) &&
-  getFallbackFont().hasGlyphForCodePoint(codePoint);
+  !font || (!IGNORED_CODE_POINTS.includes(codePoint) &&
+  !font.hasGlyphForCodePoint(codePoint) &&
+  getFallbackFont().hasGlyphForCodePoint(codePoint));
 
 const fontSubstitution = () => ({ string, runs }) => {
   let lastFont = null;

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -21,7 +21,7 @@ const getFallbackFont = () => getOrCreateFont('Helvetica');
 
 const shouldFallbackToFont = (codePoint, font) =>
   !IGNORED_CODE_POINTS.includes(codePoint) &&
-  !font.hasGlyphForCodePoint(codePoint) &&
+  (font && !font.hasGlyphForCodePoint(codePoint)) &&
   getFallbackFont().hasGlyphForCodePoint(codePoint);
 
 const fontSubstitution = () => ({ string, runs }) => {

--- a/packages/layout/src/text/ignoreChars.js
+++ b/packages/layout/src/text/ignoreChars.js
@@ -5,7 +5,7 @@ const IGNORABLE_CODEPOINTS = [
 
 const buildSubsetForFont = font =>
   IGNORABLE_CODEPOINTS.reduce((acc, codePoint) => {
-    if (font.hasGlyphForCodePoint && font.hasGlyphForCodePoint(codePoint)) {
+    if (font && font.hasGlyphForCodePoint && font.hasGlyphForCodePoint(codePoint)) {
       return acc;
     }
     return [...acc, String.fromCharCode(codePoint)];


### PR DESCRIPTION
Related to #777 

This doesn't fix the root cause of why fragments intermittently have no font property, but it does prevent the app from crashing if there is no font.