### PR TITLE
fix textDecoration inheritance

### DIFF
--- a/packages/layout/src/steps/resolveInheritance.js
+++ b/packages/layout/src/steps/resolveInheritance.js
@@ -30,6 +30,33 @@ const getInheritStyles = R.compose(
   R.propOr({}, 'style'),
 );
 
+// Merge style values
+const mergeValues = (styleName, value, inheritedValue) => {
+  switch (styleName) {
+    case 'textDecoration': {
+      // merge not none and not false textDecoration values to one rule
+      return [inheritedValue, value].filter(v => v && v !== 'none').join(' ');
+    }
+    default:
+      return value;
+  }
+};
+
+// Merge inherited and node styles
+const merge = (inheritedStyles, style) => {
+  const mergedStyles = { ...inheritedStyles };
+
+  Object.entries(style).forEach(([styleName, value]) => {
+    mergedStyles[styleName] = mergeValues(
+      styleName,
+      value,
+      inheritedStyles[styleName],
+    );
+  });
+
+  return mergedStyles;
+};
+
 /**
  * Merges styles with node
  *
@@ -37,9 +64,9 @@ const getInheritStyles = R.compose(
  * @param {Object} node
  * @returns {Object} node with styles merged
  */
-const mergeStyles = styles =>
+const mergeStyles = inheritedStyles =>
   R.evolve({
-    style: R.merge(styles),
+    style: style => merge(inheritedStyles, style),
   });
 
 /**

--- a/packages/layout/tests/steps/resolveInhritance.test.js
+++ b/packages/layout/tests/steps/resolveInhritance.test.js
@@ -80,6 +80,37 @@ describe('layout resolveInheritance', () => {
     expect(subview.style).toHaveProperty('color', 'green');
   });
 
+  test('Should inherit multiple textDecoration properly', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          style: {},
+          children: [
+            {
+              type: 'TEXT',
+              style: { textDecoration: 'line-through' },
+              children: [
+                { type: 'TEXT', style: { textDecoration: 'underline' } },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const result = resolveInheritance(root);
+    const text1 = result.children[0].children[0];
+    const text2 = text1.children[0];
+
+    expect(text1.style).toHaveProperty('textDecoration', 'line-through');
+    expect(text2.style).toHaveProperty(
+      'textDecoration',
+      'line-through underline',
+    );
+  });
+
   test('Should inherit color value', shouldInherit('color'));
   test('Should inherit fontFamily value', shouldInherit('fontFamily'));
   test('Should inherit fontSize value', shouldInherit('fontSize'));


### PR DESCRIPTION
fix merge `textDecoration` style in inherited nodes

fix #1489 