### PR TITLE
build: update crypto-js from 4.0.0 -> 4.2.0 [CVE-2023-46233]

### DIFF
--- a/.changeset/seven-dodos-live.md
+++ b/.changeset/seven-dodos-live.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+build: update crypto-js from 4.0.0 -> 4.2.0 (CVE-2023-46233)

--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -32,7 +32,7 @@
     "@babel/runtime": "^7.20.13",
     "@react-pdf/png-js": "^2.2.0",
     "browserify-zlib": "^0.2.0",
-    "crypto-js": "^4.0.0",
+    "crypto-js": "^4.2.0",
     "fontkit": "^2.0.2",
     "vite-compatible-readable-stream": "^3.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4372,10 +4372,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-crypto-js@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
-  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 cssom@^0.5.0:
   version "0.5.0"


### PR DESCRIPTION
Resolves #2447

Per https://nvd.nist.gov/vuln/detail/CVE-2023-46233 , `crypto-js` has a "critical" weakness in one of its algorithms, PBKDF2 .

`@react-pdf/pdfkit` has `crypto-js` as one of its dependencies, although it doesn't actually use the vulnerable algorithm, (it only uses `md5`). ( See https://github.com/diegomura/react-pdf/issues/2447#issuecomment-1811849815 ) 

SCA tools like dependabot don't perform static analysis to confirm that a given dependency's vulnerable code is actually used in a package, so even though react-pdf is not actually vulnerable, dependabot and other SCA tools will raise an alert.