### PR TITLE
doc: updated README to work for case insensitive systems using webpack 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Webpack 5 doesn't include node shims automatically anymore and we must opt-in to
 
 ```sh
 yarn add process browserify-zlib stream-browserify util buffer assert
+yarn add -D imports-loader
 ```
 
 after the modules are installed, we need to adjust our `webpack.config` file:
@@ -55,11 +56,19 @@ module.exports = {
       asset: require.resolve("assert"),
     }
   },
-  plugins: [
-    new webpack.ProvidePlugin({
-      Buffer: ["buffer", "Buffer"],
-      process: "process/browser",
-    }),
+  rules: [
+    {
+      test: /restructure\/src\/[^w].js/,
+      use: [
+        {
+          loader: "imports-loader",
+          options: {
+            type: "commonjs",
+            imports: "multiple ../../buffer/ Buffer Buffer",
+          },
+        },
+      ],
+    }
   ]
 
   /* ... */

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ module.exports = {
   },
   rules: [
     {
-      test: /restructure\/src\/[^w].js/,
+      test: /restructure(\/|\\)src(\/|\\)[\w]+.js/,
       use: [
         {
           loader: "imports-loader",


### PR DESCRIPTION
Solves #1732
https://github.com/diegomura/react-pdf/issues/1029#issuecomment-1050397049
https://github.com/diegomura/react-pdf/issues/1029#issuecomment-997211684

Instead of looking for the buffer library using require('buffer').Buffer (that will look first for relative files and then for global path), it will look for a relative path to the node_modules/buffer/
In that way, we will be sure to import the library even if we have a non-case sensitive OS