### PR TITLE
fix: publish primitives packages as CommonJS

### DIFF
--- a/.changeset/selfish-planets-arrive.md
+++ b/.changeset/selfish-planets-arrive.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/primitives': patch
+---
+
+publish commonjs files to npm

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -17,6 +17,7 @@
     "test": "jest"
   },
   "files": [
+    "lib",
     "src"
   ]
 }


### PR DESCRIPTION
I forget to add the lib folder with CommonJS build to published files

fix #1844
