### PR TITLE
fix: remove not supported type

### DIFF
--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -12,7 +12,6 @@ export interface Style {
   flexShrink?: number;
   flexBasis?: number | string;
   justifyContent?: 'flex-start' | 'flex-end' | 'center' | 'space-around' | 'space-between' | 'space-evenly';
-  order?: number;
 
   // Layout
 


### PR DESCRIPTION
Reverts https://github.com/diegomura/react-pdf/pull/1755

I'll remove that style from the site once published