### PR TITLE
fix: import only `md5` hash from `crypto-js`

### DIFF
--- a/.changeset/violet-pears-bake.md
+++ b/.changeset/violet-pears-bake.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+replaced `crypto-js` with `crypto-js/md5` to reduce bundle size

--- a/packages/pdfkit/rollup.config.js
+++ b/packages/pdfkit/rollup.config.js
@@ -9,11 +9,11 @@ import pkg from './package.json';
 
 const cjs = {
   exports: 'named',
-  format: 'cjs',
+  format: 'cjs'
 };
 
 const esm = {
-  format: 'es',
+  format: 'es'
 };
 
 const getCJS = override => Object.assign({}, cjs, override);
@@ -31,70 +31,72 @@ const babelConfig = ({ browser }) => ({
         modules: false,
         ...(browser
           ? { targets: { browsers: 'last 2 versions' } }
-          : { targets: { node: '12' } }),
-      },
-    ],
-  ],
+          : { targets: { node: '12' } })
+      }
+    ]
+  ]
 });
 
 const configBase = {
   input: 'src/index.js',
   plugins: [nodeResolve(), json()],
-  external: Object.keys(pkg.dependencies),
+  external: Object.keys(pkg.dependencies).map(dep =>
+    dep === 'crypto-js' ? 'crypto-js/md5' : dep
+  ),
   onwarn: (warning, rollupWarn) => {
     if (warning.code !== 'CIRCULAR_DEPENDENCY') {
       rollupWarn(warning);
     }
-  },
+  }
 };
 
 const serverConfig = Object.assign({}, configBase, {
   output: [
     getESM({ file: 'lib/pdfkit.es.js' }),
-    getCJS({ file: 'lib/pdfkit.cjs.js' }),
+    getCJS({ file: 'lib/pdfkit.cjs.js' })
   ],
   plugins: configBase.plugins.concat(
     babel(babelConfig({ browser: false })),
     replace({
-      BROWSER: JSON.stringify(false),
-    }),
+      BROWSER: JSON.stringify(false)
+    })
   ),
-  external: configBase.external.concat(['fs']),
+  external: configBase.external.concat(['fs'])
 });
 
 const serverProdConfig = Object.assign({}, serverConfig, {
   output: [
     getESM({ file: 'lib/pdfkit.es.min.js' }),
-    getCJS({ file: 'lib/pdfkit.cjs.min.js' }),
+    getCJS({ file: 'lib/pdfkit.cjs.min.js' })
   ],
-  plugins: serverConfig.plugins.concat(terser()),
+  plugins: serverConfig.plugins.concat(terser())
 });
 
 const browserConfig = Object.assign({}, configBase, {
   output: [
     getESM({ file: 'lib/pdfkit.browser.es.js' }),
-    getCJS({ file: 'lib/pdfkit.browser.cjs.js' }),
+    getCJS({ file: 'lib/pdfkit.browser.cjs.js' })
   ],
   plugins: configBase.plugins.concat(
     babel(babelConfig({ browser: true })),
     replace({
-      BROWSER: JSON.stringify(true),
+      BROWSER: JSON.stringify(true)
     }),
-    ignore(['fs']),
-  ),
+    ignore(['fs'])
+  )
 });
 
 const browserProdConfig = Object.assign({}, browserConfig, {
   output: [
     getESM({ file: 'lib/pdfkit.browser.es.min.js' }),
-    getCJS({ file: 'lib/pdfkit.browser.cjs.min.js' }),
+    getCJS({ file: 'lib/pdfkit.browser.cjs.min.js' })
   ],
-  plugins: browserConfig.plugins.concat(terser()),
+  plugins: browserConfig.plugins.concat(terser())
 });
 
 export default [
   serverConfig,
   serverProdConfig,
   browserConfig,
-  browserProdConfig,
+  browserProdConfig
 ];

--- a/packages/pdfkit/src/mixins/attachments.js
+++ b/packages/pdfkit/src/mixins/attachments.js
@@ -1,6 +1,5 @@
 import fs from 'fs';
-import CryptoJS from 'crypto-js/core';
-import MD5 from 'crypto-js/md5';
+import CryptoJS from 'crypto-js/md5';
 
 export default {
   /**
@@ -66,7 +65,9 @@ export default {
     }
 
     // add checksum and size information
-    const checksum = MD5(CryptoJS.lib.WordArray.create(new Uint8Array(data)));
+    const checksum = CryptoJS.MD5(
+      CryptoJS.lib.WordArray.create(new Uint8Array(data))
+    );
     refBody.Params.CheckSum = new String(checksum);
     refBody.Params.Size = data.byteLength;
 

--- a/packages/pdfkit/src/mixins/attachments.js
+++ b/packages/pdfkit/src/mixins/attachments.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
-import CryptoJS from 'crypto-js';
+import CryptoJS from 'crypto-js/core';
+import MD5 from 'crypto-js/md5';
 
 export default {
   /**
@@ -65,9 +66,7 @@ export default {
     }
 
     // add checksum and size information
-    const checksum = CryptoJS.MD5(
-      CryptoJS.lib.WordArray.create(new Uint8Array(data))
-    );
+    const checksum = MD5(CryptoJS.lib.WordArray.create(new Uint8Array(data)));
     refBody.Params.CheckSum = new String(checksum);
     refBody.Params.Size = data.byteLength;
 


### PR DESCRIPTION
`crypto-js` contains a lot of hash algorithms and functions, but `pdfkit` uses only `md5`
I change the imports to include only `md5` code to bundle, it should save `~42kb`

<img width="1323" alt="Снимок экрана 2021-11-22 в 10 29 52" src="https://user-images.githubusercontent.com/6726016/142821207-f063fd25-affa-4ab6-b32d-5e5ca6830ac2.png">


