### PR TITLE
fix flex

### DIFF
--- a/packages/stylesheet/src/flex.js
+++ b/packages/stylesheet/src/flex.js
@@ -1,11 +1,13 @@
 import { castFloat } from './utils';
 
-const processFlex = (key, value) => {
-  const matches = value.split(' ');
+const flexDefaults = [1, 1, 0];
 
-  const flexGrow = castFloat(matches[0] || value);
-  const flexShrink = castFloat(matches[1] || value);
-  const flexBasis = castFloat(matches[2] || value);
+const processFlex = (key, value) => {
+  const matches = `${value}`.split(' ');
+
+  const flexGrow = castFloat(matches[0] || flexDefaults[0]);
+  const flexShrink = castFloat(matches[1] || flexDefaults[1]);
+  const flexBasis = castFloat(matches[2] || flexDefaults[2]);
 
   return { flexGrow, flexShrink, flexBasis };
 };

--- a/packages/stylesheet/tests/flex.test.js
+++ b/packages/stylesheet/tests/flex.test.js
@@ -10,4 +10,34 @@ describe('stylesheet flex transform', () => {
       flexBasis: 'auto',
     });
   });
+
+  test('should process flex shorthand with one digit', () => {
+    const styles = processFlex('flex', 1);
+
+    expect(styles).toEqual({
+      flexGrow: 1,
+      flexShrink: 1,
+      flexBasis: 0,
+    });
+  });
+
+  test("should process flex '1'", () => {
+    const styles = processFlex('flex', '1');
+
+    expect(styles).toEqual({
+      flexGrow: 1,
+      flexShrink: 1,
+      flexBasis: 0,
+    });
+  });
+
+  test('should process flex shorthand with two digits', () => {
+    const styles = processFlex('flex', '1 0');
+
+    expect(styles).toEqual({
+      flexGrow: 1,
+      flexShrink: 0,
+      flexBasis: 0,
+    });
+  });
 });

--- a/packages/textkit/src/layout/index.js
+++ b/packages/textkit/src/layout/index.js
@@ -18,7 +18,7 @@ import applyDefaultStyles from './applyDefaultStyles';
  * layout behavior.
  *
  * @param  {Object}  engines
- * @param  {Object}  attributted string
+ * @param  {Object}  attributed string
  * @param  {Object}  container rect
  * @param  {Object}  layout options
  * @return {Array} paragraph blocks


### PR DESCRIPTION
fix #1332


changes:
- tests
- convert `flex` to string before split
- use flex defaults instead of value as fallback