### PR TITLE
Add callback to updateContainer

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -511,7 +511,7 @@ declare namespace ReactPDF {
     toBlob: () => Promise<Blob>;
     toBuffer: () => Promise<NodeJS.ReadableStream>;
     on: (event: 'change', callback: () => void) => void;
-    updateContainer: (document: React.ReactElement<any>) => void;
+    updateContainer: (document: React.ReactElement<any>, callback?: () => void) => void;
     removeListener: (event: 'change', callback: () => void) => void;
   };
 

--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -25,8 +25,8 @@ const pdf = initialValue => {
   renderer = renderer || createRenderer({ onChange });
   const mountNode = renderer.createContainer(container);
 
-  const updateContainer = doc => {
-    renderer.updateContainer(doc, mountNode, null);
+  const updateContainer = (doc, callback) => {
+    renderer.updateContainer(doc, mountNode, null, callback);
   };
 
   if (initialValue) updateContainer(initialValue);


### PR DESCRIPTION
This is useful so we can figure out when React is done building the page.

I had trouble with stale data getting into my pages.

This small change allows me to write a hook like:

```
const usePdf = (document: React.ReactElement) => {
	// Setup the pdfInstace. We only create it once on mount and never again. 
	// (could have same behaviour with useRef(null) + useEffect(() => ref.current = pdf(document),[]))
	const [ pdfInstance, ] = useState(() => pdf(document))

	const update = useCallback(async (newDoc: React.ReactElement) => {
                 // create a promisified update function.
		const updateInstance = (newDoc: React.ReactElement) => { 
			return new Promise<void>(resolve => (
                                 // use the new callback here to be notified when React is done working and its safe to render
				pdfInstance.updateContainer(newDoc, () => resolve())
			))
		}
		
		await updateInstance(newDoc) // We can render now!   
		const blob = await pdfInstance.toBlob()

		return blob
	  }, [ pdfInstance, ])

	  return update
}
```

In my tests this has less issues with stale data compared to the default usePdf hooks provided. 

As we are only changing an optional parameter, I dont think this should be considered a breaking change. 

Thanks for a great library!