### PR TITLE
Remove incorrect types from StyleSheet.

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -473,24 +473,7 @@ declare module '@react-pdf/renderer' {
     const Font: FontStore;
 
     const StyleSheet: {
-      hairlineWidth: number;
       create: <T extends Styles>(styles: T) => T;
-      resolve: (
-        style: Style,
-        container: {
-          width: number;
-          height: number;
-          orientation: Orientation;
-        },
-      ) => Style;
-      flatten: (...styles: (Style[] | Style | undefined)[]) => Style;
-      absoluteFillObject: {
-        position: 'absolute';
-        left: 0;
-        right: 0;
-        top: 0;
-        bottom: 0;
-      };
     };
 
     const version: any;


### PR DESCRIPTION
The `StyleSheet` type for `@react-pdf/renderer` has a number of properties that don't actually exist. We noticed this issue when upgrading from v1 to v2 because `StyleSheet.flatten` was undefined at runtime. This seems intentional, since the actual `StyleSheet` export is just this:

https://github.com/diegomura/react-pdf/blob/7ddaa1858433dd401a7382aed2fe316c408b1bf4/packages/renderer/src/index.js#L126-L128

So this pull request makes the `StyleSheet` type accurate to what's actually exported.

This seems like a backwards compatibility issue though, since at least `StyleSheet.flatten`, `StyleSheet.resolve`, etc. did previously exist in v1.