### PR TITLE
apply patch for links from v2 to v1 too

### DIFF
--- a/src/utils/attributedString.js
+++ b/src/utils/attributedString.js
@@ -29,7 +29,7 @@ const transformText = (text, transformation) => {
   }
 };
 
-export const getFragments = instance => {
+export const getFragments = (instance, parentLink) => {
   if (!instance) return [{ string: '' }];
 
   let fragments = [];
@@ -61,7 +61,7 @@ export const getFragments = instance => {
     backgroundColor,
     align: textAlign,
     indent: textIndent,
-    link: instance.src,
+    link: parentLink || instance.src,
     characterSpacing: letterSpacing,
     underlineStyle: textDecorationStyle,
     underline: textDecoration === 'underline',
@@ -92,7 +92,7 @@ export const getFragments = instance => {
       });
     } else {
       if (child) {
-        fragments.push(...getFragments(child));
+        fragments.push(...getFragments(child, attributes.link));
       }
     }
   });


### PR DESCRIPTION
Hi @diegomura 
Can you please release this patch for links in `react-pdf` v1?

now links doesn't works when they have other text elements inside, like this

```html
<Text>text: <Link src="https://link.com/"><Text style={bold}>link</Text></Link></Text>
<Text>text: <Link src="https://link.com/"><Text style={cursive}>link</Text></Link></Text>
```

this happen because `getFragments` function lose `src` prop when process `Link` children, so I fix that