### PR TITLE
Fix examples in README

### DIFF
--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -10,17 +10,23 @@
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/text/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/text/">Text</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/resume/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/resume/">Resume</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/fractals/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/fractals/">Fractals</a>
 			</td>
@@ -31,12 +37,16 @@
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">Knobs</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/pageWrap/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/pageWrap/">Page wrap</a>
 			</td>

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -9,25 +9,20 @@
 <table>
 	<tbody>
 		<tr>
-      <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/text/thumb.png">
-        <br>
-        <a href="https://github.com/diegomura/react-pdf/tree/master/examples/text/">Text</a>
-      </td>
-      <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/images/thumb.png">
-        <br>
-        <a href="https://github.com/diegomura/react-pdf/tree/master/examples/images/">Images</a>
-      </td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/resume/thumb.png">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/tree/master/examples/resume/">Resume</a>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/text/">Text</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/fractals/thumb.png">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/tree/master/examples/fractals/">Fractals</a>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/resume/">Resume</a>
+			</td>
+			<td align="center" valign="top">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
+				<br>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/fractals/">Fractals</a>
 			</td>
 		</tr>
 	</tbody>
@@ -36,15 +31,15 @@
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/knobs/thumb.png">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/tree/master/examples/knobs/">Knobs</a>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">Knobs</a>
 			</td>
-      <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/pageWrap/thumb.png">
-        <br>
-        <a href="https://github.com/diegomura/react-pdf/tree/master/examples/pageWrap/">Page wrap</a>
-      </td>
+			<td align="center" valign="top">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
+				<br>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/pageWrap/">Page wrap</a>
+			</td>
 		</tr>
 	</tbody>
 </table>

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -90,17 +90,23 @@ For each example, try opening `output.pdf` to see the result.
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/">Text</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/">Resume</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/fractals/">Fractals</a>
 			</td>
@@ -111,12 +117,16 @@ For each example, try opening `output.pdf` to see the result.
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">Knobs</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/">
+					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
+				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/pageWrap/">Page wrap</a>
 			</td>

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -89,20 +89,20 @@ For each example, try opening `output.pdf` to see the result.
 <table>
 	<tbody>
 		<tr>
-      <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/text/thumb.png">
-        <br>
-        <a href="https://github.com/diegomura/react-pdf/tree/master/examples/text/">Text</a>
-      </td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/resume/thumb.png">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/tree/master/examples/resume/">Resume</a>
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/">Text</a>
 			</td>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/fractals/thumb.png">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/tree/master/examples/fractals/">Fractals</a>
+				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/">Resume</a>
+			</td>
+			<td align="center" valign="top">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
+				<br>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/fractals/">Fractals</a>
 			</td>
 		</tr>
 	</tbody>
@@ -111,15 +111,15 @@ For each example, try opening `output.pdf` to see the result.
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/knobs/thumb.png">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/tree/master/examples/knobs/">Knobs</a>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">Knobs</a>
 			</td>
-      <td align="center" valign="top">
-        <img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/examples/pageWrap/thumb.png">
-        <br>
-        <a href="https://github.com/diegomura/react-pdf/tree/master/examples/pageWrap/">Page wrap</a>
-      </td>
+			<td align="center" valign="top">
+				<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
+				<br>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/pageWrap/">Page wrap</a>
+			</td>
 		</tr>
 	</tbody>
 </table>

--- a/packages/renderer/README.md
+++ b/packages/renderer/README.md
@@ -90,21 +90,21 @@ For each example, try opening `output.pdf` to see the result.
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/text/">
 					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/thumb.png?raw=true">
 				</a>
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/text/">Text</a>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/text/">Text</a>
 			</td>
 			<td align="center" valign="top">
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/resume/">
 					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/thumb.png?raw=true">
 				</a>
 				<br>
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/resume/">Resume</a>
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/resume/">Resume</a>
 			</td>
 			<td align="center" valign="top">
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/fractals/">
 					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/fractals/thumb.png?raw=true">
 				</a>
 				<br>
@@ -117,14 +117,14 @@ For each example, try opening `output.pdf` to see the result.
 	<tbody>
 		<tr>
 			<td align="center" valign="top">
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">
 					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/knobs/thumb.png?raw=true">
 				</a>
 				<br>
 				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/knobs/">Knobs</a>
 			</td>
 			<td align="center" valign="top">
-				<a href="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/">
+				<a href="https://github.com/diegomura/react-pdf/tree/master/packages/examples/src/pageWrap/">
 					<img width="150" height="150" src="https://github.com/diegomura/react-pdf/blob/master/packages/examples/src/pageWrap/thumb.png?raw=true">
 				</a>
 				<br>


### PR DESCRIPTION
Fixing examples links not working and images not showing in README files:
- Fixed broken paths (also, removed Images example as it doesn't appear to be around anymore).
- Added anchor element pointing to example folder for each image, instead of letting GitHub adding one automatically that points to the thumbnail file.
- Also, removed rogue spaces indentation in favour of tabs (which seems to be the preferred style) for a consistant indentation.