### PR TITLE
feat: build render package as ES module

### DIFF
--- a/.changeset/warm-mangos-learn.md
+++ b/.changeset/warm-mangos-learn.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/render': patch
+---
+
+feat: build render package as ES module

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -5,7 +5,8 @@
   "description": "A render engine for Node and the browser",
   "author": "Diego Muracciole <diegomuracciole@gmail.com>",
   "homepage": "https://github.com/diegomura/react-pdf#readme",
-  "main": "lib/index.js",
+  "main": "lib/index.cjs.js",
+  "module": "lib/index.es.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/diegomura/react-pdf.git",
@@ -13,8 +14,8 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "rimraf ./lib && babel src --out-dir lib",
-    "watch": "rimraf ./lib && babel src --out-dir lib --watch"
+    "build": "rimraf ./lib && rollup -c",
+    "watch": "rimraf ./lib && rollup -c -w"
   },
   "dependencies": {
     "@babel/runtime": "^7.16.4",

--- a/packages/render/rollup.config.js
+++ b/packages/render/rollup.config.js
@@ -1,0 +1,47 @@
+import json from '@rollup/plugin-json';
+import babel from '@rollup/plugin-babel';
+import { terser } from 'rollup-plugin-terser';
+
+import pkg from './package.json';
+
+const cjs = {
+  exports: 'named',
+  format: 'cjs',
+};
+
+const esm = {
+  format: 'es',
+};
+
+const getCJS = override => Object.assign({}, cjs, override);
+const getESM = override => Object.assign({}, esm, override);
+
+const configBase = {
+  input: 'src/index.js',
+  external: Object.keys(pkg.dependencies),
+  plugins: [
+    json(),
+    babel({
+      babelrc: true,
+      babelHelpers: 'runtime',
+      exclude: 'node_modules/**',
+    }),
+  ],
+};
+
+const config = Object.assign({}, configBase, {
+  output: [
+    getESM({ file: 'lib/index.es.js' }),
+    getCJS({ file: 'lib/index.cjs.js' }),
+  ],
+});
+
+const prodConfig = Object.assign({}, configBase, {
+  output: [
+    getESM({ file: 'lib/index.es.min.js' }),
+    getCJS({ file: 'lib/index.cjs.min.js' }),
+  ],
+  plugins: configBase.plugins.concat(terser()),
+});
+
+export default [config, prodConfig];


### PR DESCRIPTION
`@react-pdf/render` was only being published as a CJS module, causing the wrong resolution of `normalize-svg-path` [here](https://github.com/jkroso/normalize-svg-path/blob/master/package.json#L13-L14) on webpack 5. 

Fixes #1831