### PR TITLE
Restore the ability to load fonts by relative URL in browsers

### DIFF
--- a/packages/font/src/font.js
+++ b/packages/font/src/font.js
@@ -61,7 +61,7 @@ class FontSource {
     if (isDataUrl(this.src)) {
       const raw = this.src.split(',')[1];
       this.data = fontkit.create(toUint8Array(raw), postscriptName);
-    } else if (isUrl(this.src)) {
+    } else if (BROWSER || isUrl(this.src)) {
       const { headers, body, method = 'GET' } = this.options;
       const data = await fetchFont(this.src, { method, body, headers });
       this.data = fontkit.create(data, postscriptName);


### PR DESCRIPTION
This was broken in #1927, when trying to optimize for bundle size.
See https://github.com/diegomura/react-pdf/pull/1891#issuecomment-1180200312 for an explanation.