### PR TITLE
chore: updated babel runtime and added it to all packages

### DIFF
--- a/.changeset/seven-moles-pull.md
+++ b/.changeset/seven-moles-pull.md
@@ -1,0 +1,14 @@
+---
+'@react-pdf/font': minor
+'@react-pdf/fontkit': minor
+'@react-pdf/image': minor
+'@react-pdf/layout': minor
+'@react-pdf/pdfkit': minor
+'@react-pdf/render': minor
+'@react-pdf/renderer': minor
+'@react-pdf/stylesheet': minor
+'@react-pdf/svgkit': minor
+'@react-pdf/textkit': minor
+---
+
+added `@babel/runtime` to dependencies

--- a/babel.config.js
+++ b/babel.config.js
@@ -13,7 +13,7 @@ module.exports = {
     '@babel/preset-react',
   ],
   plugins: [
-    '@babel/plugin-transform-runtime',
+    ['@babel/plugin-transform-runtime', { version: '^7.16.4' }],
     ['@babel/plugin-proposal-decorators', { legacy: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
     '@babel/plugin-proposal-optional-chaining',

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -20,6 +20,7 @@
     "watch": "rimraf ./lib && rollup -c -w"
   },
   "dependencies": {
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/fontkit": "^2.0.7",
     "@react-pdf/types": "^2.0.7",
     "cross-fetch": "^3.0.4",

--- a/packages/fontkit/package.json
+++ b/packages/fontkit/package.json
@@ -26,7 +26,7 @@
   "author": "Devon Govett <devongovett@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "@babel/runtime": "^7.6.2",
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/unicode-properties": "^2.4.2",
     "brotli": "^1.2.0",
     "clone": "^1.0.4",

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -20,6 +20,7 @@
     "watch": "rimraf ./lib && rollup -c -w"
   },
   "dependencies": {
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/png-js": "^2.0.3",
     "cross-fetch": "^3.0.4"
   },

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -17,7 +17,7 @@
     "watch": "rimraf ./lib && babel src --out-dir lib --watch"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2",
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/image": "^2.0.4",
     "@react-pdf/pdfkit": "^2.0.12",
     "@react-pdf/primitives": "^2.0.1",

--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -28,6 +28,7 @@
     "lib"
   ],
   "dependencies": {
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/fontkit": "^2.0.7",
     "@react-pdf/png-js": "^2.0.3",
     "crypto-js": "^4.0.0"

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -16,7 +16,8 @@
     "build": "rimraf ./lib && babel src --out-dir lib",
     "watch": "rimraf ./lib && babel src --out-dir lib --watch"
   },
-  "dependencies": {
+  "dependencies": { 
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/primitives": "^2.0.1",
     "@react-pdf/textkit": "^2.0.7",
     "@react-pdf/types": "^2.0.7",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -25,7 +25,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@babel/runtime": "^7.6.2",
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/font": "^2.0.14",
     "@react-pdf/layout": "^2.0.21",
     "@react-pdf/pdfkit": "^2.0.12",

--- a/packages/stylesheet/package.json
+++ b/packages/stylesheet/package.json
@@ -17,6 +17,7 @@
     "watch": "rimraf ./lib && babel src --out-dir lib --watch"
   },
   "dependencies": {
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/types": "^2.0.7",
     "color-string": "^1.5.3",
     "hsl-to-hex": "^1.0.0",

--- a/packages/svgkit/package.json
+++ b/packages/svgkit/package.json
@@ -21,7 +21,7 @@
     "lib"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.4.3",
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/pdfkit": "^2.0.12",
     "ramda": "^0.26.1"
   }

--- a/packages/textkit/package.json
+++ b/packages/textkit/package.json
@@ -22,7 +22,7 @@
     "lib"
   ],
   "dependencies": {
-    "@babel/runtime": "^7.4.3",
+    "@babel/runtime": "^7.16.4",
     "@react-pdf/unicode-properties": "^2.4.2",
     "hyphen": "^1.6.4",
     "ramda": "^0.26.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -964,10 +964,10 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.4.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.8.4":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.0.tgz#e27b977f2e2088ba24748bf99b5e1dece64e4f0b"
-  integrity sha512-Nht8L0O8YCktmsDV6FqFue7vQLRx3Hb0B37lS5y0jDRqRxlBG4wIJHnf9/bgSE2UyipKFA01YtS+npRdTWBUyw==
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.10.4", "@babel/runtime@^7.11.2", "@babel/runtime@^7.16.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.8.4":
+  version "7.16.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.16.5.tgz#7f3e34bf8bdbbadf03fbb7b1ea0d929569c9487a"
+  integrity sha512-TXWihFIS3Pyv5hzR7j6ihmeLkZfrXGxAr5UfSl8CHf+6q/wpiYDkUau0czckpYG8QmnCIuPpdLtuA9VmuGGyMA==
   dependencies:
     regenerator-runtime "^0.13.4"
 


### PR DESCRIPTION
some packages use `@babel/runtime`, but didn't have it in dependencies. this pr fixes that
