### PR TITLE
feat: add onClick event to PDFDownloadLink

### DIFF
--- a/.changeset/silly-rice-chew.md
+++ b/.changeset/silly-rice-chew.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': minor
+---
+
+feat: add onClick event to PDFDownloadLink

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -448,6 +448,7 @@ declare namespace ReactPDF {
     children?:
       | React.ReactNode
       | ((params: BlobProviderParams) => React.ReactNode);
+    onClick?: function;
   }
 
   /**

--- a/packages/renderer/src/dom/PDFDownloadLink.js
+++ b/packages/renderer/src/dom/PDFDownloadLink.js
@@ -10,6 +10,7 @@ export const PDFDownloadLink = ({
   className,
   document: doc,
   fileName = 'document.pdf',
+  onClick,
 }) => {
   const [instance, updateInstance] = usePDF({ document: doc });
 
@@ -27,13 +28,18 @@ export const PDFDownloadLink = ({
     }
   };
 
+  const handleClick = event => {
+    handleDownloadIE();
+    if (onClick && typeof onClick === 'function') onClick(event, instance);
+  };
+
   return (
     <a
       style={style}
       href={instance.url}
       download={fileName}
       className={className}
-      onClick={handleDownloadIE}
+      onClick={handleClick}
     >
       {typeof children === 'function' ? children(instance) : children}
     </a>

--- a/packages/renderer/src/dom/PDFDownloadLink.js
+++ b/packages/renderer/src/dom/PDFDownloadLink.js
@@ -30,7 +30,7 @@ export const PDFDownloadLink = ({
 
   const handleClick = event => {
     handleDownloadIE();
-    if (onClick && typeof onClick === 'function') onClick(event, instance);
+    if (typeof onClick === 'function') onClick(event, instance);
   };
 
   return (


### PR DESCRIPTION
Based on request #975 and our own experience, having an `onClick` handler to invoke for `PDFDownloadLink` would be benficial. E.g. We'd like to send a custom event to our analytics on download. (We're finding other means to lazily load the heavier components, so wouldn't need to resort to the workaround for this feature [proposed there](https://github.com/diegomura/react-pdf/issues/975#issuecomment-674261430).)

This implementation refactors the existing `onClick` handler slightly, to also allow consumer's to provide a function via props. We conditionally call this function after existing `handleDownloadIE`. (We'd generally opt for `onClick?.()`, but as this package targets Node v12, we'll check `typeof` before invoking.)

I've included the `event` as the first function argument, should the consumer need to use native event properties. That seems like the expected behaviour. Secondly, we pass along the `instance`, which might be helpful in certain circumstances. If that's not a beneficial use-case, would gladly omit.

Added types. Not sure that this component has unit tests, but happy to add if need be.

Fixes #975