### PR TITLE
Fix bestFit breakpoint issue

### DIFF
--- a/.changeset/seven-buttons-joke.md
+++ b/.changeset/seven-buttons-joke.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/textkit': patch
+---
+
+fixed line breaks for the case when the word in a text is bigger than the given width

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -72,8 +72,6 @@ const applyBestFit = (nodes, widths) => {
   let subnodes = nodes;
   const breakpoints = [{ position: 0 }];
 
-  // console.log('nodes', nodes);
-
   while (subnodes.length > 0) {
     const breakpoint = getNextBreakpoint(subnodes, widths, lineNumber);
 

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -36,7 +36,7 @@ const getNextBreakpoint = (subnodes, widths, lineNumber) => {
     }
 
     if (sum.width - sum.shrink > lineLength) {
-      if (i > 0) {
+      if (i >= 1) {
         position = i - 1;
       } else {
         position = i;

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -35,7 +35,14 @@ const getNextBreakpoint = (subnodes, widths, lineNumber) => {
       sum.shrink += node.shrink;
     }
 
-    if (sum.width - sum.shrink > lineLength) break;
+    if (sum.width - sum.shrink > lineLength) {
+      if (i > 0) {
+        position = i - 1;
+      } else {
+        position = i;
+      }
+      break;
+    }
 
     if (node.type === 'penalty' || node.type === 'glue') {
       const ratio = calculateRatio(node);
@@ -61,7 +68,7 @@ const applyBestFit = (nodes, widths) => {
   while (subnodes.length > 0) {
     const breakpoint = getNextBreakpoint(subnodes, widths, lineNumber);
 
-    if (breakpoint) {
+    if (breakpoint !== null) {
       count += breakpoint;
       breakpoints.push({ position: count });
       subnodes = subnodes.slice(breakpoint + 1, subnodes.length);

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -36,22 +36,18 @@ const getNextBreakpoint = (subnodes, widths, lineNumber) => {
     }
 
     if (sum.width - sum.shrink > lineLength) {
-      let j;
-      if (i === 0) {
-        // the first block is always "box" type
-        j = i + 1;
-      } else {
-        j = i;
-      }
+      if (position === null) {
+        let j = i === 0 ? i + 1 : i;
 
-      while (
-        j < subnodes.length &&
-        (subnodes[j].type === 'glue' || subnodes[j].type === 'penalty')
-      ) {
-        j++;
-      }
+        while (
+          j < subnodes.length &&
+          (subnodes[j].type === 'glue' || subnodes[j].type === 'penalty')
+        ) {
+          j++;
+        }
 
-      position = j - 1;
+        position = j - 1;
+      }
       break;
     }
 
@@ -75,6 +71,8 @@ const applyBestFit = (nodes, widths) => {
   let lineNumber = 0;
   let subnodes = nodes;
   const breakpoints = [{ position: 0 }];
+
+  // console.log('nodes', nodes);
 
   while (subnodes.length > 0) {
     const breakpoint = getNextBreakpoint(subnodes, widths, lineNumber);

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -36,7 +36,7 @@ const getNextBreakpoint = (subnodes, widths, lineNumber) => {
     }
 
     if (sum.width - sum.shrink > lineLength) {
-      if (i >= 1) {
+      if (i >= 2) {
         position = i - 1;
       } else {
         position = i;

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -36,11 +36,22 @@ const getNextBreakpoint = (subnodes, widths, lineNumber) => {
     }
 
     if (sum.width - sum.shrink > lineLength) {
-      if (i >= 2) {
-        position = i - 1;
+      let j;
+      if (i === 0) {
+        // the first block is always "box" type
+        j = i + 1;
       } else {
-        position = i;
+        j = i;
       }
+
+      while (
+        j < subnodes.length &&
+        (subnodes[j].type === 'glue' || subnodes[j].type === 'penalty')
+      ) {
+        j++;
+      }
+
+      position = j - 1;
       break;
     }
 

--- a/packages/textkit/tests/engines/linebreaker/bestFit.test.js
+++ b/packages/textkit/tests/engines/linebreaker/bestFit.test.js
@@ -1,0 +1,330 @@
+import applyBestFit from '../../../src/engines/linebreaker/bestFit';
+
+// Sentence: "1234567891011"
+const node1 = [
+  {
+    type: 'box',
+    width: 84.81599999999999,
+    value: {
+      start: 0,
+      end: 12,
+    },
+    hyphenated: true,
+  },
+  {
+    type: 'glue',
+    value: null,
+    width: 0,
+    stretch: 10000,
+    shrink: 0,
+  },
+  {
+    type: 'penalty',
+    width: 0,
+    penalty: -10000,
+    flagged: 1,
+  },
+];
+
+// Sentence: "123 1234567891011"
+const node2 = [
+  {
+    type: 'box',
+    width: 21.204,
+    value: {
+      start: 0,
+      end: 3,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 3,
+      end: 4,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 4,
+      end: 17,
+    },
+    hyphenated: true,
+  },
+  {
+    type: 'glue',
+    value: null,
+    width: 0,
+    stretch: 10000,
+    shrink: 0,
+  },
+  {
+    type: 'penalty',
+    width: 0,
+    penalty: -10000,
+    flagged: 1,
+  },
+];
+
+// Setence: "123 1234567891011 123"
+const node3 = [
+  {
+    type: 'box',
+    width: 21.204,
+    value: {
+      start: 0,
+      end: 3,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 3,
+      end: 4,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 4,
+      end: 17,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 17,
+      end: 18,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 21.204,
+    value: {
+      start: 18,
+      end: 21,
+    },
+    hyphenated: true,
+  },
+  {
+    type: 'glue',
+    value: null,
+    width: 0,
+    stretch: 10000,
+    shrink: 0,
+  },
+  {
+    type: 'penalty',
+    width: 0,
+    penalty: -10000,
+    flagged: 1,
+  },
+];
+
+// Sentence: "123 1234567891011 123 1234567891011"
+const node4 = [
+  {
+    type: 'box',
+    width: 21.204,
+    value: {
+      start: 0,
+      end: 3,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 3,
+      end: 4,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 4,
+      end: 17,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 17,
+      end: 18,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 21.204,
+    value: {
+      start: 18,
+      end: 21,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 21,
+      end: 22,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 22,
+      end: 35,
+    },
+    hyphenated: true,
+  },
+  {
+    type: 'glue',
+    value: null,
+    width: 0,
+    stretch: 10000,
+    shrink: 0,
+  },
+  {
+    type: 'penalty',
+    width: 0,
+    penalty: -10000,
+    flagged: 1,
+  },
+];
+
+// Sentence: "123 1234567891011 1234567891011 1234567891011"
+const node5 = [
+  {
+    type: 'box',
+    width: 21.204,
+    value: {
+      start: 0,
+      end: 3,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 3,
+      end: 4,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 4,
+      end: 17,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 17,
+      end: 18,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 18,
+      end: 31,
+    },
+    hyphenated: false,
+  },
+  {
+    type: 'glue',
+    value: {
+      start: 31,
+      end: 32,
+    },
+    width: 2.724,
+    stretch: 1.362,
+    shrink: 0.908,
+  },
+  {
+    type: 'box',
+    width: 91.88399999999999,
+    value: {
+      start: 32,
+      end: 45,
+    },
+    hyphenated: true,
+  },
+  {
+    type: 'glue',
+    value: null,
+    width: 0,
+    stretch: 10000,
+    shrink: 0,
+  },
+  {
+    type: 'penalty',
+    width: 0,
+    penalty: -10000,
+    flagged: 1,
+  },
+];
+
+const widths = [78, 78];
+
+describe('bestFit', () => {
+  test('should return at least one breakpoint', () => {
+    const nodeArr = [node1, node2, node3, node4, node5];
+    nodeArr.forEach(nodes => {
+      const breakpoints = applyBestFit(nodes, widths);
+      expect(breakpoints.length).toBeGreaterThan(0);
+    });
+  });
+
+  test('should break lines when the sum of widths is bigger than the given widths', () => {
+    const nodeArr = [node1, node2, node3, node4, node5];
+    nodeArr.forEach(nodes => {
+      const breakpoints = applyBestFit(nodes, widths);
+      let count = 0;
+
+      for (let i = 0; i < nodes.length; i += 1) {
+        if (nodes[i].width > widths[0]) {
+          count += 1;
+        }
+      }
+
+      expect(breakpoints.length).toBeGreaterThanOrEqual(count);
+    });
+  });
+});

--- a/packages/textkit/tests/engines/linebreaker/bestFit.test.js
+++ b/packages/textkit/tests/engines/linebreaker/bestFit.test.js
@@ -1,214 +1,72 @@
 import applyBestFit from '../../../src/engines/linebreaker/bestFit';
 
-// Sentence: "1234567891011"
-const node1 = [
-  {
-    type: 'box',
-    width: 84.81599999999999,
-  },
-  {
-    type: 'glue',
-    width: 0,
-    stretch: 10000,
-    shrink: 0,
-  },
-  {
-    type: 'penalty',
-    width: 0,
-    penalty: -10000,
-  },
-];
-
-// Sentence: "123 1234567891011"
-const node2 = [
-  {
-    type: 'box',
-    width: 21.204,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 0,
-    stretch: 10000,
-    shrink: 0,
-  },
-  {
-    type: 'penalty',
-    width: 0,
-    penalty: -10000,
-  },
-];
-
-// Setence: "123 1234567891011 123"
-const node3 = [
-  {
-    type: 'box',
-    width: 21.204,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 21.204,
-  },
-  {
-    type: 'glue',
-    width: 0,
-    stretch: 10000,
-    shrink: 0,
-  },
-  {
-    type: 'penalty',
-    width: 0,
-    penalty: -10000,
-  },
-];
-
-// Sentence: "123 1234567891011 123 1234567891011"
-const node4 = [
-  {
-    type: 'box',
-    width: 21.204,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 21.204,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 0,
-    stretch: 10000,
-    shrink: 0,
-  },
-  {
-    type: 'penalty',
-    width: 0,
-    penalty: -10000,
-  },
-];
-
-// Sentence: "123 1234567891011 1234567891011 1234567891011"
-const node5 = [
-  {
-    type: 'box',
-    width: 21.204,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 2.724,
-    stretch: 1.362,
-    shrink: 0.908,
-  },
-  {
-    type: 'box',
-    width: 91.88399999999999,
-  },
-  {
-    type: 'glue',
-    width: 0,
-    stretch: 10000,
-    shrink: 0,
-  },
-  {
-    type: 'penalty',
-    width: 0,
-    penalty: -10000,
-  },
-];
-
-const widths = [78, 78];
+const width = 50;
 
 describe('bestFit', () => {
   test('should return at least one breakpoint', () => {
-    const nodeArr = [node1, node2, node3, node4, node5];
-    nodeArr.forEach(nodes => {
-      const breakpoints = applyBestFit(nodes, widths);
-      expect(breakpoints.length).toBeGreaterThan(0);
-    });
+    const node = [
+      {
+        type: 'box',
+        width: 25,
+      },
+      {
+        type: 'glue',
+        width: 0,
+        stretch: 10000,
+        shrink: 0,
+      },
+      {
+        type: 'penalty',
+        width: 0,
+        penalty: -10000,
+      },
+    ];
+
+    const breakpoints = applyBestFit(node, [width]);
+    expect(breakpoints.length).toBe(1);
   });
 
-  test('should break lines when the sum of widths is bigger than the given widths', () => {
-    const nodeArr = [node1, node2, node3, node4, node5];
-    nodeArr.forEach(nodes => {
-      const breakpoints = applyBestFit(nodes, widths);
-      let count = 0;
+  test('should break lines when the subnode is bigger than the given widths', () => {
+    const node = [
+      {
+        type: 'box',
+        width: 55,
+      },
+      {
+        type: 'glue',
+        width: 5,
+        stretch: 1,
+        shrink: 1,
+      },
+      {
+        type: 'box',
+        width: 55,
+      },
+      {
+        type: 'glue',
+        width: 5,
+        stretch: 1,
+        shrink: 1,
+      },
+      {
+        type: 'box',
+        width: 25,
+      },
+      {
+        type: 'glue',
+        width: 0,
+        stretch: 10000,
+        shrink: 0,
+      },
+      {
+        type: 'penalty',
+        width: 0,
+        penalty: -10000,
+      },
+    ];
 
-      for (let i = 0; i < nodes.length; i += 1) {
-        if (nodes[i].width > widths[0]) {
-          count += 1;
-        }
-      }
+    const breakpoints = applyBestFit(node, [width]);
 
-      expect(breakpoints.length).toBeGreaterThanOrEqual(count);
-    });
+    expect(breakpoints.length).toBe(3);
   });
 });

--- a/packages/textkit/tests/engines/linebreaker/bestFit.test.js
+++ b/packages/textkit/tests/engines/linebreaker/bestFit.test.js
@@ -5,15 +5,9 @@ const node1 = [
   {
     type: 'box',
     width: 84.81599999999999,
-    value: {
-      start: 0,
-      end: 12,
-    },
-    hyphenated: true,
   },
   {
     type: 'glue',
-    value: null,
     width: 0,
     stretch: 10000,
     shrink: 0,
@@ -22,7 +16,6 @@ const node1 = [
     type: 'penalty',
     width: 0,
     penalty: -10000,
-    flagged: 1,
   },
 ];
 
@@ -31,18 +24,9 @@ const node2 = [
   {
     type: 'box',
     width: 21.204,
-    value: {
-      start: 0,
-      end: 3,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 3,
-      end: 4,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -50,15 +34,9 @@ const node2 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 4,
-      end: 17,
-    },
-    hyphenated: true,
   },
   {
     type: 'glue',
-    value: null,
     width: 0,
     stretch: 10000,
     shrink: 0,
@@ -67,7 +45,6 @@ const node2 = [
     type: 'penalty',
     width: 0,
     penalty: -10000,
-    flagged: 1,
   },
 ];
 
@@ -76,18 +53,9 @@ const node3 = [
   {
     type: 'box',
     width: 21.204,
-    value: {
-      start: 0,
-      end: 3,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 3,
-      end: 4,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -95,18 +63,9 @@ const node3 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 4,
-      end: 17,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 17,
-      end: 18,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -114,15 +73,9 @@ const node3 = [
   {
     type: 'box',
     width: 21.204,
-    value: {
-      start: 18,
-      end: 21,
-    },
-    hyphenated: true,
   },
   {
     type: 'glue',
-    value: null,
     width: 0,
     stretch: 10000,
     shrink: 0,
@@ -131,7 +84,6 @@ const node3 = [
     type: 'penalty',
     width: 0,
     penalty: -10000,
-    flagged: 1,
   },
 ];
 
@@ -140,18 +92,9 @@ const node4 = [
   {
     type: 'box',
     width: 21.204,
-    value: {
-      start: 0,
-      end: 3,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 3,
-      end: 4,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -159,18 +102,9 @@ const node4 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 4,
-      end: 17,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 17,
-      end: 18,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -178,18 +112,9 @@ const node4 = [
   {
     type: 'box',
     width: 21.204,
-    value: {
-      start: 18,
-      end: 21,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 21,
-      end: 22,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -197,15 +122,9 @@ const node4 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 22,
-      end: 35,
-    },
-    hyphenated: true,
   },
   {
     type: 'glue',
-    value: null,
     width: 0,
     stretch: 10000,
     shrink: 0,
@@ -214,7 +133,6 @@ const node4 = [
     type: 'penalty',
     width: 0,
     penalty: -10000,
-    flagged: 1,
   },
 ];
 
@@ -223,18 +141,9 @@ const node5 = [
   {
     type: 'box',
     width: 21.204,
-    value: {
-      start: 0,
-      end: 3,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 3,
-      end: 4,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -242,18 +151,9 @@ const node5 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 4,
-      end: 17,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 17,
-      end: 18,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -261,18 +161,9 @@ const node5 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 18,
-      end: 31,
-    },
-    hyphenated: false,
   },
   {
     type: 'glue',
-    value: {
-      start: 31,
-      end: 32,
-    },
     width: 2.724,
     stretch: 1.362,
     shrink: 0.908,
@@ -280,15 +171,9 @@ const node5 = [
   {
     type: 'box',
     width: 91.88399999999999,
-    value: {
-      start: 32,
-      end: 45,
-    },
-    hyphenated: true,
   },
   {
     type: 'glue',
-    value: null,
     width: 0,
     stretch: 10000,
     shrink: 0,
@@ -297,7 +182,6 @@ const node5 = [
     type: 'penalty',
     width: 0,
     penalty: -10000,
-    flagged: 1,
   },
 ];
 


### PR DESCRIPTION
Hi, I have been experiencing a weird issue related to how `applyBestFit` handles position. 

## Issue
<img width="1270" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/70381940/139654605-66dd9dfe-d06c-4a29-afc4-ac5dda0eddde.png">

- [link to bestFit.js](https://github.com/diegomura/react-pdf/blob/3bcb031858062ca12865de7513c5fb5eb6ab3e4f/packages/textkit/src/engines/linebreaker/bestFit.js)

As you see, the current `applyBestfit` function suddenly stops getting `nextBreakPoint`.
I think this issue occurred because of the two lines. 

1. `getNextBreakpoint` returning null, when it shouldn't
```
if (sum.width - sum.shrink > lineLength) break; // getNextBreakpoint. 
```
In the function, when `sum.width - sum.shrink` is bigger than `lineLength`, it breaks. However, because the default value of position is `null`, in some cases, it just returns `null`. 

It is problematic because it means that after any node that has a width bigger than lineLength, it stops there and doesn't calculate the next breakpoint. 
```javascript
    const breakpoint = getNextBreakpoint(subnodes, widths, lineNumber); // this just returns null 

    if (breakpoint) { 
      count += breakpoint;
      breakpoints.push({ position: count });
      subnodes = subnodes.slice(breakpoint + 1, subnodes.length);
      count++;
      lineNumber++;
    } else {
      // it ends up here even when it has more subnodes to calculate. 
      subnodes = [];
    }
```

So my solution is to give a position value based on `i` value. 

```
    if (sum.width - sum.shrink > lineLength) {
      if (i > 0) {
        position = i - 1;
      } else {
        position = i;
      }
      break;
    }
```

When it is the first block of the subnodes, I think the position value should be '0'. Otherwise, the position has to be `i-1`, because I think it makes more sense not to include the current subnode to the previous one to make it to the next line. 


2. if(breakpoint) condition
```javascript
if (breakpoint !== null) { // breakpoint -> breakpoint !== null
      count += breakpoint;
      breakpoints.push({ position: count });
      subnodes = subnodes.slice(breakpoint + 1, subnodes.length);
      count++;
      lineNumber++;
    } else {
      subnodes = [];
    }
```
I think this should be `breakpoint !== null` because this while loop shouldn't stop when the breakpoint is zero. There could be more subnodes to calculate. 

## Result
<img width="1271" alt="Pasted Graphic 7" src="https://user-images.githubusercontent.com/70381940/139655822-da957b6c-5e4a-447a-b8c0-0a301056d080.png">


Any feedback is welcome! 