### PR TITLE
refactor: remove unused ramda dependency from renderer

### DIFF
--- a/.changeset/great-candles-retire.md
+++ b/.changeset/great-candles-retire.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': patch
+---
+
+refactor: remove unused ramda dependency

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -34,7 +34,6 @@
     "@react-pdf/types": "^2.0.8",
     "blob-stream": "^0.1.3",
     "queue": "^6.0.1",
-    "ramda": "^0.26.1",
     "react-reconciler": "^0.23.0",
     "scheduler": "^0.17.0"
   },


### PR DESCRIPTION
Gradually start removing ramda. Although I like it, it's probably confusing for most people, it's slow and adds unneccesary bundle size. Some helper fns will still be needed. For the moment I moved them to utils dir, in the future it worths building our own set of light and reusable utils