### PR TITLE
Typings: Add `table` support to `display` style

### DIFF
--- a/.changeset/tidy-turtles-trade.md
+++ b/.changeset/tidy-turtles-trade.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/types': minor
+---
+
+Typings: Add `table` support to `display` style

--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -20,7 +20,7 @@ export interface Style {
 
   aspectRatio?: number | string;
   bottom?: number | string;
-  display?: 'flex' | 'none';
+  display?: 'flex' | 'table' | 'none';
   left?: number | string;
   position?: 'absolute' | 'relative';
   right?: number | string;


### PR DESCRIPTION
Fix #2358: Add missing `table` value for `display` attribute.