### PR TITLE
fix: fix crash on `transform="translate(1)`

### DIFF
--- a/.changeset/silent-flowers-dream.md
+++ b/.changeset/silent-flowers-dream.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/render': patch
+---
+
+Fixed crash on `transform="translate(1)"`

--- a/packages/render/src/operations/transform.js
+++ b/packages/render/src/operations/transform.js
@@ -15,7 +15,7 @@ const applySingleTransformation = (ctx, transform, origin) => {
     }
 
     case 'translate': {
-      const [x, y] = value;
+      const [x, y = 0] = value;
       ctx.translate(x, y, { origin });
       break;
     }


### PR DESCRIPTION
Providing one value to `translate()` produces valid SVG and is a common thing to see especially in minified SVGs.

When working with such SVG, I got a crash with a rather cryptic error message: "Error: unsupported number: undefined". Upon investigation, the lack of default `y` value turned out to be the cause.