### PR TITLE
Add support for multiple text decorations

### DIFF
--- a/packages/layout/src/svg/layoutText.js
+++ b/packages/layout/src/svg/layoutText.js
@@ -53,9 +53,13 @@ const getFragments = (fontStore, instance) => {
     fontSize,
     color: fill,
     underlineStyle: textDecorationStyle,
-    underline: textDecoration === 'underline',
+    underline:
+      typeof textDecoration === 'string' &&
+      textDecoration.includes('underline'),
     underlineColor: textDecorationColor || fill,
-    strike: textDecoration === 'line-through',
+    strike:
+      typeof textDecoration === 'string' &&
+      textDecoration.includes('line-through'),
     strikeStyle: textDecorationStyle,
     strikeColor: textDecorationColor || fill,
   };

--- a/packages/layout/src/svg/layoutText.js
+++ b/packages/layout/src/svg/layoutText.js
@@ -54,12 +54,14 @@ const getFragments = (fontStore, instance) => {
     color: fill,
     underlineStyle: textDecorationStyle,
     underline:
-      typeof textDecoration === 'string' &&
-      textDecoration.includes('underline'),
+      textDecoration === 'underline' ||
+      textDecoration === 'underline line-through' ||
+      textDecoration === 'line-through underline',
     underlineColor: textDecorationColor || fill,
     strike:
-      typeof textDecoration === 'string' &&
-      textDecoration.includes('line-through'),
+      textDecoration === 'line-through' ||
+      textDecoration === 'underline line-through' ||
+      textDecoration === 'line-through underline',
     strikeStyle: textDecorationStyle,
     strikeColor: textDecorationColor || fill,
   };

--- a/packages/layout/src/text/getAttributedString.js
+++ b/packages/layout/src/text/getAttributedString.js
@@ -62,11 +62,13 @@ const getFragments = (fontStore, instance, level = 0) => {
     strikeStyle: textDecorationStyle,
     underlineStyle: textDecorationStyle,
     underline:
-      typeof textDecoration === 'string' &&
-      textDecoration.includes('underline'),
+      textDecoration === 'underline' ||
+      textDecoration === 'underline line-through' ||
+      textDecoration === 'line-through underline',
     strike:
-      typeof textDecoration === 'string' &&
-      textDecoration.includes('line-through'),
+      textDecoration === 'line-through' ||
+      textDecoration === 'underline line-through' ||
+      textDecoration === 'line-through underline',
     strikeColor: textDecorationColor || color,
     underlineColor: textDecorationColor || color,
     link: instance.props?.src || instance.props?.href,

--- a/packages/layout/src/text/getAttributedString.js
+++ b/packages/layout/src/text/getAttributedString.js
@@ -61,8 +61,12 @@ const getFragments = (fontStore, instance, level = 0) => {
     characterSpacing: letterSpacing,
     strikeStyle: textDecorationStyle,
     underlineStyle: textDecorationStyle,
-    underline: textDecoration === 'underline',
-    strike: textDecoration === 'line-through',
+    underline:
+      typeof textDecoration === 'string' &&
+      textDecoration.includes('underline'),
+    strike:
+      typeof textDecoration === 'string' &&
+      textDecoration.includes('line-through'),
     strikeColor: textDecorationColor || color,
     underlineColor: textDecorationColor || color,
     link: instance.props?.src || instance.props?.href,

--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -48,7 +48,7 @@ export interface Style {
   lineHeight?: number | string;
   maxLines?: number; // ?
   textAlign?: 'left' | 'right' | 'center' | 'justify'; // ?
-  textDecoration?: 'line-through' | 'underline' | 'none';
+  textDecoration?: 'line-through' | 'underline' | 'none' | 'line-through underline' | 'underline line-through';
   textDecorationColor?: string;
   textDecorationStyle?: "dashed" | "dotted" | "solid" | string; // ?
   textIndent?: any; // ?

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,6 +4113,11 @@ estraverse@~1.5.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
   integrity sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=
 
+estree-walker@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
+  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
+
 estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
@@ -6569,7 +6574,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.4:
+minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -8201,6 +8206,13 @@ rollup-plugin-sourcemaps@^0.4.2:
     rollup-pluginutils "^2.0.1"
     source-map-resolve "^0.5.0"
 
+rollup-plugin-string@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-string/-/rollup-plugin-string-2.0.2.tgz#f5323a22cfd738b450cbea62ab6593705eac744b"
+  integrity sha1-9TI6Is/XOLRQy+piq2WTcF6sdEs=
+  dependencies:
+    rollup-pluginutils "^1.5.0"
+
 rollup-plugin-terser@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz#6f661ef284fa7c27963d242601691dc3d23f994e"
@@ -8210,6 +8222,14 @@ rollup-plugin-terser@^4.0.4:
     jest-worker "^24.0.0"
     serialize-javascript "^1.6.1"
     terser "^3.14.1"
+
+rollup-pluginutils@^1.5.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
+  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
+  dependencies:
+    estree-walker "^0.2.1"
+    minimatch "^3.0.2"
 
 rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1:
   version "2.8.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4113,11 +4113,6 @@ estraverse@~1.5.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-1.5.1.tgz#867a3e8e58a9f84618afb6c2ddbcd916b7cbaf71"
   integrity sha1-hno+jlip+EYYr7bC3bzZFrfLr3E=
 
-estree-walker@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.2.1.tgz#bdafe8095383d8414d5dc2ecf4c9173b6db9412e"
-  integrity sha1-va/oCVOD2EFNXcLs9MkXO225QS4=
-
 estree-walker@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
@@ -6574,7 +6569,7 @@ min-indent@^1.0.0:
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
 
-minimatch@^3.0.2, minimatch@^3.0.4:
+minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -8206,13 +8201,6 @@ rollup-plugin-sourcemaps@^0.4.2:
     rollup-pluginutils "^2.0.1"
     source-map-resolve "^0.5.0"
 
-rollup-plugin-string@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-string/-/rollup-plugin-string-2.0.2.tgz#f5323a22cfd738b450cbea62ab6593705eac744b"
-  integrity sha1-9TI6Is/XOLRQy+piq2WTcF6sdEs=
-  dependencies:
-    rollup-pluginutils "^1.5.0"
-
 rollup-plugin-terser@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/rollup-plugin-terser/-/rollup-plugin-terser-4.0.4.tgz#6f661ef284fa7c27963d242601691dc3d23f994e"
@@ -8222,14 +8210,6 @@ rollup-plugin-terser@^4.0.4:
     jest-worker "^24.0.0"
     serialize-javascript "^1.6.1"
     terser "^3.14.1"
-
-rollup-pluginutils@^1.5.0:
-  version "1.5.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
-  integrity sha1-HhVud4+UtyVb+hs9AXi+j1xVJAg=
-  dependencies:
-    estree-walker "^0.2.1"
-    minimatch "^3.0.2"
 
 rollup-pluginutils@^2.0.1, rollup-pluginutils@^2.3.1, rollup-pluginutils@^2.6.0, rollup-pluginutils@^2.8.1:
   version "2.8.2"


### PR DESCRIPTION
## Summary

Adds functionality for specifying multiple values for the `textDecoration` style attribute (Related to #809). 

This brings the `textDecoration` attribute in this library closer in line to  the standard CSS `text-decoration` attribute so it seems like a logical addition (and something that I was looking for in this library).

## Details

In particular, this change allows for specifying either `'underline line-through'` or `'line-through underline'` while disallowing invalid combinations such as `'underline none'`.  

I've updated the Typescript types as well to include `'underline line-through'` or `'line-through underline'` as valid values for the `textDecoration` style attribute.

I am unsure on how to approach implementing a test for this functionality or if one is needed, so any input on that front is welcome.