### PR TITLE
docs: fixed typo in webpack 5 config

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ module.exports = {
       stream: require.resolve("stream-browserify"),
       util: require.resolve("util"),
       buffer: require.resolve("buffer"),
-      asset: require.resolve("assert"),
+      assert: require.resolve("assert"),
     }
   },
   plugins: [


### PR DESCRIPTION
I believe `assert` should be the right key for the configuration object?