### PR TITLE
Update 'display' to accept 'table' - value

### DIFF
--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -17,7 +17,7 @@ export interface Style {
   // Layout
 
   bottom?: number | string;
-  display?: 'flex' | 'none';
+  display?: 'flex' | 'none' | 'table';
   left?: number | string;
   position?: 'absolute' | 'relative';
   right?: number | string;


### PR DESCRIPTION
Previously display could also be "table", I wonder if this change has been done on purpose?