### PR TITLE
fix: fix all strings allowed in `fontWeight` in `Font.register`

### DIFF
--- a/.changeset/cyan-keys-sing.md
+++ b/.changeset/cyan-keys-sing.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/types': patch
+---
+
+Fixed all strings allowed in `fontWeight` in `Font.register`

--- a/packages/types/font.d.ts
+++ b/packages/types/font.d.ts
@@ -61,7 +61,7 @@ interface SingleLoad {
   family: string;
   src: string;
   fontStyle?: string;
-  fontWeight?: string | number;
+  fontWeight?: FontWeight;
   [key: string]: any;
 }
 
@@ -70,7 +70,7 @@ interface BulkLoad {
   fonts: {
     src: string;
     fontStyle?: string;
-    fontWeight?: string | number;
+    fontWeight?: FontWeight;
     [key: string]: any;
   }[];
 }


### PR DESCRIPTION
When working on the PDF, I wrote the following code:

```ts
Font.register({
  family: 'Helvetica Neue',
  fonts: [
    { src: helveticaNeueRegular },
    { src: helveticaNeueMedium, fontWeight: '500' },
    { src: helveticaNeueBold, fontWeight: '700' },
  ],
});

const styles = StyleSheet.create({
  foo: {
    fontFamily: 'Helvetica Neue',
    fontWeight: 500,
  }
});
```

To my surprise, this did not work properly. After investigation, I figured out that my mistake was in defining `fontWeight` as string in `Font.register`, which is something TypeScript was okay with me to do.

Narrowing `fontWeight` type fixes that.