### PR TITLE
chore: fix module path

### DIFF
--- a/.changeset/few-news-invent.md
+++ b/.changeset/few-news-invent.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/layout': patch
+---
+
+fixed path to es module bundle

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -6,7 +6,7 @@
   "author": "Diego Muracciole <diegomuracciole@gmail.com>",
   "homepage": "https://github.com/diegomura/react-pdf#readme",
   "main": "lib/index.cjs.js",
-  "module": "lib/index.esm.js",
+  "module": "lib/index.es.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/diegomura/react-pdf.git",


### PR DESCRIPTION
propper setup for es modules