### PR TITLE
feat: add support of source factories for Image component

### DIFF
--- a/packages/layout/src/image/fetchImage.js
+++ b/packages/layout/src/image/fetchImage.js
@@ -3,15 +3,7 @@
 import resolveImage from '@react-pdf/image';
 
 import getSource from './getSource';
-
-/**
- * Resolves async src if passed
- *
- * @param {string | Function} src
- * @returns {object} resolved src
- */
-const resolveSrc = async src =>
-  typeof src === 'function' ? { uri: await src() } : src;
+import resolveSource from './resolveSource';
 
 /**
  * Fetches image and append data to node
@@ -29,7 +21,7 @@ const fetchImage = async node => {
   }
 
   try {
-    const source = await resolveSrc(src);
+    const source = await resolveSource(src);
     node.image = await resolveImage(source, { cache });
   } catch (e) {
     node.image = { width: 0, height: 0 };

--- a/packages/layout/src/image/getSource.js
+++ b/packages/layout/src/image/getSource.js
@@ -2,11 +2,9 @@
  * Get image source
  *
  * @param {Object} image node
- * @returns {String} image src
+ * @returns {String | Object} image src
  */
-const getSource = node => {
-  const value = node.props?.src || node.props?.source || node.props?.href;
-  return typeof value === 'string' ? { uri: value } : value;
-};
+const getSource = node =>
+  node.props?.src || node.props?.source || node.props?.href;
 
 export default getSource;

--- a/packages/layout/src/image/resolveSource.js
+++ b/packages/layout/src/image/resolveSource.js
@@ -1,0 +1,14 @@
+/**
+ * Resolves `src` to `@react-pdf/image` interface.
+ *
+ * Also it handles factories and async sources.
+ *
+ * @param {string | Object | Function} src
+ * @returns {object} resolved src
+ */
+const resolveSource = async src => {
+  const source = typeof src === 'function' ? await src() : await src;
+  return typeof source === 'string' ? { uri: source } : source;
+};
+
+export default resolveSource;

--- a/packages/layout/tests/image/getSource.test.js
+++ b/packages/layout/tests/image/getSource.test.js
@@ -5,17 +5,17 @@ const VALUE = 'gotcha';
 describe('image getSource', () => {
   test('Should get src', () => {
     const node = { type: 'IMAGE', props: { src: VALUE } };
-    expect(getSource(node)).toEqual({ uri: VALUE });
+    expect(getSource(node)).toEqual(VALUE);
   });
 
   test('Should get source', () => {
     const node = { type: 'IMAGE', props: { source: VALUE } };
-    expect(getSource(node)).toEqual({ uri: VALUE });
+    expect(getSource(node)).toEqual(VALUE);
   });
 
   test('Should get href', () => {
     const node = { type: 'IMAGE', props: { href: VALUE } };
-    expect(getSource(node)).toEqual({ uri: VALUE });
+    expect(getSource(node)).toEqual(VALUE);
   });
 
   test('Should get undefined if either present', () => {

--- a/packages/layout/tests/image/resolveSource.test.js
+++ b/packages/layout/tests/image/resolveSource.test.js
@@ -1,0 +1,104 @@
+import resolveSource from '../../src/image/resolveSource';
+
+const SOURCE_URL = 'gotcha';
+const SOURCE_URL_OBJECT = { uri: 'gotcha', method: 'GET' };
+const SOURCE_BUFFER = Buffer.from('gotcha');
+const SOURCE_DATA_BUFFER = { data: Buffer.from('gotcha'), format: 'png' };
+
+describe('image resolveSource', () => {
+  describe('source', () => {
+    it('resolves url', () => {
+      expect(resolveSource(SOURCE_URL)).resolves.toEqual({ uri: SOURCE_URL });
+    });
+
+    it('resolves url object', () => {
+      expect(resolveSource(SOURCE_URL_OBJECT)).resolves.toBe(SOURCE_URL_OBJECT);
+    });
+
+    it('resolves buffer', () => {
+      expect(resolveSource(SOURCE_BUFFER)).resolves.toBe(SOURCE_BUFFER);
+    });
+
+    it('resolves data buffer', () => {
+      expect(resolveSource(SOURCE_DATA_BUFFER)).resolves.toBe(
+        SOURCE_DATA_BUFFER,
+      );
+    });
+  });
+
+  describe('async', () => {
+    it('resolves url', () => {
+      expect(resolveSource(Promise.resolve(SOURCE_URL))).resolves.toEqual({
+        uri: SOURCE_URL,
+      });
+    });
+
+    it('resolves url object', () => {
+      expect(resolveSource(Promise.resolve(SOURCE_URL_OBJECT))).resolves.toBe(
+        SOURCE_URL_OBJECT,
+      );
+    });
+
+    it('resolves buffer', () => {
+      expect(resolveSource(Promise.resolve(SOURCE_BUFFER))).resolves.toBe(
+        SOURCE_BUFFER,
+      );
+    });
+
+    it('resolves data buffer', () => {
+      expect(resolveSource(Promise.resolve(SOURCE_DATA_BUFFER))).resolves.toBe(
+        SOURCE_DATA_BUFFER,
+      );
+    });
+  });
+
+  describe('factory', () => {
+    it('resolves url', () => {
+      expect(resolveSource(() => SOURCE_URL)).resolves.toEqual({
+        uri: SOURCE_URL,
+      });
+    });
+
+    it('resolves url object', () => {
+      expect(resolveSource(() => SOURCE_URL_OBJECT)).resolves.toBe(
+        SOURCE_URL_OBJECT,
+      );
+    });
+
+    it('resolves buffer', () => {
+      expect(resolveSource(() => SOURCE_BUFFER)).resolves.toBe(SOURCE_BUFFER);
+    });
+
+    it('resolves data buffer', () => {
+      expect(resolveSource(() => SOURCE_DATA_BUFFER)).resolves.toBe(
+        SOURCE_DATA_BUFFER,
+      );
+    });
+  });
+
+  describe('async factory', () => {
+    it('resolves url', () => {
+      expect(resolveSource(async () => SOURCE_URL)).resolves.toEqual({
+        uri: SOURCE_URL,
+      });
+    });
+
+    it('resolves url object', () => {
+      expect(resolveSource(async () => SOURCE_URL_OBJECT)).resolves.toBe(
+        SOURCE_URL_OBJECT,
+      );
+    });
+
+    it('resolves buffer', () => {
+      expect(resolveSource(async () => SOURCE_BUFFER)).resolves.toBe(
+        SOURCE_BUFFER,
+      );
+    });
+
+    it('resolves data buffer', () => {
+      expect(resolveSource(async () => SOURCE_DATA_BUFFER)).resolves.toBe(
+        SOURCE_DATA_BUFFER,
+      );
+    });
+  });
+});

--- a/packages/types/image.d.ts
+++ b/packages/types/image.d.ts
@@ -1,6 +1,23 @@
 type HTTPMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
 
-export type SourceObject =
-  | string
-  | { data: Buffer; format: 'png' | 'jpg' }
-  | { uri: string; method: HTTPMethod; body: any; headers: any };
+type SourceURL = string
+
+type SourceBuffer = Buffer
+
+type SourceDataBuffer = { data: Buffer; format: 'png' | 'jpg' }
+
+type SourceURLObject =  { uri: string; method: HTTPMethod; body: any; headers: any }
+
+type Source =
+  | SourceURL
+  | SourceBuffer
+  | SourceDataBuffer
+  | SourceURLObject
+
+type SourceFactory = () => Source
+
+type SourceAsync = Promise<Source>
+
+type SourceAsyncFactory = () => Promise<Source>
+
+export type SourceObject = Source | SourceFactory | SourceAsync | SourceAsyncFactory


### PR DESCRIPTION
The PR brings support of not url only factories, async sources, async factories for `Image` component.

```jsx
<View>
  {/* Sources */}
  <Image src={url} />
  <Image src={{ uri: valid-url, method: 'GET' }} />
  <Image src={buffer} />
  <Image src={{ data: buffer, format: 'png' }} />

  {/* Source factories */}
  <Image src={() => url} />
  <Image src={() => ({ uri: valid-url, method: 'GET' })} />
  <Image src={() => buffer} />
  <Image src={() => ({ data: buffer, format: 'png' })} />

  {/* Async sources */}
  <Image src={Promise.resolve(url)} />
  <Image src={Promise.resolve({ uri: valid-url, method: 'GET' })} />
  <Image src={Promise.resolve(buffer)} />
  <Image src={Promise.resolve({ data: buffer, format: 'png' })} />
  
  {/* Async source factories */}
  <Image src={async () => url} />
  <Image src={async () => ({ uri: valid-url, method: 'GET' })} />
  <Image src={async () => buffer} />
  <Image src={async () => ({ data: buffer, format: 'png' })} />
</View>
```

Also it fixes #1211