### PR TITLE
feat: error handling when source factories of Image return undefined

### DIFF
--- a/packages/layout/src/image/fetchImage.js
+++ b/packages/layout/src/image/fetchImage.js
@@ -22,6 +22,11 @@ const fetchImage = async node => {
 
   try {
     const source = await resolveSource(src);
+
+    if (!source) {
+      throw new Error(`Image's "src" or "source" prop returned ${source}`);
+    }
+
     node.image = await resolveImage(source, { cache });
   } catch (e) {
     node.image = { width: 0, height: 0 };

--- a/packages/layout/tests/image/resolveSource.test.js
+++ b/packages/layout/tests/image/resolveSource.test.js
@@ -74,6 +74,10 @@ describe('image resolveSource', () => {
         SOURCE_DATA_BUFFER,
       );
     });
+
+    it('resolves undefined', () => {
+      expect(resolveSource(() => undefined)).resolves.toBe(undefined);
+    });
   });
 
   describe('async factory', () => {
@@ -99,6 +103,10 @@ describe('image resolveSource', () => {
       expect(resolveSource(async () => SOURCE_DATA_BUFFER)).resolves.toBe(
         SOURCE_DATA_BUFFER,
       );
+    });
+
+    it('resolves undefined', () => {
+      expect(resolveSource(async () => undefined)).resolves.toBe(undefined);
     });
   });
 });

--- a/packages/types/image.d.ts
+++ b/packages/types/image.d.ts
@@ -13,6 +13,7 @@ type Source =
   | SourceBuffer
   | SourceDataBuffer
   | SourceURLObject
+  | undefined
 
 type SourceFactory = () => Source
 


### PR DESCRIPTION
When resolving Image's source prop, if `src`/`source` is `undefined`, `fetchImage` will show relevant error message and return:

https://github.com/diegomura/react-pdf/blob/66d6259971e99846602d69de85fcbba98825d608/packages/layout/src/image/fetchImage.js#L18-L20

However, if `src`/`source` is not `undefined` but function returning `undefined`, `fetchImage` will pass through the above `if` block, invoke `resolveImage` and encounter `Cannot read property 'data' of undefined` error when evaluating `src.data`:

https://github.com/diegomura/react-pdf/blob/66d6259971e99846602d69de85fcbba98825d608/packages/image/src/resolve.js#L159-L160

This pull request adds code that will show relevant error message and return before invoking `resolveImage`, when `src`/`source` is function returning `undefined`.