### PR TITLE
Add optional dimension callback 

### DIFF
--- a/packages/render/src/primitives/renderDebug.js
+++ b/packages/render/src/primitives/renderDebug.js
@@ -176,6 +176,20 @@ const debugOrigin = (ctx, node) => {
 };
 
 const renderDebug = (ctx, node) => {
+  if (node.props?.dimensionCallback) {
+    const { width, height } = node.box;
+    const {
+      marginLeft = 0,
+      marginTop = 0,
+      marginRight = 0,
+      marginBottom = 0,
+    } = getMargin(node.box);
+
+    const roundedWidth = Math.round(width + marginLeft + marginRight);
+    const roundedHeight = Math.round(height + marginTop + marginBottom);
+    node.props.dimensionCallback(roundedHeight, roundedWidth);
+  }
+
   if (!node.props?.debug) return;
 
   ctx.save();


### PR DESCRIPTION
- allow dimensions of nodes to be determined by rendering PDF more than once.
- callback happens during debug phase to match node dimensions that would be output to the user after the PDF finishes rendering with debug enabled
- dev can render a PDF more than once to determine height and width of dynamic components and use that information to inform the final layout of the PDF