### PR TITLE
fix: use `types` field, fix exports

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -2,7 +2,7 @@
   "name": "@react-pdf/renderer",
   "version": "2.0.19",
   "license": "MIT",
-  "typings": "index.d.ts",
+  "types": "index.d.ts",
   "author": "Diego Muracciole <diegomuracciole@gmail.com>",
   "homepage": "https://github.com/diegomura/react-pdf#readme",
   "repository": "git@github.com:diegomura/react-pdf.git",

--- a/packages/types/font.d.ts
+++ b/packages/types/font.d.ts
@@ -33,7 +33,7 @@ interface FontInstance {
   sources: FontSource[];
 }
 
-type HyphenationCallback = (
+export type HyphenationCallback = (
   words: string,
   glyphString: { [key: string]: any },
 ) => string[];


### PR DESCRIPTION
typings field seems obsoled / deprecated
i can't find any information about it, so i change it to [`types`](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package)

export `HyphenationCallback` because it being used in `node.d.ts`