### PR TITLE
feat: variable dpi

### DIFF
--- a/.changeset/pretty-jars-begin.md
+++ b/.changeset/pretty-jars-begin.md
@@ -1,0 +1,9 @@
+---
+'@react-pdf/layout': minor
+'@react-pdf/pdfkit': minor
+'@react-pdf/render': minor
+'@react-pdf/stylesheet': minor
+'@react-pdf/types': minor
+---
+
+feat: variable dpi

--- a/packages/layout/src/page/getSize.js
+++ b/packages/layout/src/page/getSize.js
@@ -71,6 +71,18 @@ const toSizeObject = v => ({ width: v[0], height: v[1] });
 const flipSizeObject = v => ({ width: v.height, height: v.width });
 
 /**
+ * Adjust page size to passed DPI
+ *
+ * @param {Object} size object
+ * @param {number} dpi
+ * @returns {Object} adjusted size object
+ */
+const adjustDpi = (v, dpi) => ({
+  width: v.width * dpi,
+  height: v.height * dpi,
+});
+
+/**
  * Returns size object from a given string
  *
  * @param {String} page size string
@@ -96,6 +108,7 @@ const getNumberSize = n => toSizeObject([n]);
  */
 const getSize = page => {
   const value = page.props?.size || 'A4';
+  const dpi = parseFloat(page.props?.dpi || 72);
 
   const type = typeof value;
 
@@ -108,6 +121,8 @@ const getSize = page => {
   } else if (type === 'number') {
     size = getNumberSize(value);
   }
+
+  size = adjustDpi(size, dpi / 72);
 
   return isLandscape(page) ? flipSizeObject(size) : size;
 };

--- a/packages/layout/src/page/getSize.js
+++ b/packages/layout/src/page/getSize.js
@@ -78,8 +78,8 @@ const flipSizeObject = v => ({ width: v.height, height: v.width });
  * @returns {Object} adjusted size object
  */
 const adjustDpi = (v, dpi) => ({
-  width: v.width * dpi,
-  height: v.height * dpi,
+  width: v.width ? v.width * dpi : v.width,
+  height: v.height ? v.height * dpi : v.height,
 });
 
 /**

--- a/packages/layout/src/steps/resolveStyles.js
+++ b/packages/layout/src/steps/resolveStyles.js
@@ -49,7 +49,10 @@ const resolveNodeStyles = container => node => {
  * @returns {Object} document page with resolved styles
  */
 const resolvePageStyles = page => {
-  const container = page.box || page.style;
+  const dpi = page.props?.dpi || 72;
+  const box = page.box || page.style;
+  const container = { ...box, dpi };
+
   return resolveNodeStyles(container)(page);
 };
 

--- a/packages/pdfkit/src/page.js
+++ b/packages/pdfkit/src/page.js
@@ -66,6 +66,7 @@ class PDFPage {
     }
     this.size = options.size || 'letter';
     this.layout = options.layout || 'portrait';
+    this.userUnit = options.userUnit || 1.0;
     this.margins = DEFAULT_MARGINS;
 
     // calculate page dimensions
@@ -122,7 +123,8 @@ class PDFPage {
       Parent: this.document._root.data.Pages,
       MediaBox: [0, 0, this.width, this.height],
       Contents: this.content,
-      Resources: this.resources
+      Resources: this.resources,
+      UserUnit: this.userUnit
     });
   }
 

--- a/packages/render/src/primitives/renderPage.js
+++ b/packages/render/src/primitives/renderPage.js
@@ -1,7 +1,9 @@
 const renderPage = (ctx, node) => {
   const { width, height } = node.box;
+  const dpi = node.props?.dpi || 72;
+  const userUnit = dpi / 72;
 
-  ctx.addPage({ size: [width, height], margin: 0 });
+  ctx.addPage({ size: [width, height], margin: 0, userUnit });
 };
 
 export default renderPage;

--- a/packages/stylesheet/src/transform/units.js
+++ b/packages/stylesheet/src/transform/units.js
@@ -1,9 +1,3 @@
-const DPI = 72; // 72pt per inch.
-
-const MM_FACTOR = (1 / 25.4) * DPI;
-
-const CM_FACTOR = (1 / 2.54) * DPI;
-
 /**
  * Parses scalar value in value and unit pairs
  *
@@ -28,13 +22,17 @@ const parseValue = value => {
 const transformUnit = (container, value) => {
   const scalar = parseValue(value);
 
+  const dpi = container.dpi || 72;
+  const mmFactor = (1 / 25.4) * dpi;
+  const cmFactor = (1 / 2.54) * dpi;
+
   switch (scalar.unit) {
     case 'in':
-      return scalar.value * DPI;
+      return scalar.value * dpi;
     case 'mm':
-      return scalar.value * MM_FACTOR;
+      return scalar.value * mmFactor;
     case 'cm':
-      return scalar.value * CM_FACTOR;
+      return scalar.value * cmFactor;
     case 'vh':
       return scalar.value * (container.height / 100);
     case 'vw':

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -35,6 +35,7 @@ interface PageProps extends BaseProps {
   wrap?: boolean;
   size?: PageSize;
   orientation?: Orientation;
+  dpi?: number;
 }
 
 type PageLayout =


### PR DESCRIPTION
Adds optional `dpi` prop to `Page` primitive

**Why Page and not Document?**

So the same document can have different DPIs in different pages

**What this prop does under the hood**

- Resizes page dimensions to match new dpi 
- Setup PDF page `UserUnit` field to dpi/72 

Reading at the PDF spect it seems that the latter point is the way to go, but I haven't seen any change in how readers (specially Adobe) renders pages or shows page dimensions. Seems like it's being ignored as far as I saw. But hopefully this will work for anyone requiring to have variable dpi.

Please open a new issue if someone trying this finds something not working as expected 

Fixes #1066