### PR TITLE
Instruct contributors to install before bootstrap

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,6 +46,7 @@ Other versions should work although I can't guarantee it
 We need to download this project dependencies in order to make it work. Because this is a monorepo, we also have to bind all the internal packages together so they are aware of each other. Both things can be done by running:
 
 ```sh
+yarn install 
 yarn bootstrap
 ```
 


### PR DESCRIPTION
As I was working to get setup to contribute, I followed the instructions in the contribution guide. I didn't previously have `lerna` so I first had to run `yarn install` before I could `yarn bootstrap`.