### PR TITLE
fix: interface PDFDownloadLinkProps attribute onClick

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -448,7 +448,7 @@ declare namespace ReactPDF {
     children?:
       | React.ReactNode
       | ((params: BlobProviderParams) => React.ReactNode);
-    onClick?: Function;
+    onClick?: () => void;
   }
 
   /**


### PR DESCRIPTION
Vite.js is unable to build with the onClick attribute type of the ReactPDFDownloadLink function.
```bash
node_modules/@react-pdf/renderer/index.d.ts(451,15): error TS2552: Cannot find name 'function'. Did you mean 'Function'?
```
Suggested fix

```javascript
interface PDFDownloadLinkProps {
    document: React.ReactElement<DocumentProps>;
    fileName?: string;
    style?: Style | Style[];
    className?: string;
    children?:
      | React.ReactNode
      | ((params: BlobProviderParams) => React.ReactNode);
    onClick?: () => void; // 👈 Function void
  }
```