### PR TITLE
Break on containers whose children can not fit on a page

### DIFF
--- a/.changeset/moody-bottles-buy.md
+++ b/.changeset/moody-bottles-buy.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/layout': minor
+---
+
+Break on containers whose children can not fit on a page

--- a/packages/layout/src/steps/resolvePagination.js
+++ b/packages/layout/src/steps/resolvePagination.js
@@ -95,6 +95,18 @@ const splitNodes = (height, contentArea, nodes) => {
     if (shouldSplit) {
       const [currentChild, nextChild] = split(child, height, contentArea);
 
+      // All children are moved to the next page, it doesn't make sense to show the parent on the current page
+      if (child.children.length > 0 && currentChild.children.length === 0) {
+        const box = Object.assign({}, child.box, {
+          top: child.box.top - height,
+        });
+        const next = Object.assign({}, child, { box });
+
+        currentChildren.push(...futureFixedNodes);
+        nextChildren.push(next, ...futureNodes);
+        break;
+      }
+
       if (currentChild) currentChildren.push(currentChild);
       if (nextChild) nextChildren.push(nextChild);
 

--- a/packages/layout/tests/steps/resolvePagination.test.js
+++ b/packages/layout/tests/steps/resolvePagination.test.js
@@ -169,4 +169,66 @@ describe('pagination step', () => {
 
     expect(layout.children.length).toBe(1);
   });
+
+  test('should break on a container whose children can not fit on a page', () => {
+    const root = {
+      type: 'DOCUMENT',
+      children: [
+        {
+          type: 'PAGE',
+          box: {},
+          style: {
+            width: 5,
+            height: 60,
+          },
+
+          children: [
+            {
+              type: 'VIEW',
+              box: {},
+              style: {
+                width: 5,
+                height: 40,
+              },
+              props: {},
+              children: [],
+            },
+            {
+              type: 'VIEW',
+              box: {},
+              style: {
+                width: 5,
+              },
+              props: {},
+              children: [
+                {
+                  type: 'VIEW',
+                  box: {},
+                  style: {
+                    height: 40,
+                  },
+                  props: {
+                    wrap: false,
+                  },
+                  children: [],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const layout = calcLayout(root);
+    console.log(layout.children[0].children);
+
+    const page1 = layout.children[0];
+    const page2 = layout.children[1];
+
+    // Only the first view is displayed on the first page
+    expect(page1.children.length).toBe(1);
+    // The second page displays the second wrapper, with its full height
+    expect(page2.children.length).toBe(1);
+    expect(page2.children[0].box.height).toBe(40);
+  });
 });


### PR DESCRIPTION
Fixes problem described in #2197. I've tested it locally with [repro](https://react-pdf.org/repl?code=3187b0760ce02e0040a200f021816c00e01b0298c0bc3002804a3c03e420281860078011118015c52cc294abada005240731cd0027b65c01bdc5a24004c6404b30fc0170c004c001800d0c0046498006b7e009c4133032030880c204ea804419e7f0016514d6618e02fafce6e6e71006d00461d35005d003a1424340262324a20a0807a002a180015377908180037792c0077186024300072583724229c329304890033240c082c5f1d5d2c2aa61e9879769808457e6c4afc8c1951c2a45d19f6f958701828371c69411800491832ead828101834265875ad9d932c18984cf4ae34da0035528a9131491878899f88a0010880a0e7142a8d400561d348e4535500199b47a03318cc166b2d9ec4e00310c861000e003b1931cd47f0c102ef6e0d0bee563ab4d01d2e8f57c1328288b01271195e4326d938c21a0d001491c3a1dab83c28b17f431a6732586c76070c11cf8b26e98944a94029040d078321d0987f9d2b4ba67dbeccb6b893add5e972797c8150adc22b164ba55859541e568fd11995d8b55e335dad26ebf596eb5a468e94659413d4221117c6f5a3a4f8825a52618cc563b138440037050ab00252c018a03c3a000c4620f4b1604c041a22150981c15a2b1420000) and the issue is resolved.

I am open to all suggestions, I am not familiar with the codebase.