### PR TITLE
fix: FontDescriptor TS type

### DIFF
--- a/packages/types/font.d.ts
+++ b/packages/types/font.d.ts
@@ -13,7 +13,7 @@ export type FontWeight =
   | 'heavy';
 
 export interface FontDescriptor {
-  family: string;
+  fontFamily: string;
   fontStyle?: FontStyle;
   fontWeight?: FontWeight;
 }


### PR DESCRIPTION
It should be `fontFamily` instead of `family`.

https://github.com/diegomura/react-pdf/blob/721113e72e73b308caa7dd82b0776418e76c491b/packages/font/src/index.js#L37
https://github.com/diegomura/react-pdf/blob/721113e72e73b308caa7dd82b0776418e76c491b/packages/font/src/index.js#L52