### PR TITLE
Add children Props to SvgProps. this fix #1873

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -239,6 +239,7 @@ declare namespace ReactPDF {
     height?: string | number;
     viewBox?: string;
     preserveAspectRatio?: string;
+    children?: React.ReactNode;
   }
 
   /**

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -343,7 +343,9 @@ declare namespace ReactPDF {
    */
   class Tspan extends React.Component<TspanProps> {}
 
-  interface GProps extends SVGPresentationAttributes {}
+  interface GProps extends SVGPresentationAttributes {
+    children?: React.ReactNode;
+  }
 
   /**
    * The <G /> SVG element is a container used to group other SVG elements.


### PR DESCRIPTION
this will fix the Typescript error for svg. see issue #1873 