### PR TITLE
fix: deduplicate scheduler

### DIFF
--- a/.changeset/metal-stingrays-roll.md
+++ b/.changeset/metal-stingrays-roll.md
@@ -2,4 +2,4 @@
 '@react-pdf/renderer': patch
 ---
 
-removed duplicate `scheduler` package
+removed duplicate of `scheduler` package

--- a/.changeset/metal-stingrays-roll.md
+++ b/.changeset/metal-stingrays-roll.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': patch
+---
+
+removed duplicate `scheduler` package

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -36,7 +36,7 @@
     "queue": "^6.0.1",
     "ramda": "^0.26.1",
     "react-reconciler": "^0.23.0",
-    "scheduler": "^0.15.0"
+    "scheduler": "^0.17.0"
   },
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8994,14 +8994,6 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-scheduler@^0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.15.0.tgz#6bfcf80ff850b280fed4aeecc6513bc0b4f17f8e"
-  integrity sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-
 scheduler@^0.17.0:
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"


### PR DESCRIPTION
`@react-pdf/renderer` uses `scheduler@0.15.0`
`react-reconciler@0.23.0` uses `scheduler@0.17.0`

as result we have two `scheduler` instances in bundle
<img width="523" alt="Снимок экрана 2021-11-21 в 14 11 02" src="https://user-images.githubusercontent.com/6726016/142760983-50ed626f-2655-4c28-80e5-bdad2ed68d3a.png">

pr fix this

