### PR TITLE
Exposing layout only

### DIFF
--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -49,6 +49,11 @@ const pdf = initialValue => {
     return renderPDF(ctx, layout);
   };
 
+  const toLayout = async () => {
+    const layout = await layoutDocument(container.document, fontStore);
+    return layout;
+  };
+
   const callOnRender = (params = {}) => {
     if (container.document.props.onRender) {
       container.document.props.onRender(params);
@@ -113,6 +118,7 @@ const pdf = initialValue => {
   return {
     on,
     container,
+    toLayout,
     toBlob,
     toBuffer,
     toString,


### PR DESCRIPTION
I have checked issue https://github.com/diegomura/react-pdf/issues/1496. I have also similar requirement to preview quickly and may be allow to edit ( in future ). so, I though if we only expose layout and provide preview and not spend time on generating actual  pdf but just display the layout on screen, then it will be quick turn around time for preview.

@diegomura please tell me if you have any other thoughts for this. I am happy to add feature for rendering preview or may be update REPL based on layout. 

Looking forward for your feedback. 
