### PR TITLE
fix: add clipPath to typing for SVGPresentationAttributes

### DIFF
--- a/.changeset/eighty-lizards-leave.md
+++ b/.changeset/eighty-lizards-leave.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/types": patch
+---
+
+fix: add clipPath to typing for SVGPresentationAttributes

--- a/packages/types/svg.d.ts
+++ b/packages/types/svg.d.ts
@@ -12,6 +12,7 @@ export interface SVGPresentationAttributes {
   textAnchor?: 'start' | 'middle' | 'end';
   strokeLineCap?: 'butt' | 'round' | 'square';
   visibility?: 'visible' | 'hidden' | 'collapse';
+  clipPath?: string;
   dominantBaseline?:
     | 'auto'
     | 'middle'


### PR DESCRIPTION
Using the clipPath attribute was causing a type error in Typescript because it was missing from the type def.