### PR TITLE
chore: adds missing licenses to package.json

### DIFF
--- a/.changeset/fresh-moons-cheer.md
+++ b/.changeset/fresh-moons-cheer.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/pdfkit': patch
+'@react-pdf/png-js': patch
+---
+
+chore: adds missing licenses to package.json

--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@react-pdf/pdfkit",
   "version": "2.4.0",
+  "license": "MIT",
   "description": "A PDF generation library for Node.js",
   "main": "./lib/pdfkit.cjs.js",
   "module": "./lib/pdfkit.es.js",

--- a/packages/png-js/package.json
+++ b/packages/png-js/package.json
@@ -2,6 +2,7 @@
   "name": "@react-pdf/png-js",
   "description": "A PNG decoder in JS",
   "version": "2.1.0",
+  "license": "MIT",
   "main": "./lib/png-js.cjs.js",
   "module": "./lib/png-js.es.js",
   "browser": {


### PR DESCRIPTION
Both packages, `pdfkit` and `png-js` are distributed with MIT license. This PR  adds an entry into each packages `package.json` file.
Hit me up if something is missing.

Thanks for the work @diegomura !