### PR TITLE
bundle react-reconciler to avoid peerDeps problem

### DIFF
--- a/.changeset/funny-gifts-grin.md
+++ b/.changeset/funny-gifts-grin.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': minor
+---
+
+fix react peer dependency problem

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -33,11 +33,13 @@
     "@react-pdf/render": "^3.2.1",
     "@react-pdf/types": "^2.1.1",
     "queue": "^6.0.1",
-    "react-reconciler": "^0.23.0",
+    "loose-envify": "^1.1.0",
+    "object-assign": "^4.1.1",
+    "prop-types": "^15.6.2",
     "scheduler": "^0.17.0"
   },
   "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0"
+    "react": "^16.8.6 || ^17.0.0 || ^18.0.0"
   },
   "lint-staged": {
     "*.js": [
@@ -66,6 +68,7 @@
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "process": "^0.11.10",
+    "react-reconciler": "0.23.0",
     "size-limit": "^7.0.5",
     "util": "^0.12.4"
   }

--- a/packages/renderer/rollup.config.js
+++ b/packages/renderer/rollup.config.js
@@ -38,12 +38,9 @@ const babelConfig = () => ({
 });
 
 const getExternal = ({ browser }) => [
-  '@babel/runtime/helpers/extends',
-  '@babel/runtime/helpers/objectWithoutPropertiesLoose',
-  '@babel/runtime/helpers/asyncToGenerator',
-  '@babel/runtime/regenerator',
+  /@babel\/runtime/,
   ...(browser ? [] : ['fs', 'path', 'url']),
-  ...Object.keys(pkg.dependencies),
+  ...Object.keys(pkg.dependencies).filter(name => name !== 'react-reconciler'),
   ...Object.keys(pkg.peerDependencies),
 ];
 
@@ -58,6 +55,7 @@ const getPlugins = ({ browser, minify = false }) => [
     preventAssignment: true,
     values: {
       BROWSER: JSON.stringify(browser),
+      'process.env.NODE_ENV': JSON.stringify('production'),
     },
   }),
   ...(minify ? [terser()] : []),

--- a/packages/renderer/src/renderer.js
+++ b/packages/renderer/src/renderer.js
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-param-reassign */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8852,7 +8852,7 @@ react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-react-reconciler@^0.23.0:
+react-reconciler@0.23.0:
   version "0.23.0"
   resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.23.0.tgz#5f0bfc35dda030b0220c07de11f93131c5d6db63"
   integrity sha512-vV0KlLimP9a/NuRcM6GRVakkmT6MKSzhfo8K72fjHMnlXMOhz9GlPe+/tCp5CWBkg+lsMUt/CR1nypJBTPfwuw==


### PR DESCRIPTION
## another try to solve react peer dependency problem

I found a way to test it. 

npm supports installations from the tar archive, so I bundle a `@react-pdf/renderer` with those changes to a tar file with `npm pack` command and install into some new project


- The current master fails with error: 

```
npm i ./react-pdf-renderer-3.0.3.tgz
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: test-peer-deps@1.0.0
npm ERR! Found: react@18.2.0
npm ERR! node_modules/react
npm ERR!   react@"^18.2.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer react@"^16.8.6 || ^17.0.0" from @react-pdf/renderer@3.0.3
npm ERR! node_modules/@react-pdf/renderer
npm ERR!   @react-pdf/renderer@"file:react-pdf-renderer-3.0.3.tgz" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```

- peerDependencies `"react": "^16.8.6 || ^17.0.0 || ^18.0.0"` has the warning: 

```
npm i ./react-pdf-renderer-3.0.3.tgz
npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: react-reconciler@0.23.0
npm WARN Found: react@18.2.0
npm WARN node_modules/react
npm WARN   react@"^18.2.0" from the root project
npm WARN   1 more (@react-pdf/renderer)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peer react@"^16.0.0" from react-reconciler@0.23.0
npm WARN node_modules/@react-pdf/renderer/node_modules/react-reconciler
npm WARN   react-reconciler@"^0.23.0" from @react-pdf/renderer@3.0.3
npm WARN   node_modules/@react-pdf/renderer
npm WARN 
npm WARN Conflicting peer dependency: react@16.14.0
npm WARN node_modules/react
npm WARN   peer react@"^16.0.0" from react-reconciler@0.23.0
npm WARN   node_modules/@react-pdf/renderer/node_modules/react-reconciler
npm WARN     react-reconciler@"^0.23.0" from @react-pdf/renderer@3.0.3
npm WARN     node_modules/@react-pdf/renderer

```

- When `react-reconciler` is bundled everything is installed without errors and warnings 🥲

```
npm i ./react-pdf-renderer-3.0.3.tgz

added 65 packages, and audited 66 packages in 10s

2 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```



fix #1878 


