### PR TITLE
fix: overwrite default styles in link component

### DIFF
--- a/.changeset/old-bottles-end.md
+++ b/.changeset/old-bottles-end.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/layout': patch
+---
+
+fixed overwriting for default link style

--- a/packages/layout/src/steps/resolveStyles.js
+++ b/packages/layout/src/steps/resolveStyles.js
@@ -3,7 +3,7 @@ import stylesheet from '@react-pdf/stylesheet';
 
 const isLink = node => node.type === P.Link;
 
-const LINK_STYLES = {
+const DEFAULT_LINK_STYLES = {
   color: 'blue',
   textDecoration: 'underline',
 };
@@ -16,11 +16,13 @@ const LINK_STYLES = {
  * @returns {Object} computed styles
  */
 const computeStyle = (container, node) => {
-  const overrideStyle = isLink(node) ? LINK_STYLES : {};
+  let baseStyle = node.style;
 
-  const baseStyle = Array.isArray(node.style)
-    ? [...node.style, overrideStyle]
-    : Object.assign({}, overrideStyle, node.style);
+  if (isLink(node)) {
+    baseStyle = Array.isArray(node.style)
+      ? [DEFAULT_LINK_STYLES, ...node.style]
+      : [DEFAULT_LINK_STYLES, node.style];
+  }
 
   return stylesheet(container, baseStyle);
 };

--- a/packages/layout/tests/steps/__snapshots__/resolveStyles.test.js.snap
+++ b/packages/layout/tests/steps/__snapshots__/resolveStyles.test.js.snap
@@ -1,5 +1,55 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`layout resolveStyles Should overide default link styles 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "box": Object {
+        "height": 200,
+        "width": 100,
+      },
+      "children": Array [
+        Object {
+          "style": Object {
+            "color": "wheat",
+            "textDecoration": "none",
+          },
+          "type": "LINK",
+        },
+      ],
+      "style": Object {},
+      "type": "PAGE",
+    },
+  ],
+  "type": "DOCUMENT",
+}
+`;
+
+exports[`layout resolveStyles Should overide default link styles with array 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "box": Object {
+        "height": 200,
+        "width": 100,
+      },
+      "children": Array [
+        Object {
+          "style": Object {
+            "color": "wheat",
+            "textDecoration": "none",
+          },
+          "type": "LINK",
+        },
+      ],
+      "style": Object {},
+      "type": "PAGE",
+    },
+  ],
+  "type": "DOCUMENT",
+}
+`;
+
 exports[`layout resolveStyles Should resolve default link styles 1`] = `
 Object {
   "children": Array [

--- a/packages/layout/tests/steps/resolveStyles.test.js
+++ b/packages/layout/tests/steps/resolveStyles.test.js
@@ -183,4 +183,46 @@ describe('layout resolveStyles', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  test('Should overide default link styles', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          box: { width: 100, height: 200 },
+          children: [
+            {
+              type: 'LINK',
+              style: { color: 'wheat', textDecoration: 'none' },
+            },
+          ],
+        },
+      ],
+    };
+    const result = resolveStyles(root);
+
+    expect(result).toMatchSnapshot();
+  });
+
+  test('Should overide default link styles with array', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          box: { width: 100, height: 200 },
+          children: [
+            {
+              type: 'LINK',
+              style: [{ color: 'wheat', textDecoration: 'none' }],
+            },
+          ],
+        },
+      ],
+    };
+    const result = resolveStyles(root);
+
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
default link style overwrote user ones in the case with an array

[repl](https://react-pdf.org/repl?code=3187b0760ce02e00408a057025803c450298c0bc300500943807cf805030c00f0022230080b6198531165d400a02180e659a004f003619b006f61622003a0046200099080beed3a72a006491800d631a78891330a2834328004e3ca127000b86007230e032b803431408901b175779111e607d1f18461e1b3e3d1700460026557500090c1100aa007a5d030d4d6a02c36349006d330c0b2b5b7b4730608f302f5f7f40e0d0f0c8d55f0918b8849814d5005d0cac9cfcbd7d22ca3cde0122bcba0666567602006e323250485863081c18006528510c33800b0c0c2859601b0c7b0c3c090e4515174fcd00071e128947a3e0005440ff170019800acde0e25101c0d040085d050102305c00367862260c890580f8e940920005ee0280f04430fc6515464550ecf6002557b00a05c1a000c5642f3012830363c15110a87416172c456500)

