### PR TITLE
feat: add page mode support

### DIFF
--- a/.changeset/lucky-wombats-smoke.md
+++ b/.changeset/lucky-wombats-smoke.md
@@ -1,0 +1,7 @@
+---
+'@react-pdf/pdfkit': minor
+'@react-pdf/renderer': minor
+'@react-pdf/types': minor
+---
+
+feat: add page mode support

--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -76,6 +76,10 @@ class PDFDocument extends stream.Readable {
       this._root.data.PageLayout = capitalize(this.options.pageLayout);
     }
 
+    if (this.options.pageMode) {
+      this._root.data.PageMode = capitalize(this.options.pageMode);
+    }
+
     // The current page
     this.page = null;
 

--- a/packages/pdfkit/src/mixins/outline.js
+++ b/packages/pdfkit/src/mixins/outline.js
@@ -9,7 +9,7 @@ export default {
     this.outline.endOutline();
     if (this.outline.children.length > 0) {
       this._root.data.Outlines = this.outline.dictionary;
-      this._root.data.PageMode = 'UseOutlines';
+      this._root.data.PageMode = this._root.data.PageMode || 'UseOutlines';
     }
   }
 };

--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -34,7 +34,7 @@ const pdf = initialValue => {
 
   const render = async (compress = true) => {
     const props = container.document.props || {};
-    const { pdfVersion, language, pageLayout } = props;
+    const { pdfVersion, language, pageLayout, pageMode } = props;
 
     const ctx = new PDFDocument({
       compress,
@@ -43,6 +43,7 @@ const pdf = initialValue => {
       displayTitle: true,
       autoFirstPage: false,
       pageLayout,
+      pageMode,
     });
 
     const layout = await layoutDocument(container.document, fontStore);

--- a/packages/types/bookmark.d.ts
+++ b/packages/types/bookmark.d.ts
@@ -7,6 +7,4 @@ interface ExpandedBookmark {
   expanded?: true | false;
 }
 
-export type Bookmark =
-  | string
-  | ExpandedBookmark
+export type Bookmark = string | ExpandedBookmark;

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -37,7 +37,21 @@ interface PageProps extends BaseProps {
   orientation?: Orientation;
 }
 
-type PageLayout = 'singlePage' | 'oneColumn' | 'twoColumnLeft' | 'twoColumnRight' | 'twoPageLeft' | 'twoPageRight'
+type PageLayout =
+  | 'singlePage'
+  | 'oneColumn'
+  | 'twoColumnLeft'
+  | 'twoColumnRight'
+  | 'twoPageLeft'
+  | 'twoPageRight';
+
+type PageMode =
+  | 'useNone'
+  | 'useOutlines'
+  | 'useThumbs'
+  | 'fullScreen'
+  | 'useOC'
+  | 'useAttachments';
 
 interface DocumentProps {
   title?: string;
@@ -46,7 +60,8 @@ interface DocumentProps {
   keywords?: string;
   creator?: string;
   producer?: string;
-  pageLayout?: PageLayout
+  pageLayout?: PageLayout;
+  pageMode?: PageMode;
 }
 
 interface TextInstanceNode {


### PR DESCRIPTION
Add `pageMode` prop to Document. A name object specifying how the document should be displayed when opened

Values are

- useNone: Neither document outline nor thumbnail images visible
- useOutlines: Document outline visible
- useThumbs: Thumbnail images visible
- fullScreen: Full-screen mode, with no menu bar, window controls, or any other window visible
- useOC: Optional content group panel visible
- useAttachments: Attachments panel visible