### PR TITLE
Update borderWidth type to accept string

### DIFF
--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -89,7 +89,7 @@ export interface Style {
   // Borders
 
   border?: number | string;
-  borderWidth?: number;
+  borderWidth?: number | string;
   borderColor?: string;
   borderStyle?: "dashed" | "dotted" | "solid";
   borderTop?: number | string;


### PR DESCRIPTION
Allow strings for borderWidth in Typescript