### PR TITLE
Hotfix: issue #1805 by not using the cache for images from a buffer

### DIFF
--- a/packages/image/src/resolve.js
+++ b/packages/image/src/resolve.js
@@ -157,17 +157,15 @@ const resolveImageFromUrl = async src => {
 };
 
 const resolveImage = (src, { cache = true } = {}) => {
+  let image;
   const cacheKey = src.data ? src.data.toString() : src.uri;
 
-  if (cache && IMAGE_CACHE.get(cacheKey)) {
-    return IMAGE_CACHE.get(cacheKey);
-  }
-
-  let image;
-  if (isCompatibleBase64(src)) {
-    image = resolveBase64Image(src);
-  } else if (Buffer.isBuffer(src)) {
+  if (Buffer.isBuffer(src)) {
     image = resolveBufferImage(src);
+  } else if (cache && IMAGE_CACHE.get(cacheKey)) {
+    return IMAGE_CACHE.get(cacheKey);
+  } else if (isCompatibleBase64(src)) {
+    image = resolveBase64Image(src);
   } else if (typeof src === 'object' && src.data) {
     image = resolveImageFromData(src);
   } else {


### PR DESCRIPTION
Hi,
this is a Hotfix for #1805.
It will disable caching for images from a buffer, until someone comes up with a better solution.
