### PR TITLE
refactor: remove ramda from svgkit

### DIFF
--- a/.changeset/green-mangos-begin.md
+++ b/.changeset/green-mangos-begin.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/svgkit': minor
+---
+
+refactor: remove ramda from svgkit

--- a/packages/svgkit/package.json
+++ b/packages/svgkit/package.json
@@ -22,7 +22,6 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.16.4",
-    "@react-pdf/pdfkit": "^2.1.0",
-    "ramda": "^0.26.1"
+    "@react-pdf/pdfkit": "^2.1.0"
   }
 }

--- a/packages/svgkit/src/utils/getPageSize.js
+++ b/packages/svgkit/src/utils/getPageSize.js
@@ -1,5 +1,3 @@
-import * as R from 'ramda';
-
 const PAGE_SIZES = {
   '4A0': [4767.87, 6740.79],
   '2A0': [3370.39, 4767.87],
@@ -89,15 +87,6 @@ const getStringSize = v => {
 const getNumberSize = n => toSizeObject([n]);
 
 /**
- * Throws invalid size error
- *
- * @param {String} invalid page size input
- */
-const throwInvalidError = size => {
-  throw new Error(`Invalid Page size: ${JSON.stringify(size)}`);
-};
-
-/**
  * // TODO: Move this to separate pacjage to reuse with layout
  * Return page size in an object { width, height }
  *
@@ -105,13 +94,15 @@ const throwInvalidError = size => {
  * @returns {Object} size object with width and height
  */
 const getSize = (value, orientation) => {
-  const size = R.cond([
-    [R.is(String), getStringSize],
-    [R.is(Array), toSizeObject],
-    [R.is(Number), getNumberSize],
-    [R.is(Object), R.identity],
-    [R.T, throwInvalidError],
-  ])(value);
+  let size = value;
+
+  if (typeof size === 'string') {
+    size = getStringSize(value);
+  } else if (Array.isArray(value)) {
+    size = toSizeObject(value);
+  } else if (typeof size === 'number') {
+    size = getNumberSize(value);
+  }
 
   return orientation === 'landscape' ? flipSizeObject(size) : size;
 };


### PR DESCRIPTION
Gradually start removing ramda. Although I like it, it's probably confusing for most people, it's slow and adds unneccesary bundle size. Some helper fns will still be needed. For the moment I moved them to utils dir, in the future it worths building our own set of light and reusable utils