### PR TITLE
chore: upgrade to latest ramda

### DIFF
--- a/packages/examples/package.json
+++ b/packages/examples/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@react-pdf/renderer": "^2.0.6",
     "camelcase": "^6.2.0",
-    "ramda": "^0.27.1"
+    "ramda": "^0.28.0"
   },
   "peerDependencies": {
     "react": "^16.8.6 || ^17.0.0",

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -28,7 +28,7 @@
     "cross-fetch": "^3.1.5",
     "emoji-regex": "^8.0.0",
     "queue": "^6.0.1",
-    "ramda": "^0.26.1"
+    "ramda": "^0.28.0"
   },
   "devDependencies": {
     "jest-fetch-mock": "^2.1.1"

--- a/packages/layout/src/steps/resolveStyles.js
+++ b/packages/layout/src/steps/resolveStyles.js
@@ -18,7 +18,7 @@ const LINK_STYLES = {
  */
 const resolveNodeStyles = container => node =>
   R.o(
-    R.when(isLink, R.evolve({ style: R.merge(LINK_STYLES) })),
+    R.when(isLink, R.evolve({ style: R.mergeRight(LINK_STYLES) })),
     R.evolve({
       style: stylesheet(container),
       children: R.map(resolveNodeStyles(container)),

--- a/packages/layout/src/steps/resolveSvg.js
+++ b/packages/layout/src/steps/resolveSvg.js
@@ -93,7 +93,7 @@ const parseProps = container =>
 
 const mergeStyles = node => {
   const style = node.style || {};
-  return R.evolve({ props: R.merge(style) }, node);
+  return R.evolve({ props: R.mergeRight(style) }, node);
 };
 
 const removeNoneValues = R.evolve({
@@ -103,7 +103,7 @@ const removeNoneValues = R.evolve({
 const pickStyleProps = node => {
   const props = node.props || {};
   const styleProps = R.pick(STYLE_PROPS, props);
-  return R.evolve({ style: R.merge(styleProps) }, node);
+  return R.evolve({ style: R.mergeRight(styleProps) }, node);
 };
 
 const parseSvgProps = R.evolve({

--- a/packages/layout/src/svg/inheritProps.js
+++ b/packages/layout/src/svg/inheritProps.js
@@ -43,7 +43,7 @@ const inheritProps = node => {
       R.compose(
         inheritProps,
         R.evolve({
-          props: R.merge(props),
+          props: R.mergeRight(props),
         }),
       ),
     ),

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -25,7 +25,7 @@
     "color-string": "^1.5.3",
     "normalize-svg-path": "^1.1.0",
     "parse-svg-path": "^0.1.2",
-    "ramda": "^0.26.1",
+    "ramda": "^0.28.0",
     "svg-arc-to-cubic-bezier": "^3.2.0"
   },
   "files": [

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -34,7 +34,7 @@
     "@react-pdf/types": "^2.0.8",
     "blob-stream": "^0.1.3",
     "queue": "^6.0.1",
-    "ramda": "^0.26.1",
+    "ramda": "^0.28.0",
     "react-reconciler": "^0.23.0",
     "scheduler": "^0.17.0"
   },

--- a/packages/stylesheet/package.json
+++ b/packages/stylesheet/package.json
@@ -23,7 +23,7 @@
     "hsl-to-hex": "^1.0.0",
     "media-engine": "^1.0.3",
     "postcss-value-parser": "^4.1.0",
-    "ramda": "^0.26.1"
+    "ramda": "^0.28.0"
   },
   "files": [
     "lib"

--- a/packages/svgkit/package.json
+++ b/packages/svgkit/package.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "@babel/runtime": "^7.16.4",
     "@react-pdf/pdfkit": "^2.1.0",
-    "ramda": "^0.26.1"
+    "ramda": "^0.28.0"
   }
 }

--- a/packages/textkit/package.json
+++ b/packages/textkit/package.json
@@ -25,6 +25,6 @@
     "@babel/runtime": "^7.16.4",
     "@react-pdf/unicode-properties": "^2.5.0",
     "hyphen": "^1.6.4",
-    "ramda": "^0.26.1"
+    "ramda": "^0.28.0"
   }
 }

--- a/packages/textkit/src/attributedString/runAt.js
+++ b/packages/textkit/src/attributedString/runAt.js
@@ -10,7 +10,7 @@ import runIndexAt from './runIndexAt';
  * @return {Object} run
  */
 const runAt = (n, attributedString) => {
-  const runIndex = runIndexAt(n)(attributedString);
+  const runIndex = R.max(runIndexAt(n)(attributedString))(null);
   return R.path(['runs', runIndex])(attributedString);
 };
 

--- a/packages/textkit/src/engines/justification/getFactors.js
+++ b/packages/textkit/src/engines/justification/getFactors.js
@@ -38,8 +38,8 @@ const getCharFactor = (direction, options) => {
   const shrinkCharFactor = R.propOr({}, 'shrinkCharFactor', options);
 
   return direction === 'GROW'
-    ? R.merge(EXPAND_CHAR_FACTOR, expandCharFactor)
-    : R.merge(SHRINK_CHAR_FACTOR, shrinkCharFactor);
+    ? R.mergeRight(EXPAND_CHAR_FACTOR, expandCharFactor)
+    : R.mergeRight(SHRINK_CHAR_FACTOR, shrinkCharFactor);
 };
 
 const getWhitespaceFactor = (direction, options) => {
@@ -55,8 +55,8 @@ const getWhitespaceFactor = (direction, options) => {
   );
 
   return direction === 'GROW'
-    ? R.merge(EXPAND_WHITESPACE_FACTOR, expandWhitespaceFactor)
-    : R.merge(SHRINK_WHITESPACE_FACTOR, shrinkWhitespaceFactor);
+    ? R.mergeRight(EXPAND_WHITESPACE_FACTOR, expandWhitespaceFactor)
+    : R.mergeRight(SHRINK_WHITESPACE_FACTOR, shrinkWhitespaceFactor);
 };
 
 const factor = (direction, options) => glyphs => {

--- a/packages/textkit/src/engines/wordHyphenation/index.js
+++ b/packages/textkit/src/engines/wordHyphenation/index.js
@@ -9,7 +9,7 @@ const splitHyphen = R.split(SOFT_HYPHEN);
 const cache = {};
 
 const getParts = R.ifElse(
-  R.contains(SOFT_HYPHEN),
+  R.includes(SOFT_HYPHEN),
   splitHyphen,
   R.o(splitHyphen, hyphenator),
 );

--- a/packages/textkit/src/run/concat.js
+++ b/packages/textkit/src/run/concat.js
@@ -3,7 +3,7 @@ import * as R from 'ramda';
 import length from './length';
 import normalizeIndices from '../indices/normalize';
 
-const reverseMerge = R.flip(R.merge);
+const reverseMerge = R.flip(R.mergeRight);
 const reverseConcat = R.flip(R.concat);
 
 /**

--- a/packages/textkit/src/run/flatten.js
+++ b/packages/textkit/src/run/flatten.js
@@ -6,7 +6,7 @@ import isEmpty from './isEmpty';
 const sortPoints = (a, b) => a[1] - b[1] || a[3] - b[3];
 
 const mergeAttributes = (key, left, right) =>
-  key === 'attributes' ? R.merge(left, right) : right;
+  key === 'attributes' ? R.mergeRight(left, right) : right;
 
 const generatePoints = R.o(
   R.sort(sortPoints),
@@ -38,7 +38,7 @@ const flattenRegularRuns = runs => {
 
     if (type === 'start') {
       stack.push(attributes);
-      attrs = R.merge(attrs, attributes);
+      attrs = R.mergeRight(attrs, attributes);
     } else {
       attrs = {};
 
@@ -47,7 +47,7 @@ const flattenRegularRuns = runs => {
           // eslint-disable-next-line no-plusplus
           stack.splice(j--, 1);
         } else {
-          attrs = R.merge(attrs, stack[j]);
+          attrs = R.mergeRight(attrs, stack[j]);
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8868,15 +8868,10 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-ramda@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
-
-ramda@^0.27.1:
-  version "0.27.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
-  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
+ramda@^0.28.0:
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.28.0.tgz#acd785690100337e8b063cab3470019be427cc97"
+  integrity sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA==
 
 randombytes@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Fixes a vulnerability with an outdated version of ramda: https://snyk.io/test/npm/@react-pdf/renderer/2.1.1