### PR TITLE
fix: flexbox types

### DIFF
--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -4,13 +4,13 @@ export interface Style {
   alignContent?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'space-between' | 'space-around';
   alignItems?: 'flex-start' | 'flex-end' | 'center' | 'stretch' | 'baseline';
   alignSelf?: 'auto' | 'flex-start' | 'flex-end' | 'center' | 'baseline' | 'stretch';
-  flex?: number;
+  flex?: number | string;
   flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
   flexWrap?: 'nowrap' | 'wrap' | 'wrap-reverse';
   flexFlow?: number;
   flexGrow?: number;
   flexShrink?: number;
-  flexBasis?: number;
+  flexBasis?: number | string;
   justifyContent?: 'flex-start' | 'flex-end' | 'center' | 'space-around' | 'space-between' | 'space-evenly';
   order?: number;
 


### PR DESCRIPTION
Fixes https://github.com/diegomura/react-pdf/issues/1320. Adding only flexbox types here. `display: block` don't think has any effect on this lib. If I'm mistaken I'll add it in a separate PR. Thanks!