### PR TITLE
Removed conflicting or redundant children props

### DIFF
--- a/.changeset/young-students-allow.md
+++ b/.changeset/young-students-allow.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': patch
+---
+
+Improved `children` prop types for react@18.

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -29,7 +29,6 @@ declare namespace ReactPDF {
     language?: string;
     pdfVersion?: PDFVersion;
     onRender?: (props: OnRenderProps) => any;
-    children?: React.ReactNode;
   }
 
   /**
@@ -76,7 +75,6 @@ declare namespace ReactPDF {
     orientation?: Orientation;
     dpi?: number;
     bookmark?: Bookmark;
-    children?: React.ReactNode;
   }
 
   /**
@@ -103,7 +101,6 @@ declare namespace ReactPDF {
       pageNumber: number;
       subPageNumber: number;
     }) => React.ReactNode;
-    children?: React.ReactNode;
   }
 
   /**
@@ -155,7 +152,6 @@ declare namespace ReactPDF {
       subPageNumber: number;
       subPageTotalPages: number;
     }) => React.ReactNode;
-    children?: React.ReactNode;
     /**
      * Override the default hyphenation-callback
      * @see https://react-pdf.org/fonts#registerhyphenationcallback
@@ -202,7 +198,6 @@ declare namespace ReactPDF {
      */
     debug?: boolean;
     src: string;
-    children?: React.ReactNode;
   }
 
   /**
@@ -215,7 +210,7 @@ declare namespace ReactPDF {
     children: string;
   }
 
-  class Note extends React.Component<React.PropsWithChildren<NoteProps>> {}
+  class Note extends React.Component<NoteProps> {}
 
   interface CanvasProps extends NodeProps {
     /**
@@ -425,7 +420,7 @@ declare namespace ReactPDF {
    * @see https://react-pdf.org/advanced#on-the-fly-rendering
    * @platform web
    */
-  class BlobProvider extends React.Component<React.PropsWithChildren<BlobProviderProps>> {}
+  class BlobProvider extends React.Component<BlobProviderProps> {}
 
   interface PDFViewerProps {
     width?: number | string;
@@ -441,7 +436,7 @@ declare namespace ReactPDF {
    * Iframe PDF viewer for client-side generated documents.
    * @platform web
    */
-  class PDFViewer extends React.Component<React.PropsWithChildren<PDFViewerProps>> {}
+  class PDFViewer extends React.Component<PDFViewerProps> {}
 
   interface PDFDownloadLinkProps {
     document: React.ReactElement<DocumentProps>;
@@ -459,7 +454,7 @@ declare namespace ReactPDF {
    * @see https://react-pdf.org/advanced#on-the-fly-rendering
    * @platform web
    */
-  class PDFDownloadLink extends React.Component<React.PropsWithChildren<PDFDownloadLinkProps>> {}
+  class PDFDownloadLink extends React.Component<PDFDownloadLinkProps> {}
 
   interface UsePDFInstance {
     loading: boolean;

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -132,7 +132,7 @@ declare namespace ReactPDF {
    * A React component for displaying network or local (Node only) JPG or
    * PNG images, as well as base64 encoded image strings.
    */
-  class Image extends React.Component<React.PropsWithChildren<ImageProps>> {}
+  class Image extends React.Component<ImageProps> {}
 
   interface TextProps extends NodeProps {
     id?: string;
@@ -225,7 +225,7 @@ declare namespace ReactPDF {
     ) => null;
   }
 
-  class Canvas extends React.Component<React.PropsWithChildren<CanvasProps>> {}
+  class Canvas extends React.Component<CanvasProps> {}
 
   interface SVGProps extends NodeProps {
     /**


### PR DESCRIPTION
# Purpose

Fixes issues with conflicting or redundant `children` type definitions. 


# Issue History

I've included some history here to explain the issue as I understand it, what has been done to address it, and what is needed to fix the outstanding issues.

## Conflicting `children`

As mentioned in #1798, the release of react@18 [removed the implicit `children` prop](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210). It appears that the [types-react-codemod](https://github.com/eps1lon/types-react-codemod#readme) was used which added `React.PropsWithChildren<>` to all components. While this works for the majority of components, there are a few (`BlobProvider`, `PDFViewer`, and `PDFDownloadLink`) which have more specific requirements for `children`. The addition of `React.PropsWithChildren` with the existing definitions of `children` for these components causes issues like #2169. 


## Redundant `children`

In #1825 a few definitions of `children?: React.ReactNode` were added which became redundant when `React.PropsWithChildren` was added to the components that use those prop types. In these cases I just removed the redundant `children` definition and left the `React.PropsWithChildren`.



Fixes #2169 