### PR TITLE
feat: include text preceeding special case emojis, include ™ symbol in excluded emojis

### DIFF
--- a/.changeset/sharp-mirrors-taste.md
+++ b/.changeset/sharp-mirrors-taste.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/layout": patch
+---
+
+feat: include text preceeding special case emojis, include ™ symbol in excluded emojis

--- a/packages/layout/src/text/emoji.js
+++ b/packages/layout/src/text/emoji.js
@@ -67,7 +67,7 @@ export const fetchEmojis = (string, source) => {
   return promises;
 };
 
-const specialCases = ['©️', '®']; // Do not treat these as emojis if emoji not present
+const specialCases = ['©️', '®', '™']; // Do not treat these as emojis if emoji not present
 
 export const embedEmojis = fragments => {
   const result = [];
@@ -101,7 +101,7 @@ export const embedEmojis = fragments => {
           },
         });
       } else if (isSpecialCase) {
-        result.push({ string: emoji, attributes: fragment.attributes });
+        result.push({ string: chunk, attributes: fragment.attributes });
       } else {
         // If no emoji data, we just replace the emoji with a nodef char
         result.push({


### PR DESCRIPTION
This PR fixes an issue where text fragments containing a special case symbol (trademark/copyright symbol) would get replaced with just the symbol. It also adds a new excluded symbol (™). 