### PR TITLE
fix: allow credentials option in Image

### DIFF
--- a/.changeset/four-shirts-refuse.md
+++ b/.changeset/four-shirts-refuse.md
@@ -1,0 +1,6 @@
+---
+"@react-pdf/image": patch
+"@react-pdf/types": patch
+---
+
+fix: allow credentials option in Image

--- a/packages/image/src/resolve.js
+++ b/packages/image/src/resolve.js
@@ -153,7 +153,7 @@ const resolveImageFromUrl = async src => {
           body,
           headers,
           method,
-          ...(credentials && { credentials }),
+          credentials,
         });
 
   const extension = getImageFormat(data);

--- a/packages/image/src/resolve.js
+++ b/packages/image/src/resolve.js
@@ -144,12 +144,17 @@ const getImageFormat = body => {
 };
 
 const resolveImageFromUrl = async src => {
-  const { uri, body, headers, method = 'GET' } = src;
+  const { uri, body, headers, method = 'GET', credentials } = src;
 
   const data =
     !BROWSER && getAbsoluteLocalPath(uri)
       ? await fetchLocalFile(uri)
-      : await fetchRemoteFile(uri, { body, headers, method });
+      : await fetchRemoteFile(uri, {
+          body,
+          headers,
+          method,
+          ...(credentials && { credentials }),
+        });
 
   const extension = getImageFormat(data);
 

--- a/packages/image/tests/resolve.test.js
+++ b/packages/image/tests/resolve.test.js
@@ -59,7 +59,7 @@ describe('image resolveImage', () => {
     expect(fetch.mock.calls[0][1].credentials).toBe(credentials);
   });
 
-  test('Should fetch remote image without credentials if not exist', async () => {
+  test('Should not include credentials if not exist', async () => {
     fetch.once(localJPGImage);
 
     await resolveImage({ uri: jpgImageUrl });

--- a/packages/image/tests/resolve.test.js
+++ b/packages/image/tests/resolve.test.js
@@ -50,6 +50,23 @@ describe('image resolveImage', () => {
     expect(fetch.mock.calls[0][1].body).toEqual(body);
   });
 
+  test('Should fetch remote image using passed credentials', async () => {
+    fetch.once(localJPGImage);
+
+    const credentials = 'include';
+    await resolveImage({ uri: jpgImageUrl, credentials });
+
+    expect(fetch.mock.calls[0][1].credentials).toBe(credentials);
+  });
+
+  test('Should fetch remote image without credentials if not exist', async () => {
+    fetch.once(localJPGImage);
+
+    await resolveImage({ uri: jpgImageUrl });
+
+    expect(fetch.mock.calls[0][1].credentials).toBeUndefined();
+  });
+
   test('Should render a jpeg image over http', async () => {
     fetch.once(localJPGImage);
 

--- a/packages/types/image.d.ts
+++ b/packages/types/image.d.ts
@@ -6,7 +6,7 @@ type SourceBuffer = Buffer
 
 type SourceDataBuffer = { data: Buffer; format: 'png' | 'jpg' }
 
-type SourceURLObject =  { uri: string; method: HTTPMethod; body: any; headers: any }
+type SourceURLObject =  { uri: string; method: HTTPMethod; body: any; headers: any, credentials?: 'omit' | 'same-origin' | 'include' }
 
 type Source =
   | SourceURL

--- a/packages/types/image.d.ts
+++ b/packages/types/image.d.ts
@@ -6,7 +6,7 @@ type SourceBuffer = Buffer
 
 type SourceDataBuffer = { data: Buffer; format: 'png' | 'jpg' }
 
-type SourceURLObject =  { uri: string; method: HTTPMethod; body: any; headers: any, credentials?: 'omit' | 'same-origin' | 'include' }
+type SourceURLObject =  { uri: string; method: HTTPMethod; body: any; headers: any; credentials?: 'omit' | 'same-origin' | 'include' }
 
 type Source =
   | SourceURL


### PR DESCRIPTION
**Description of change:**
Added `credentials` option which is required in `fetch` in order to send cookies in cross-origin requests.
src:[ mdn web docs](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch)

<img width="830" alt="image" src="https://user-images.githubusercontent.com/21151562/210028984-000412b4-13fb-46be-ba1c-9e1f95c4bcdc.png">

This PR also fixes the issue #1412