### PR TITLE
Fix Object URL cleanup in `usePDF`

### DIFF
--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -51,6 +51,7 @@ export const usePDF = ({ document }) => {
 
     return () => {
       renderQueue.end();
+      pdfInstance.current.removeListener('change', queueDocumentRender);
     };
   }, []);
 

--- a/packages/renderer/src/dom.js
+++ b/packages/renderer/src/dom.js
@@ -6,11 +6,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import queue from 'queue';
 import { pdf, version, Font, StyleSheet } from './index';
 
-
 export const usePDF = ({ document }) => {
   const pdfInstance = useRef(null);
-
-  const previousUrl = useRef(null);
 
   const [state, setState] = useState({
     url: null,
@@ -37,8 +34,6 @@ export const usePDF = ({ document }) => {
     };
 
     const onRenderSuccessful = blob => {
-      previousUrl.current = state.url;
-
       setState({
         blob,
         error: null,
@@ -61,8 +56,12 @@ export const usePDF = ({ document }) => {
 
   // Revoke old unused url instances
   useEffect(() => {
-    if (previousUrl.current) URL.revokeObjectURL(previousUrl.current);
-  }, [state.blob]);
+    return () => {
+      if (state.url) {
+        URL.revokeObjectURL(state.url);
+      }
+    };
+  }, [state.url]);
 
   const update = () => {
     pdfInstance.current.updateContainer(document);


### PR DESCRIPTION
Related to #1326

### Summary

Main issue - event added with `pdfInstance.on('change', queueDocumentRender)` were never removed. 
Since the implementation is a singleton all the past events were re-triggered

Update cleanup logic so that the previous `state.url` is always revoked
during a `useEffect` cleanup

This would also revoke the blob url when the hook is done and unmounts

I went with the `useEffect` cleanup function as it will run for each previous `state.url` 
as well as when a component using the hook unmounts in the end

---

### Testing 

I think the easiest way to test this is manually

1. Have a sample PDF document 
2. Have something that uses the `usePDF` hook (I think everything uses it internally ATM)
3. Trigger updates
4. Monitor the "Network" tab for `blob:...` urls 
5. You should be able to open the last `blob` url 
6. Any previous `blob` urls should be discarded. Opening such URL in new tab should display a "Your file couldn’t be accessed" page ![image](https://user-images.githubusercontent.com/12156624/123612335-1dbb8300-d80b-11eb-8753-5d66340704ad.png)