### PR TITLE
refactor: encode unicode trie as base64

### DIFF
--- a/.changeset/khaki-tomatoes-live.md
+++ b/.changeset/khaki-tomatoes-live.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/unicode-properties': minor
+---
+
+refactor: encode unicode trie as base64

--- a/packages/unicode-properties/generate.js
+++ b/packages/unicode-properties/generate.js
@@ -104,7 +104,11 @@ for (codePoint of Array.from(codePoints)) {
 
 // Trie is serialized suboptimally as JSON so it can be loaded via require,
 // allowing unicode-properties to work in the browser
-fs.writeFileSync('./trie.json', JSON.stringify(trie.toBuffer()));
+fs.writeFileSync(
+  './trie.json',
+  JSON.stringify({ data: trie.toBuffer().toString('base64') }),
+);
+
 fs.writeFileSync(
   './data.json',
   JSON.stringify({

--- a/packages/unicode-properties/index.js
+++ b/packages/unicode-properties/index.js
@@ -5,7 +5,7 @@ import trieBuffer from './trie.json';
 
 // Trie is serialized as a Buffer in node, but here
 // we may be running in a browser so we make an Uint8Array
-const trieData = new Uint8Array(trieBuffer.data);
+const trieData = new Uint8Array(Buffer.from(trieBuffer.data, 'base64'));
 const trie = new UnicodeTrie(trieData);
 
 const log2 = Math.log2 || (n => Math.log(n) / Math.LN2);


### PR DESCRIPTION
Encodes trie data as base64 instead of raw buffer to reduce package size. Based on some quick estimations this reduces `@react-pdf/unicode-properties` size by half (from ~40kb to ~20kb). It's not much but every kb counts to reduce the lib overall bundle size