### PR TITLE
feat: Added DocProvider to access PDFDocument directly during render

### DIFF
--- a/packages/examples/src/docProvider/index.js
+++ b/packages/examples/src/docProvider/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Page, Document, Text, DocProvider } from '@react-pdf/renderer';
+import PDFDocument from '@react-pdf/pdfkit';
+import { renderNode } from '@react-pdf/render';
+
+export default () => (
+  <Document
+    title="Table"
+    author="Jane Doe"
+    subject="Rendering with react-pdf and modifying document during render"
+    keywords={['react', 'pdf', 'table']}
+  >
+    <Page size="A4">
+      <Text>This is the first page</Text>
+    </Page>
+    <DocProvider fn={doc => {
+      doc.addPage({ size: "A4" });
+      doc.text('This is the middle page, added using pdfkit!');
+    }} />
+    <Page size="A4">
+      <Text>This is the last page</Text>
+    </Page>
+  </Document>
+);

--- a/packages/examples/src/index.js
+++ b/packages/examples/src/index.js
@@ -11,6 +11,7 @@ import Knobs from './knobs';
 import Resume from './resume';
 import Fractals from './fractals';
 import PageWrap from './pageWrap';
+import DocProvider from './docProvider';
 
 const MOUNT_ELEMENT = document.getElementById('root');
 
@@ -22,6 +23,7 @@ const EXAMPLES = {
   resume: Resume,
   pageWrap: PageWrap,
   fractals: Fractals,
+  docProvider: DocProvider,
 };
 
 const Viewer = () => {

--- a/packages/primitives/src/index.js
+++ b/packages/primitives/src/index.js
@@ -22,3 +22,4 @@ export const ClipPath = 'CLIP_PATH';
 export const TextInstance = 'TEXT_INSTANCE';
 export const LinearGradient = 'LINEAR_GRADIENT';
 export const RadialGradient = 'RADIAL_GRADIENT';
+export const DocProvider = 'DOCUMENT_PROVIDER';

--- a/packages/primitives/tests/index.test.js
+++ b/packages/primitives/tests/index.test.js
@@ -92,4 +92,8 @@ describe('primitives', () => {
   test('should export text radial gradient', () => {
     expect(primitives.RadialGradient).toBeTruthy();
   });
+
+  test('should export document provider', () => {
+    expect(primitives.DocProvider).toBeTruthy();
+  });
 });

--- a/packages/render/src/index.js
+++ b/packages/render/src/index.js
@@ -18,3 +18,4 @@ const render = (ctx, doc) => {
 };
 
 export default render;
+export { renderNode };

--- a/packages/render/src/primitives/renderDocProvider.js
+++ b/packages/render/src/primitives/renderDocProvider.js
@@ -1,0 +1,8 @@
+const renderDocProvider = (ctx, node) => {
+  const fn = node?.props?.fn;
+  if (typeof fn === 'function') {
+    fn(ctx);
+  }
+};
+
+export default renderDocProvider;

--- a/packages/render/src/primitives/renderNode.js
+++ b/packages/render/src/primitives/renderNode.js
@@ -3,6 +3,7 @@ import renderSvg from './renderSvg';
 import renderText from './renderText';
 import renderPage from './renderPage';
 import renderNote from './renderNote';
+import renderDocProvider from './renderDocProvider';
 import renderImage from './renderImage';
 import renderDebug from './renderDebug';
 import renderCanvas from './renderCanvas';
@@ -13,7 +14,7 @@ import clipNode from '../operations/clipNode';
 import transform from '../operations/transform';
 import setDestination from '../operations/setDestination';
 
-const isRecursiveNode = node => node.type !== P.Text && node.type !== P.Svg;
+const isRecursiveNode = node => node.type !== P.Text && node.type !== P.Svg && node.type !== P.DocProvider;
 
 const renderChildren = (ctx, node, options) => {
   ctx.save();
@@ -36,6 +37,7 @@ const renderFns = {
   [P.Image]: renderImage,
   [P.Canvas]: renderCanvas,
   [P.Svg]: renderSvg,
+  [P.DocProvider]: renderDocProvider,
   [P.Link]: setLink,
 };
 

--- a/packages/render/tests/primitives/renderDocProvider.test.js
+++ b/packages/render/tests/primitives/renderDocProvider.test.js
@@ -1,0 +1,17 @@
+import * as P from '@react-pdf/primitives';
+
+import createCTX from '../ctx';
+import renderDocProvider from '../../src/primitives/renderDocProvider';
+
+describe('primitive renderDocProvider', () => {
+  test('should not render if node has no background', () => {
+    const ctx = createCTX();
+    let capture = null;
+    const props = { fn: jest.fn() };
+    const node = { type: P.DocProvider, props };
+
+    renderDocProvider(ctx, node);
+
+    expect(node.props.fn).toHaveBeenCalledWith(ctx);
+  });
+});


### PR DESCRIPTION
Adds a `<DocProvider fn={...}/>` primitive that gives you access to underlying `pdfkit` `PDFDocument`. This means you can use both `@react-pdf/renderer` (doing things in React/JSX) while also being able to use `pdfkit` functionality when needed.

This PR includes:
* The new functionality
* Some tests for `packages/primitives` and `packages/render`
* A new example called `docProvider` to demonstrate usage

### Example usage:

```jsx
<Document
  title="Table"
  author="Jane Doe"
  subject="Rendering with react-pdf and modifying document during render"
  keywords={['react', 'pdf', 'table']}
>
  <Page size="A4">
    <Text>This is the first page</Text>
  </Page>
  <DocProvider fn={doc => {
    doc.addPage({ size: "A4" });
    doc.text('This is the middle page, added using pdfkit!');
  }} />
  <Page size="A4">
    <Text>This is the last page</Text>
  </Page>
</Document>
```

### Thoughts:

I would also be nice to go the other way, allow `pdfkit` to pass a `PDFDocument` instance to `react-pdf/render` to render out nodes created using React/JSX. The problem is React/JSX nodes need to be rendered by the React Fiber Reconciler and also need to go through `react-pdf/layout` (which currently is only setup to be passed a document, not pages, or nodes individually), so the task was larger than I was willing to take on currently.