### PR TITLE
Fix missing style type for zIndex support

### DIFF
--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -22,6 +22,7 @@ export interface Style {
   right?: number | string;
   top?: number | string;
   overflow?: 'hidden';
+  zIndex?: number | string;
 
   // Dimension
 


### PR DESCRIPTION
Hi, just a small fix to add zIndex property support to defined types.

Thanks for your work !
