### PR TITLE
feat: add page layout support

### DIFF
--- a/.changeset/honest-cars-carry.md
+++ b/.changeset/honest-cars-carry.md
@@ -1,0 +1,7 @@
+---
+'@react-pdf/pdfkit': minor
+'@react-pdf/renderer': minor
+'@react-pdf/types': minor
+---
+
+feat: add page layout support

--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -12,6 +12,7 @@ import Annotations from './mixins/annotations';
 import OutlineMixin from './mixins/outline';
 import AcroFormMixin from './mixins/acroform';
 import Attachments from './mixins/attachments';
+import capitalize from './utils/capitalize';
 
 class PDFDocument extends stream.Readable {
   constructor(options = {}) {
@@ -69,6 +70,10 @@ class PDFDocument extends stream.Readable {
 
     if (this.options.lang) {
       this._root.data.Lang = new String(this.options.lang);
+    }
+
+    if (this.options.pageLayout) {
+      this._root.data.PageLayout = capitalize(this.options.pageLayout);
     }
 
     // The current page

--- a/packages/pdfkit/src/utils/capitalize.js
+++ b/packages/pdfkit/src/utils/capitalize.js
@@ -1,0 +1,3 @@
+const capitalize = v => v[0].toUpperCase() + v.slice(1);
+
+export default capitalize;

--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -34,7 +34,7 @@ const pdf = initialValue => {
 
   const render = async (compress = true) => {
     const props = container.document.props || {};
-    const { pdfVersion, language } = props;
+    const { pdfVersion, language, pageLayout } = props;
 
     const ctx = new PDFDocument({
       compress,
@@ -42,6 +42,7 @@ const pdf = initialValue => {
       lang: language,
       displayTitle: true,
       autoFirstPage: false,
+      pageLayout,
     });
 
     const layout = await layoutDocument(container.document, fontStore);

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -37,6 +37,8 @@ interface PageProps extends BaseProps {
   orientation?: Orientation;
 }
 
+type PageLayout = 'singlePage' | 'oneColumn' | 'twoColumnLeft' | 'twoColumnRight' | 'twoPageLeft' | 'twoPageRight'
+
 interface DocumentProps {
   title?: string;
   author?: string;
@@ -44,6 +46,7 @@ interface DocumentProps {
   keywords?: string;
   creator?: string;
   producer?: string;
+  pageLayout?: PageLayout
 }
 
 interface TextInstanceNode {


### PR DESCRIPTION
Add `pageLayout` prop to Document. This controls how (some) PDF viewers choose to show pages

Values are

- singlePage: Display one page at a time
- oneColumn: Display the pages in one column
- twoColumnLeft: Display the pages in two columns, with odd numbered pages on the left
- twoColumnRight: Display the pages in two columns, with odd numbered pages on the right
- twoPageLeft: Display the pages two at a time, with odd-numbered pages on the left
- twoPageRight: Display the pages two at a time, with odd-numbered pages on the right