### PR TITLE
fix: page wrap=false not preventing page from breaking

### DIFF
--- a/.changeset/tall-eggs-destroy.md
+++ b/.changeset/tall-eggs-destroy.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/layout': patch
+---
+
+fix: fix page wrap=false not preventing page from breaking

--- a/.changeset/tall-eggs-destroy.md
+++ b/.changeset/tall-eggs-destroy.md
@@ -2,4 +2,4 @@
 '@react-pdf/layout': patch
 ---
 
-fix: fix page wrap=false not preventing page from breaking
+fix: page wrap=false not preventing page from breaking

--- a/packages/layout/src/steps/resolvePagination.js
+++ b/packages/layout/src/steps/resolvePagination.js
@@ -260,6 +260,11 @@ const resolvePagination = (doc, fontStore) => {
 
   for (let i = 0; i < doc.children.length; i += 1) {
     const page = doc.children[i];
+    if (!page.props?.wrap) {
+      pages.push(page);
+      continue;
+    }
+
     let subpages = paginate(page, pageNumber, fontStore);
 
     subpages = assocSubPageData(subpages);

--- a/packages/layout/src/steps/resolvePagination.js
+++ b/packages/layout/src/steps/resolvePagination.js
@@ -231,6 +231,8 @@ const dissocSubPageData = page => {
 const paginate = (page, pageNumber, fontStore) => {
   if (!page) return [];
 
+  if (page.props?.wrap === false) return [page];
+
   let splittedPage = splitPage(page, pageNumber, fontStore);
 
   const pages = [splittedPage[0]];
@@ -260,11 +262,6 @@ const resolvePagination = (doc, fontStore) => {
 
   for (let i = 0; i < doc.children.length; i += 1) {
     const page = doc.children[i];
-    if (!page.props?.wrap) {
-      pages.push(page);
-      continue;
-    }
-
     let subpages = paginate(page, pageNumber, fontStore);
 
     subpages = assocSubPageData(subpages);

--- a/packages/layout/tests/steps/resolvePagination.test.js
+++ b/packages/layout/tests/steps/resolvePagination.test.js
@@ -137,4 +137,36 @@ describe('pagination step', () => {
     expect(view2.box.height).toBe(60);
     expect(view3.box.height).toBe(10);
   });
+
+  test('should not wrap page with false wrap prop', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          box: {},
+          style: {
+            width: 5,
+            height: 60,
+          },
+          props: {
+            wrap: false,
+          },
+          children: [
+            {
+              type: 'VIEW',
+              box: {},
+              style: { height: 130 },
+              props: {},
+              children: [],
+            },
+          ],
+        },
+      ],
+    };
+
+    const layout = calcLayout(root);
+
+    expect(layout.children.length).toBe(1);
+  });
 });


### PR DESCRIPTION
This fixes `<Page wrap={false}>` not actually preventing a page from breaking. It also can save large amounts of time (I noticed a 50% performance increase) on pages with many elements.