### PR TITLE
Change renderer queue require to import statement

### DIFF
--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -3,10 +3,9 @@
 
 import * as primitives from '@react-pdf/primitives';
 import React, { useEffect, useRef, useState } from 'react';
-
+import queue from 'queue';
 import { pdf, version, Font, StyleSheet } from './index';
 
-const queue = require('queue');
 
 export const usePDF = ({ document }) => {
   const pdfInstance = useRef(null);


### PR DESCRIPTION
This change will allow Snowpack (or any rollup-related build system) work without the need to workaround mixed esm/commonjs dependencies as described https://github.com/snowpackjs/snowpack/discussions/1321