### PR TITLE
feat(stylesheet): rework box model style parsing

### DIFF
--- a/.changeset/empty-zoos-live.md
+++ b/.changeset/empty-zoos-live.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/stylesheet': minor
+---
+
+fixed `margin: auto` parsing

--- a/packages/stylesheet/package.json
+++ b/packages/stylesheet/package.json
@@ -22,6 +22,7 @@
     "color-string": "^1.5.3",
     "hsl-to-hex": "^1.0.0",
     "media-engine": "^1.0.3",
+    "postcss-value-parser": "^4.1.0",
     "ramda": "^0.26.1"
   },
   "files": [

--- a/packages/stylesheet/src/expand/boxModel.js
+++ b/packages/stylesheet/src/expand/boxModel.js
@@ -1,49 +1,76 @@
-import * as R from 'ramda';
+import parse from 'postcss-value-parser/lib/parse';
+import parseUnit from 'postcss-value-parser/lib/unit';
 
-const BOX_MODEL_REGEX = /-?\d+(\.\d+)?(px|in|mm|cm|pt|%|vw|vh|px)?/g;
+const BOX_MODEL_UNITS = 'px,in,mm,cm,pt,%,vw,vh';
 
-const matchBoxModelValue = R.match(BOX_MODEL_REGEX);
+const expandBoxModel = ({
+  expandsTo,
+  maxValues = 1,
+  autoSupported = false,
+} = {}) => (key, value) => {
+  const nodes = parse(`${value}`);
 
-const expandBoxModel = model => (key, value) => {
-  if (value === 'auto')
-    return {
-      [`${model}Top`]: 'auto',
-      [`${model}Right`]: 'auto',
-      [`${model}Bottom`]: 'auto',
-      [`${model}Left`]: 'auto',
-    };
+  if (nodes.some(node => node.type === 'function')) {
+    // value contains `calc`, `url` or other css function
 
-  const match = matchBoxModelValue(`${value}`);
+    console.error('x');
 
-  if (match) {
-    const top = match[0];
-    const right = match[1] || match[0];
-    const bottom = match[2] || match[0];
-    const left = match[3] || match[1] || match[0];
-
-    if (key.match(/Horizontal$/)) {
-      return {
-        [`${model}Right`]: right,
-        [`${model}Left`]: left,
-      };
-    }
-
-    if (key.match(/Vertical$/)) {
-      return {
-        [`${model}Top`]: top,
-        [`${model}Bottom`]: bottom,
-      };
-    }
-
-    return {
-      [`${model}Top`]: top,
-      [`${model}Right`]: right,
-      [`${model}Bottom`]: bottom,
-      [`${model}Left`]: left,
-    };
+    return {};
   }
 
-  return value;
+  if (nodes.some(node => node.type === 'string' || node.type === 'div')) {
+    // value contains `,`, `/` or strings
+    console.error('x');
+
+    return {};
+  }
+
+  const parts = nodes
+    .filter(node => node.type === 'word')
+    .map(word => ({
+      raw: word.value,
+      parsed: parseUnit(word.value),
+    }));
+
+  if (parts.length > maxValues) {
+    console.error('x');
+
+    return {};
+  }
+
+  const allPartsValid = parts.every(part => {
+    if (!part.parsed && part.raw === 'auto' && autoSupported) {
+      return true;
+    }
+
+    if (part.parsed && BOX_MODEL_UNITS.includes(part.parsed.unit)) {
+      return true;
+    }
+
+    return false;
+  });
+
+  if (!allPartsValid) {
+    console.error('x');
+
+    return {};
+  }
+
+  const match = parts.map(part => part.raw);
+
+  const first = match[0];
+
+  if (expandsTo) {
+    const second = match[1] || match[0];
+    const third = match[2] || match[0];
+    const fourth = match[3] || match[1] || match[0];
+  
+    return expandsTo({ first, second, third, fourth });
+  }
+
+  return {
+    [key]: first,
+  };
 };
 
 export default expandBoxModel;

--- a/packages/stylesheet/src/expand/index.js
+++ b/packages/stylesheet/src/expand/index.js
@@ -1,18 +1,36 @@
 import processFlex from './flex';
-import processMargin from './margins';
+import {
+  processMargin,
+  processMarginVertical,
+  processMarginHorizontal,
+  processMarginSingle,
+} from './margins';
 import processBorders from './borders';
-import processPadding from './paddings';
+import {
+  processPadding,
+  processPaddingVertical,
+  processPaddingHorizontal,
+  processPaddingSingle,
+} from './paddings';
 import processObjectPosition from './objectPosition';
 import processTransformOrigin from './transformOrigin';
 
 const shorthands = {
   flex: processFlex,
   margin: processMargin,
-  marginHorizontal: processMargin,
-  marginVertical: processMargin,
+  marginHorizontal: processMarginHorizontal,
+  marginVertical: processMarginVertical,
+  marginTop: processMarginSingle,
+  marginRight: processMarginSingle,
+  marginBottom: processMarginSingle,
+  marginLeft: processMarginSingle,
   padding: processPadding,
-  paddingHorizontal: processPadding,
-  paddingVertical: processPadding,
+  paddingHorizontal: processPaddingHorizontal,
+  paddingVertical: processPaddingVertical,
+  paddingTop: processPaddingSingle,
+  paddingRight: processPaddingSingle,
+  paddingBottom: processPaddingSingle,
+  paddingLeft: processPaddingSingle,
   border: processBorders,
   borderTop: processBorders,
   borderRight: processBorders,

--- a/packages/stylesheet/src/expand/margins.js
+++ b/packages/stylesheet/src/expand/margins.js
@@ -30,7 +30,6 @@ const processMarginHorizontal = processBoxModel({
 });
 
 const processMarginSingle = processBoxModel({
-  maxValues: 1,
   autoSupported: true,
 });
 

--- a/packages/stylesheet/src/expand/margins.js
+++ b/packages/stylesheet/src/expand/margins.js
@@ -1,5 +1,42 @@
 import processBoxModel from './boxModel';
 
-const expandMargin = processBoxModel('margin');
+const processMargin = processBoxModel({
+  expandsTo: ({ first, second, third, fourth }) => ({
+    marginTop: first,
+    marginRight: second,
+    marginBottom: third,
+    marginLeft: fourth,
+  }),
+  maxValues: 4,
+  autoSupported: true,
+});
 
-export default expandMargin;
+const processMarginVertical = processBoxModel({
+  expandsTo: ({ first, second }) => ({
+    marginTop: first,
+    marginBottom: second,
+  }),
+  maxValues: 2,
+  autoSupported: true,
+});
+
+const processMarginHorizontal = processBoxModel({
+  expandsTo: ({ first, second }) => ({
+    marginRight: first,
+    marginLeft: second,
+  }),
+  maxValues: 2,
+  autoSupported: true,
+});
+
+const processMarginSingle = processBoxModel({
+  maxValues: 1,
+  autoSupported: true,
+});
+
+export {
+  processMargin,
+  processMarginVertical,
+  processMarginHorizontal,
+  processMarginSingle,
+};

--- a/packages/stylesheet/src/expand/paddings.js
+++ b/packages/stylesheet/src/expand/paddings.js
@@ -1,5 +1,33 @@
 import processBoxModel from './boxModel';
 
-const expandPadding = processBoxModel('padding');
+const processPadding = processBoxModel({
+  expandsTo: ({ first, second, third, fourth }) => ({
+    paddingTop: first,
+    paddingRight: second,
+    paddingBottom: third,
+    paddingLeft: fourth,
+  }),
+  maxValues: 4,
+});
 
-export default expandPadding;
+const processPaddingVertical = processBoxModel({
+  expandsTo: ({ first, second }) => ({
+    paddingTop: first,
+    paddingBottom: second,
+  }),
+  maxValues: 2,
+});
+
+const processPaddingHorizontal = processBoxModel({
+  expandsTo: ({ first, second }) => ({
+    paddingRight: first,
+    paddingLeft: second,
+  }),
+  maxValues: 2,
+});
+
+const processPaddingSingle = processBoxModel({
+  maxValues: 1,
+});
+
+export { processPadding, processPaddingVertical, processPaddingHorizontal, processPaddingSingle };

--- a/packages/stylesheet/src/expand/paddings.js
+++ b/packages/stylesheet/src/expand/paddings.js
@@ -26,8 +26,11 @@ const processPaddingHorizontal = processBoxModel({
   maxValues: 2,
 });
 
-const processPaddingSingle = processBoxModel({
-  maxValues: 1,
-});
+const processPaddingSingle = processBoxModel();
 
-export { processPadding, processPaddingVertical, processPaddingHorizontal, processPaddingSingle };
+export {
+  processPadding,
+  processPaddingVertical,
+  processPaddingHorizontal,
+  processPaddingSingle,
+};

--- a/packages/stylesheet/tests/expand.test.js
+++ b/packages/stylesheet/tests/expand.test.js
@@ -7,11 +7,63 @@ describe('stylesheet expand', () => {
   });
 
   describe('expand margins', () => {
-    test('should expand marginHorizontal attribute', () => {
-      const style = { marginHorizontal: '1' };
+    test('should ignore invalid values', () => {
+      const margins = [
+        { margin: '"string"' },
+        { margin: 'url("link.com")' },
+        { margin: 'auto 2 black 4' },
+        { margin: 'calc(100% - 10px)' },
+        { margin: 'rgba(1 1 1 / 0.3)' },
+        { margin: '1, 2, 3' },
+        { marginLeft: 'yellow' },
+        { marginTop: '12lelkek' },
+        { marginBottom: '1 2 3' },
+        { marginHorizontal: '1 2 3' },
+        { margin: '1 2 3 4 5' },
+        { margin: () => console.log('function') },
+      ];
+      const expanded = {};
+
+      margins.forEach(style => {
+        expect(expandStyles(style)).toEqual(expanded);
+      });
+    });
+
+    test('should parse values with improper formatting', () => {
+      const style = { margin: '  1 ' };
       const expanded = {
+        marginTop: '1',
         marginRight: '1',
+        marginBottom: '1',
         marginLeft: '1',
+      };
+
+      expect(expandStyles(style)).toEqual(expanded);
+    });
+
+    test('should expand marginHorizontal attribute', () => {
+      const margins = [{ marginHorizontal: '1 2' }, { marginHorizontal: '2' }];
+      const expandedMargins = [
+        {
+          marginRight: '1',
+          marginLeft: '2',
+        },
+        {
+          marginRight: '2',
+          marginLeft: '2',
+        },
+      ];
+
+      margins.forEach((style, index) => {
+        expect(expandStyles(style)).toEqual(expandedMargins[index]);
+      });
+    });
+
+    test('should expand marginHorizontal attribute with auto', () => {
+      const style = { marginHorizontal: 'auto' };
+      const expanded = {
+        marginRight: 'auto',
+        marginLeft: 'auto',
       };
 
       expect(expandStyles(style)).toEqual(expanded);
@@ -22,6 +74,16 @@ describe('stylesheet expand', () => {
       const expanded = {
         marginTop: '1',
         marginBottom: '1',
+      };
+
+      expect(expandStyles(style)).toEqual(expanded);
+    });
+
+    test('should expand marginVertical attribute with auto', () => {
+      const style = { marginVertical: 'auto' };
+      const expanded = {
+        marginTop: 'auto',
+        marginBottom: 'auto',
       };
 
       expect(expandStyles(style)).toEqual(expanded);
@@ -38,9 +100,72 @@ describe('stylesheet expand', () => {
 
       expect(expandStyles(style)).toEqual(expanded);
     });
+
+    test('should expand margin attribute with auto', () => {
+      const margins = [
+        { margin: 'auto 2 3 4' },
+        { margin: '1 auto 3 4' },
+        { margin: '1 2 auto 4' },
+        { margin: '1 2 3 auto' },
+      ];
+      const expandedMargins = [
+        {
+          marginTop: 'auto',
+          marginRight: '2',
+          marginBottom: '3',
+          marginLeft: '4',
+        },
+        {
+          marginTop: '1',
+          marginRight: 'auto',
+          marginBottom: '3',
+          marginLeft: '4',
+        },
+        {
+          marginTop: '1',
+          marginRight: '2',
+          marginBottom: 'auto',
+          marginLeft: '4',
+        },
+        {
+          marginTop: '1',
+          marginRight: '2',
+          marginBottom: '3',
+          marginLeft: 'auto',
+        },
+      ];
+
+      margins.forEach((style, index) => {
+        expect(expandStyles(style)).toEqual(expandedMargins[index]);
+      });
+    });
   });
 
   describe('expand paddings', () => {
+    test('should ignore invalid values', () => {
+      const paddings = [
+        { padding: '2 auto' },
+        { padding: '"string"' },
+        { padding: 'url("link.com")' },
+        { padding: 'auto 2 black 4' },
+        { padding: 'calc(100% - 10px)' },
+        { padding: 'rgba(1 1 1 / 0.3)' },
+        { padding: '1, 2, 3' },
+        { padding: 'yellow' },
+        { paddingTop: '12lelkek' },
+        { paddingRight: 'auto' },
+        { paddingBottom: '1 2 3' },
+        { paddingHorizontal: '1 2 3' },
+        { padding: '1 2 3 4 5' },
+        { padding: () => console.log('function') },
+      ];
+      const expanded = {};
+
+      paddings.forEach(style => {
+        expect(expandStyles(style)).toEqual(expanded);
+      });
+    });
+
     test('should expand paddingHorizontal attribute', () => {
       const style = { paddingHorizontal: '1' };
       const expanded = {

--- a/packages/stylesheet/tests/resolve.test.js
+++ b/packages/stylesheet/tests/resolve.test.js
@@ -438,17 +438,6 @@ describe('stylesheet resolve', () => {
     });
   });
 
-  test('should transform padding auto shortcut correctly', () => {
-    const styles = resolve({}, { padding: 'auto' });
-
-    expect(styles).toEqual({
-      paddingRight: 'auto',
-      paddingLeft: 'auto',
-      paddingTop: 'auto',
-      paddingBottom: 'auto',
-    });
-  });
-
   test('should transform font weight correctly', () => {
     const styles = resolve({}, { fontWeight: 'ultrabold' });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8158,6 +8158,11 @@ posix-character-classes@^0.1.0:
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
 
+postcss-value-parser@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
+  integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
+
 preferred-pm@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/preferred-pm/-/preferred-pm-3.0.3.tgz#1b6338000371e3edbce52ef2e4f65eb2e73586d6"


### PR DESCRIPTION
Here is the first step for a stricter style parser. The current one ignores all edge cases and `@react-pdf/render` fails with crazy unpredicted errors. I use `postcss-value-parser` to achieve that, this is an internal package from `post-css` that parse all possible CSS values to `AST`. it introduces other opportunities, like `background` style support or maybe `calc` support

I rewrite box model parsing (margin/padding) to a new approach in this PR. it now 
- auto works properly in all cases ( `2 auto` or `1 auto 2 3` )
- auto works only with margin
- checks units for margin and padding
- ignores all invalid values

@diegomura @izmaelmag what do you think about these changes? what does `@react-pdf` should do with invalid values in the best scenario? (ignore, log errors, throw errors)

### todos
- [x] write **unified** error message for all cases
- [x] check that PR doesn't have breaking changes 