### PR TITLE
fix: define renderToStream to return promise

### DIFF
--- a/.changeset/hip-trainers-tickle.md
+++ b/.changeset/hip-trainers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': patch
+---
+
+defined renderToStream to return promise

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -497,7 +497,7 @@ declare namespace ReactPDF {
     document: React.ReactElement<DocumentProps>,
   ) => Promise<NodeJS.ReadableStream>;
 
-  const renderToString: (document: React.ReactElement<DocumentProps>) => string;
+  const renderToString: (document: React.ReactElement<DocumentProps>) => Promise<string>;
 
   const renderToFile: (
     document: React.ReactElement<DocumentProps>,


### PR DESCRIPTION
The old return type was `string` which is wrong, because it returns a `promise` which resolves in a `string` instead.

This pull request fixes the warning `'await' has no effect on the type of this expression` when using it like this:
```ts
    const document = await ReactPDF.renderToString(...)
```