### PR TITLE
fix : bug fix about husky & lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "git add . && lint-staged"
+      "pre-commit": "lint-staged"
     }
   },
   "dependencies": {}


### PR DESCRIPTION
Hello! @jeetiss :)

We're here again~~
We read your issue #1625 , and we think that we solved this issue!

In the package.json file, "husky" part might cause problem.
In "pre-commit" part, we think "git add ." is useless and it cause bug.
So we deleted "git add ." and when we add/commit 1 file of 2 file(or more),  it was confirmed that only the added file was uploaded.

If our fix is wrong, please comment us!
Thank you for reading this PR, and have a wonderful day~!

Desktop
- OS : Windows 10
- Browser : Chrome
- React-pdf version : 2.0.0