### PR TITLE
chore: make `cx` and `cy` optional in `Circle` and `Ellipse`

### DIFF
--- a/.changeset/warm-needles-cough.md
+++ b/.changeset/warm-needles-cough.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/renderer': patch
+'@react-pdf/render': patch
+---
+
+Make `cx` and `cy` optional in `Circle` and `Ellipse`

--- a/packages/render/src/primitives/renderEllipse.js
+++ b/packages/render/src/primitives/renderEllipse.js
@@ -1,6 +1,6 @@
 const KAPPA = 4.0 * ((Math.sqrt(2) - 1.0) / 3.0);
 
-export const drawEllipse = (ctx, cx, cy, rx, ry) => {
+export const drawEllipse = (ctx, cx = 0, cy = 0, rx, ry) => {
   const x = cx - rx;
   const y = cy - ry;
   const ox = rx * KAPPA;

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -32,7 +32,7 @@ declare namespace ReactPDF {
     language?: string;
     pdfVersion?: PDFVersion;
     pageMode?: PageMode;
-    pageLayout ?: PageLayout;
+    pageLayout?: PageLayout;
     onRender?: (props: OnRenderProps) => any;
   }
 
@@ -318,8 +318,8 @@ declare namespace ReactPDF {
 
   interface CircleProps extends SVGPresentationAttributes {
     style?: SVGPresentationAttributes;
-    cx: string | number;
-    cy: string | number;
+    cx?: string | number;
+    cy?: string | number;
     r: string | number;
   }
 
@@ -330,8 +330,8 @@ declare namespace ReactPDF {
 
   interface EllipseProps extends SVGPresentationAttributes {
     style?: SVGPresentationAttributes;
-    cx: string | number;
-    cy: string | number;
+    cx?: string | number;
+    cy?: string | number;
     rx: string | number;
     ry: string | number;
   }


### PR DESCRIPTION
In SVG, when `<circle>` is not provided with `cx` or `cy`, it defaults them to `0`. So, there's no need to require users to explicitly provide these props.
