### PR TITLE
fix: console error when text overflows the last available rect

### DIFF
--- a/.changeset/fifty-boxes-argue.md
+++ b/.changeset/fifty-boxes-argue.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/textkit': patch
+---
+
+fix: console error when text overflows the last available rect

--- a/packages/textkit/src/layout/layoutParagraph.js
+++ b/packages/textkit/src/layout/layoutParagraph.js
@@ -36,7 +36,7 @@ const layoutLines = (rects, lines, indent) => {
     const style = line.runs?.[0]?.attributes || {};
     const height = Math.max(stringHeight(line), style.lineHeight);
 
-    if (currentY + height > rect.y + rect.height) {
+    if (currentY + height > rect.y + rect.height && rects.length > 0) {
       rect = rects.shift();
       currentY = rect.y;
     }

--- a/packages/textkit/tests/layout/layoutParagraph.test.js
+++ b/packages/textkit/tests/layout/layoutParagraph.test.js
@@ -1,0 +1,29 @@
+import layoutParagraph from '../../src/layout/layoutParagraph';
+
+describe('layoutParagraph', () => {
+  test('should keep overflowing text in the last rect', () => {
+    // eslint-disable-next-line no-unused-vars
+    const linebreaker = _options => (attributedString, _availableWidths) => {
+      return [attributedString];
+    };
+    const layouter = layoutParagraph({ linebreaker });
+
+    const container = {
+      excludeRects: [],
+      x: 2,
+      y: 4,
+      width: 20,
+      height: 10,
+    };
+    const paragraph = {
+      string: 'Lorem',
+      runs: [
+        { start: 0, end: 5, attributes: { lineHeight: 11, color: 'red' } },
+      ],
+    };
+
+    layouter(container, paragraph);
+
+    // expect no errors
+  });
+});


### PR DESCRIPTION
Bug was introduced in #1895
Error message: TypeError: rect2 is undefined (or similar)
In case there is no rect left for the text to flow to, we have to stay in the last one and overflow its bottom.