### PR TITLE
Add missing `dpi` and `bookmark` page prop types

### DIFF
--- a/.changeset/tiny-needles-sing.md
+++ b/.changeset/tiny-needles-sing.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/renderer': patch
+'@react-pdf/types': patch
+---
+
+Add `dpi` and `bookmark` page prop types

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -8,6 +8,7 @@ import {
   SourceObject,
   HyphenationCallback,
   SVGPresentationAttributes,
+  Bookmark,
 } from '@react-pdf/types';
 
 declare namespace ReactPDF {
@@ -73,6 +74,8 @@ declare namespace ReactPDF {
     debug?: boolean;
     size?: PageSize;
     orientation?: Orientation;
+    dpi?: number;
+    bookmark?: Bookmark;
     children?: React.ReactNode;
   }
 

--- a/packages/types/index.d.ts
+++ b/packages/types/index.d.ts
@@ -7,3 +7,4 @@ export * from './style';
 export * from './image';
 export * from './context';
 export * from './primitive';
+export * from './bookmark';


### PR DESCRIPTION
**Addresses [1957](https://github.com/diegomura/react-pdf/issues/1957)**

Updates the typescript definitions for the Page component to include missing prop types: `dpi` and `bookmark`.

We're needing to use the `dpi` prop for our Typescript project so wanted to put in a quick fix for this issue!