### PR TITLE
feat: bookmarks support

### DIFF
--- a/.changeset/cuddly-kiwis-pump.md
+++ b/.changeset/cuddly-kiwis-pump.md
@@ -1,0 +1,8 @@
+---
+'@react-pdf/layout': minor
+'@react-pdf/pdfkit': minor
+'@react-pdf/render': minor
+'@react-pdf/types': minor
+---
+
+feat: bookmarks support

--- a/packages/layout/src/index.js
+++ b/packages/layout/src/index.js
@@ -5,6 +5,7 @@ import resolveZIndex from './steps/resolveZIndex';
 import resolveAssets from './steps/resolveAssets';
 import resolveStyles from './steps/resolveStyles';
 import resolveOrigins from './steps/resolveOrigins';
+import resolveBookmarks from './steps/resolveBookmarks';
 import resolvePageSizes from './steps/resolvePageSizes';
 import resolvePagination from './steps/resolvePagination';
 import resolveDimensions from './steps/resolveDimensions';
@@ -29,6 +30,7 @@ const layout = asyncCompose(
   resolvePagePaddings,
   resolveStyles,
   resolveLinkSubstitution,
+  resolveBookmarks,
   resolvePageSizes,
 );
 

--- a/packages/layout/src/steps/resolveBookmarks.js
+++ b/packages/layout/src/steps/resolveBookmarks.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-plusplus */
+/* eslint-disable prefer-const */
+/* eslint-disable prefer-destructuring */
+
+const getBookmarkValue = title => {
+  return typeof title === 'string'
+    ? { title, fit: false, expanded: false }
+    : title;
+};
+
+const resolveBookmarks = node => {
+  let refs = 0;
+
+  const children = (node.children || []).slice(0);
+  const listToExplore = children.map(value => ({ value, parent: null }));
+
+  while (listToExplore.length > 0) {
+    const element = listToExplore.shift();
+    const child = element.value;
+
+    let parent = element.parent;
+
+    if (child.props?.bookmark) {
+      const bookmark = getBookmarkValue(child.props.bookmark);
+      const ref = refs++;
+      const newHierarchy = { ref, parent: parent?.ref, ...bookmark };
+
+      child.props.bookmark = newHierarchy;
+      parent = newHierarchy;
+    }
+
+    if (child.children) {
+      child.children.forEach(childNode => {
+        listToExplore.push({ value: childNode, parent });
+      });
+    }
+  }
+
+  return node;
+};
+
+export default resolveBookmarks;

--- a/packages/layout/src/steps/resolvePagination.js
+++ b/packages/layout/src/steps/resolvePagination.js
@@ -190,8 +190,14 @@ const splitPage = (page, pageNumber, fontStore) => {
     return [currentPage, null];
 
   const nextBox = omit('height', page.box);
+  const nextProps = omit('bookmark', page.props);
+
   const nextPage = relayout(
-    Object.assign({}, page, { box: nextBox, children: nextChilds }),
+    Object.assign({}, page, {
+      props: nextProps,
+      box: nextBox,
+      children: nextChilds,
+    }),
   );
 
   return [currentPage, nextPage];

--- a/packages/layout/tests/steps/resolveBookmarks.test.js
+++ b/packages/layout/tests/steps/resolveBookmarks.test.js
@@ -1,0 +1,146 @@
+import resolveBookmarks from '../../src/steps/resolveBookmarks';
+
+describe('layout resolveBookmarks', () => {
+  test('should keep nodes the same if no bookmark passed', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    };
+    const result = resolveBookmarks(root);
+
+    expect(result).toEqual(root);
+  });
+
+  test('should resolve bookmark in page node', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          props: { bookmark: 'page' },
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    };
+    const result = resolveBookmarks(root);
+
+    expect(result.children[0].props.bookmark).toEqual({
+      ref: 0,
+      title: 'page',
+      fit: false,
+      expanded: false,
+    });
+  });
+
+  test('should resolve bookmark hierarchy', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          props: { bookmark: 'page' },
+          children: [
+            {
+              type: 'VIEW',
+              children: [
+                {
+                  type: 'VIEW',
+                  children: [
+                    {
+                      type: 'VIEW',
+                      props: {
+                        bookmark: 'sub chapter',
+                      },
+                    },
+                  ],
+                  props: {
+                    bookmark: 'chapter 1',
+                  },
+                },
+              ],
+              props: {},
+            },
+            {
+              type: 'VIEW',
+              props: {
+                bookmark: 'chapter 2',
+              },
+            },
+          ],
+        },
+      ],
+    };
+    const result = resolveBookmarks(root);
+    const page = result.children[0];
+    const view = page.children[1];
+    const nestedView = page.children[0].children[0];
+    const subNestedView = nestedView.children[0];
+
+    expect(page.props.bookmark).toEqual({
+      ref: 0,
+      title: 'page',
+      fit: false,
+      expanded: false,
+    });
+
+    expect(view.props.bookmark).toEqual({
+      ref: 1,
+      parent: 0,
+      title: 'chapter 2',
+      fit: false,
+      expanded: false,
+    });
+
+    expect(nestedView.props.bookmark).toEqual({
+      ref: 2,
+      parent: 0,
+      title: 'chapter 1',
+      fit: false,
+      expanded: false,
+    });
+
+    expect(subNestedView.props.bookmark).toEqual({
+      ref: 3,
+      parent: 2,
+      title: 'sub chapter',
+      fit: false,
+      expanded: false,
+    });
+  });
+
+  test('should resolve bookmark object prop', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          props: {
+            bookmark: {
+              title: 'page',
+              top: 20,
+              left: 10,
+              zoom: 5,
+              expanded: true,
+            },
+          },
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    };
+    const result = resolveBookmarks(root);
+
+    expect(result.children[0].props.bookmark).toEqual({
+      ref: 0,
+      title: 'page',
+      expanded: true,
+      top: 20,
+      left: 10,
+      zoom: 5,
+    });
+  });
+});

--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -9,6 +9,7 @@ import Fonts from './mixins/fonts';
 import Text from './mixins/text';
 import Images from './mixins/images';
 import Annotations from './mixins/annotations';
+import OutlineMixin from './mixins/outline';
 import AcroFormMixin from './mixins/acroform';
 import Attachments from './mixins/attachments';
 
@@ -79,6 +80,7 @@ class PDFDocument extends stream.Readable {
     this.initFonts();
     this.initText();
     this.initImages();
+    this.initOutline();
 
     // Initialize the metadata
     this.info = {
@@ -239,6 +241,8 @@ class PDFDocument extends stream.Readable {
       font.finalize();
     }
 
+    this.endOutline();
+
     this._root.end();
     this._root.data.Pages.end();
     this._root.data.Names.end();
@@ -250,9 +254,9 @@ class PDFDocument extends stream.Readable {
 
     if (this._waiting === 0) {
       return this._finalize();
-    } else {
-      return (this._ended = true);
     }
+
+    this._ended = true;
   }
 
   _finalize(fn) {
@@ -308,6 +312,7 @@ mixin(Fonts);
 mixin(Text);
 mixin(Images);
 mixin(Annotations);
+mixin(OutlineMixin);
 mixin(AcroFormMixin);
 mixin(Attachments);
 

--- a/packages/pdfkit/src/mixins/outline.js
+++ b/packages/pdfkit/src/mixins/outline.js
@@ -1,0 +1,15 @@
+import PDFOutline from '../outline';
+
+export default {
+  initOutline() {
+    this.outline = new PDFOutline(this, null, null, null);
+  },
+
+  endOutline() {
+    this.outline.endOutline();
+    if (this.outline.children.length > 0) {
+      this._root.data.Outlines = this.outline.dictionary;
+      this._root.data.PageMode = 'UseOutlines';
+    }
+  }
+};

--- a/packages/pdfkit/src/outline.js
+++ b/packages/pdfkit/src/outline.js
@@ -1,0 +1,87 @@
+const DEFAULT_OPTIONS = {
+  top: 0,
+  left: 0,
+  zoom: 0,
+  fit: false,
+  pageNumber: null,
+  expanded: false
+};
+
+class PDFOutline {
+  constructor(document, parent, title, dest, options = DEFAULT_OPTIONS) {
+    this.document = document;
+    this.options = options;
+    this.outlineData = {};
+
+    if (dest !== null) {
+      const destWidth = dest.data.MediaBox[2];
+      const destHeight = dest.data.MediaBox[3];
+      const top = destHeight - (options.top || 0);
+      const left = destWidth - (options.left || 0);
+      const zoom = options.zoom || 0;
+
+      this.outlineData.Dest = options.fit
+        ? [dest, 'Fit']
+        : [dest, 'XYZ', left, top, zoom];
+    }
+
+    if (parent !== null) {
+      this.outlineData.Parent = parent;
+    }
+
+    if (title !== null) {
+      this.outlineData.Title = new String(title);
+    }
+
+    this.dictionary = this.document.ref(this.outlineData);
+    this.children = [];
+  }
+
+  addItem(title, options = DEFAULT_OPTIONS) {
+    const pages = this.document._root.data.Pages.data.Kids;
+
+    const dest =
+      options.pageNumber !== null
+        ? pages[options.pageNumber]
+        : this.document.page.dictionary;
+
+    const result = new PDFOutline(
+      this.document,
+      this.dictionary,
+      title,
+      dest,
+      options
+    );
+    this.children.push(result);
+
+    return result;
+  }
+
+  endOutline() {
+    if (this.children.length > 0) {
+      if (this.options.expanded) {
+        this.outlineData.Count = this.children.length;
+      }
+
+      const first = this.children[0];
+      const last = this.children[this.children.length - 1];
+      this.outlineData.First = first.dictionary;
+      this.outlineData.Last = last.dictionary;
+
+      for (let i = 0, len = this.children.length; i < len; i++) {
+        const child = this.children[i];
+        if (i > 0) {
+          child.outlineData.Prev = this.children[i - 1].dictionary;
+        }
+        if (i < this.children.length - 1) {
+          child.outlineData.Next = this.children[i + 1].dictionary;
+        }
+        child.endOutline();
+      }
+    }
+
+    return this.dictionary.end();
+  }
+}
+
+export default PDFOutline;

--- a/packages/render/src/index.js
+++ b/packages/render/src/index.js
@@ -1,5 +1,6 @@
 import renderNode from './primitives/renderNode';
 import addMetadata from './operations/addMetadata';
+import addBookmarks from './operations/addBookmarks';
 
 const render = (ctx, doc) => {
   const pages = doc.children || [];
@@ -7,6 +8,8 @@ const render = (ctx, doc) => {
   addMetadata(ctx, doc);
 
   pages.forEach(page => renderNode(ctx, page));
+
+  addBookmarks(ctx, doc);
 
   ctx.end();
 

--- a/packages/render/src/operations/addBookmarks.js
+++ b/packages/render/src/operations/addBookmarks.js
@@ -1,0 +1,40 @@
+/* eslint-disable no-param-reassign */
+
+const addNodeBookmark = (ctx, node, pageNumber, registry) => {
+  const bookmark = node.props?.bookmark;
+
+  if (bookmark) {
+    const { title, parent, expanded, zoom, fit } = bookmark;
+    const outline = registry[parent] || ctx.outline;
+    const top = bookmark.top || node.box.top;
+    const left = bookmark.left || node.box.left;
+    const instance = outline.addItem(title, {
+      pageNumber,
+      expanded,
+      top,
+      left,
+      zoom,
+      fit,
+    });
+
+    registry[bookmark.ref] = instance;
+  }
+
+  if (!node.children) return;
+
+  node.children.forEach(child =>
+    addNodeBookmark(ctx, child, pageNumber, registry),
+  );
+};
+
+const addBookmarks = (ctx, root) => {
+  const registry = {};
+
+  const pages = root.children || [];
+
+  pages.forEach((page, i) => {
+    addNodeBookmark(ctx, page, i, registry);
+  });
+};
+
+export default addBookmarks;

--- a/packages/types/bookmark.ts
+++ b/packages/types/bookmark.ts
@@ -1,0 +1,12 @@
+interface ExpandedBookmark {
+  title: string;
+  top?: number;
+  left?: number;
+  zoom?: number;
+  fit?: true | false;
+  expanded?: true | false;
+}
+
+export type Bookmark =
+  | string
+  | ExpandedBookmark

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -2,12 +2,14 @@ import { Style } from './style';
 import { Primitive } from './primitive';
 import { HyphenationCallback } from './font';
 import { PageSize, Orientation } from './page';
+import { Bookmark } from './bookmark';
 
 interface BaseProps {
   id?: string;
   fixed?: boolean;
   break?: boolean;
   debug?: boolean;
+  bookmark?: Bookmark;
   minPresenceAhead?: number;
 }
 


### PR DESCRIPTION
Add bookmarks support. Bookmarks can be added by the `bookmark` prop on any component. Prop value can be either

- String, defining the bookmark title
- Object, with the following keys
  - title: mandatory. Bookmark title
  - top: optional. x coordinate to redirect bookmark. defaults to element top coordiante
  - left: optional. y coordinate to redirect bookmark. defaults to element left coordinate
  - fit: optional. redirect bookmark to page (0,0) coordinate
  - zoom: optional. change zoom on bookmark redirect
  - expanded. optional. all of that section's children will be visible by default 

Fixes #237

