### PR TITLE
refactor(renderer): move events to the closure of `pdf`

### DIFF
--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -12,11 +12,11 @@ const fontStore = new FontStore();
 // We must keep a single renderer instance, otherwise React will complain
 let renderer;
 
-// The pdf instance acts as an event emmiter for DOM usage.
-// We only want to trigger an update then PDF content changes
-const events = {};
-
 const pdf = initialValue => {
+  // The pdf instance acts as an event emitter for DOM usage.
+  // We only want to trigger an update when PDF content changes
+  const events = {};
+
   const onChange = () => {
     const listeners = events.change?.slice() || [];
     for (let i = 0; i < listeners.length; i += 1) listeners[i]();


### PR DESCRIPTION
### Description

When you render multiple PDFs, since all events are kept in the same object
it will emit events to all usages and not only to the one that changed

### Example 

Let's say I have 3 pdf previews, I'll use the hook for simplicity

```jsx
const [a, updateA] = usePDF({ document: Document_A });
const [b, updateB] = usePDF({ document: Document_B });
const [c, updateC] = usePDF({ document: Document_C });

useEffect(() => {
  updateB();
}, [somethingThatUpdatesOnlyB])
```

Each hook registers a listener 

https://github.com/diegomura/react-pdf/blob/a21154486d41597aadd8b44b0d3b6c882a1cfd15/packages/renderer/src/dom.js#L45-L46

When `updateB()` is called this this will trigger a change and all listeners would be invoked
https://github.com/diegomura/react-pdf/blob/a21154486d41597aadd8b44b0d3b6c882a1cfd15/packages/renderer/src/index.js#L20-L23

### Solution

`events` can be moved inside the closure of the `pdf` instance
Otherwise separate usages of `pdf()` would be notified of each
others events in vain