### PR TITLE
chore(render): tweak rollup config

### DIFF
--- a/packages/render/rollup.config.js
+++ b/packages/render/rollup.config.js
@@ -19,7 +19,7 @@ const configBase = {
   input: 'src/index.js',
   external: Object.keys(pkg.dependencies).concat(
     /@babel\/runtime/,
-    /@react-pdf\/textkit/,
+    /@react-pdf/,
   ),
   plugins: [
     json(),

--- a/packages/render/rollup.config.js
+++ b/packages/render/rollup.config.js
@@ -1,6 +1,5 @@
 import json from '@rollup/plugin-json';
 import babel from '@rollup/plugin-babel';
-import { terser } from 'rollup-plugin-terser';
 
 import pkg from './package.json';
 
@@ -18,7 +17,10 @@ const getESM = override => Object.assign({}, esm, override);
 
 const configBase = {
   input: 'src/index.js',
-  external: Object.keys(pkg.dependencies),
+  external: Object.keys(pkg.dependencies).concat(
+    /@babel\/runtime/,
+    /@react-pdf\/textkit/,
+  ),
   plugins: [
     json(),
     babel({
@@ -36,12 +38,4 @@ const config = Object.assign({}, configBase, {
   ],
 });
 
-const prodConfig = Object.assign({}, configBase, {
-  output: [
-    getESM({ file: 'lib/index.es.min.js' }),
-    getCJS({ file: 'lib/index.cjs.min.js' }),
-  ],
-  plugins: configBase.plugins.concat(terser()),
-});
-
-export default [config, prodConfig];
+export default config;


### PR DESCRIPTION
- remove minified build because nobody uses it and it takes so much time to compile.


- exclude `@babel/runtime` from the final bundle, it has weird imports like `@babel/runtime/**` so default approach with `Object.keys(pkg.dependencies)` doesn't work.

