### PR TITLE
fix: Add missing props types on Document element

### DIFF
--- a/.changeset/forty-forks-divide.md
+++ b/.changeset/forty-forks-divide.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': patch
+---
+
+Add missing props types on `Document` component

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -9,6 +9,8 @@ import {
   HyphenationCallback,
   SVGPresentationAttributes,
   Bookmark,
+  PageLayout,
+  PageMode,
 } from '@react-pdf/types';
 
 declare namespace ReactPDF {
@@ -28,6 +30,8 @@ declare namespace ReactPDF {
     producer?: string;
     language?: string;
     pdfVersion?: PDFVersion;
+    pageMode?: PageMode;
+    pageLayout ?: PageLayout;
     onRender?: (props: OnRenderProps) => any;
   }
 

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -22,6 +22,7 @@ declare namespace ReactPDF {
   }
 
   interface DocumentProps {
+    style?: Style | Style[];
     title?: string;
     author?: string;
     subject?: string;


### PR DESCRIPTION
fix issue #2231 

I added types in the correct file and it work properly