### PR TITLE
feat: remove blob stream dependency

### DIFF
--- a/.changeset/soft-ladybugs-yell.md
+++ b/.changeset/soft-ladybugs-yell.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/pdfkit': patch
+'@react-pdf/renderer': patch
+---
+
+feat: remove blob stream dependency

--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -34,7 +34,6 @@
     "fontkit": "^2.0.2"
   },
   "devDependencies": {
-    "blob-stream": "^0.1.2",
     "iconv-lite": "^0.4.13"
   }
 }

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -32,7 +32,6 @@
     "@react-pdf/primitives": "^3.0.0",
     "@react-pdf/render": "^3.2.0",
     "@react-pdf/types": "^2.1.0",
-    "blob-stream": "^0.1.3",
     "queue": "^6.0.1",
     "react-reconciler": "^0.23.0",
     "scheduler": "^0.17.0"

--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -1,4 +1,3 @@
-import BlobStream from 'blob-stream';
 import FontStore from '@react-pdf/font';
 import renderPDF from '@react-pdf/render';
 import PDFDocument from '@react-pdf/pdfkit';
@@ -58,21 +57,25 @@ const pdf = initialValue => {
   };
 
   const toBlob = async () => {
+    const chunks = [];
     const instance = await render();
-    const stream = instance.pipe(BlobStream());
 
     return new Promise((resolve, reject) => {
-      stream.on('finish', () => {
+      instance.on('data', chunk => {
+        chunks.push(
+          chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk),
+        );
+      });
+
+      instance.on('end', () => {
         try {
-          const blob = stream.toBlob('application/pdf');
+          const blob = new Blob(chunks, { type: 'application/pdf' });
           callOnRender({ blob });
           resolve(blob);
         } catch (error) {
           reject(error);
         }
       });
-
-      stream.on('error', reject);
     });
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,18 +3317,6 @@ bl@^4.0.3:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-blob-stream@^0.1.2, blob-stream@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/blob-stream/-/blob-stream-0.1.3.tgz#98d668af6996e0f32ef666d06e215ccc7d77686c"
-  integrity sha1-mNZor2mW4PMu9mbQbiFczH13aGw=
-  dependencies:
-    blob "0.0.4"
-
-blob@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/blob/-/blob-0.0.4.tgz#bcf13052ca54463f30f9fc7e95b9a47630a94921"
-  integrity sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=
-
 bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"


### PR DESCRIPTION
There's no need to actually have this. We can just use pdfkit document stream to convert blob directly, which enables not having to polyfill stream just for blob creation in #1891