### PR TITLE
feat: wasm yoga

### DIFF
--- a/.changeset/slimy-kiwis-cry.md
+++ b/.changeset/slimy-kiwis-cry.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/renderer': minor
+'@react-pdf/layout': minor
+---
+
+feat: wasm yoga

--- a/packages/layout/src/image/measureImage.js
+++ b/packages/layout/src/image/measureImage.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import getRatio from './getRatio';
 import getMargin from '../node/getMargin';
@@ -40,32 +40,32 @@ const measureImage = (page, node) => (width, widthMode, height, heightMode) => {
   if (!node.image) return { width: 0, height: 0 };
 
   if (
-    widthMode === Yoga.MEASURE_MODE_EXACTLY &&
-    heightMode === Yoga.MEASURE_MODE_UNDEFINED
+    widthMode === Yoga.MeasureMode.Exactly &&
+    heightMode === Yoga.MeasureMode.Undefined
   ) {
     const scaledHeight = width / imageRatio;
     return { height: Math.min(pageArea, scaledHeight) };
   }
 
   if (
-    heightMode === Yoga.MEASURE_MODE_EXACTLY &&
-    (widthMode === Yoga.MEASURE_MODE_AT_MOST ||
-      widthMode === Yoga.MEASURE_MODE_UNDEFINED)
+    heightMode === Yoga.MeasureMode.Exactly &&
+    (widthMode === Yoga.MeasureMode.AtMost ||
+      widthMode === Yoga.MeasureMode.Undefined)
   ) {
     return { width: Math.min(height * imageRatio, width) };
   }
 
   if (
-    widthMode === Yoga.MEASURE_MODE_EXACTLY &&
-    heightMode === Yoga.MEASURE_MODE_AT_MOST
+    widthMode === Yoga.MeasureMode.Exactly &&
+    heightMode === Yoga.MeasureMode.AtMost
   ) {
     const scaledHeight = width / imageRatio;
     return { height: Math.min(height, pageArea, scaledHeight) };
   }
 
   if (
-    widthMode === Yoga.MEASURE_MODE_AT_MOST &&
-    heightMode === Yoga.MEASURE_MODE_AT_MOST
+    widthMode === Yoga.MeasureMode.AtMost &&
+    heightMode === Yoga.MeasureMode.AtMost
   ) {
     if (imageRatio > 1) {
       return {

--- a/packages/layout/src/index.js
+++ b/packages/layout/src/index.js
@@ -1,6 +1,7 @@
 import { asyncCompose } from '@react-pdf/fns';
 
 import resolveSvg from './steps/resolveSvg';
+import resolveYoga from './steps/resolveYoga';
 import resolveZIndex from './steps/resolveZIndex';
 import resolveAssets from './steps/resolveAssets';
 import resolveStyles from './steps/resolveStyles';
@@ -32,6 +33,7 @@ const layout = asyncCompose(
   resolveLinkSubstitution,
   resolveBookmarks,
   resolvePageSizes,
+  resolveYoga,
 );
 
 export default layout;

--- a/packages/layout/src/node/getBorderWidth.js
+++ b/packages/layout/src/node/getBorderWidth.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 const getComputedBorder = (yogaNode, edge) =>
   yogaNode ? yogaNode.getComputedBorder(edge) : 0;
@@ -13,10 +13,10 @@ const getBorderWidth = (node) => {
   const { yogaNode } = node;
 
   return {
-    borderTopWidth: getComputedBorder(yogaNode, Yoga.EDGE_TOP),
-    borderRightWidth: getComputedBorder(yogaNode, Yoga.EDGE_RIGHT),
-    borderBottomWidth: getComputedBorder(yogaNode, Yoga.EDGE_BOTTOM),
-    borderLeftWidth: getComputedBorder(yogaNode, Yoga.EDGE_LEFT),
+    borderTopWidth: getComputedBorder(yogaNode, Yoga.Edge.Top),
+    borderRightWidth: getComputedBorder(yogaNode, Yoga.Edge.Right),
+    borderBottomWidth: getComputedBorder(yogaNode, Yoga.Edge.Bottom),
+    borderLeftWidth: getComputedBorder(yogaNode, Yoga.Edge.Left),
   };
 };
 

--- a/packages/layout/src/node/getMargin.js
+++ b/packages/layout/src/node/getMargin.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 const getComputedMargin = (node, edge) => {
   const { yogaNode } = node;
@@ -15,7 +15,7 @@ const getMargin = (node) => {
   const { style, box } = node;
 
   const marginTop =
-    getComputedMargin(node, Yoga.EDGE_TOP) ||
+    getComputedMargin(node, Yoga.Edge.Top) ||
     box?.marginTop ||
     style?.marginTop ||
     style?.marginVertical ||
@@ -23,7 +23,7 @@ const getMargin = (node) => {
     0;
 
   const marginRight =
-    getComputedMargin(node, Yoga.EDGE_RIGHT) ||
+    getComputedMargin(node, Yoga.Edge.Right) ||
     box?.marginRight ||
     style?.marginRight ||
     style?.marginHorizontal ||
@@ -31,7 +31,7 @@ const getMargin = (node) => {
     0;
 
   const marginBottom =
-    getComputedMargin(node, Yoga.EDGE_BOTTOM) ||
+    getComputedMargin(node, Yoga.Edge.Bottom) ||
     box?.marginBottom ||
     style?.marginBottom ||
     style?.marginVertical ||
@@ -39,7 +39,7 @@ const getMargin = (node) => {
     0;
 
   const marginLeft =
-    getComputedMargin(node, Yoga.EDGE_LEFT) ||
+    getComputedMargin(node, Yoga.Edge.Left) ||
     box?.marginLeft ||
     style?.marginLeft ||
     style?.marginHorizontal ||

--- a/packages/layout/src/node/getPadding.js
+++ b/packages/layout/src/node/getPadding.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 const getComputedPadding = (node, edge) => {
   const { yogaNode } = node;
@@ -15,7 +15,7 @@ const getPadding = (node) => {
   const { style, box } = node;
 
   const paddingTop =
-    getComputedPadding(node, Yoga.EDGE_TOP) ||
+    getComputedPadding(node, Yoga.Edge.Top) ||
     box?.paddingTop ||
     style?.paddingTop ||
     style?.paddingVertical ||
@@ -23,7 +23,7 @@ const getPadding = (node) => {
     0;
 
   const paddingRight =
-    getComputedPadding(node, Yoga.EDGE_RIGHT) ||
+    getComputedPadding(node, Yoga.Edge.Right) ||
     box?.paddingRight ||
     style?.paddingRight ||
     style?.paddingHorizontal ||
@@ -31,7 +31,7 @@ const getPadding = (node) => {
     0;
 
   const paddingBottom =
-    getComputedPadding(node, Yoga.EDGE_BOTTOM) ||
+    getComputedPadding(node, Yoga.Edge.Bottom) ||
     box?.paddingBottom ||
     style?.paddingBottom ||
     style?.paddingVertical ||
@@ -39,7 +39,7 @@ const getPadding = (node) => {
     0;
 
   const paddingLeft =
-    getComputedPadding(node, Yoga.EDGE_LEFT) ||
+    getComputedPadding(node, Yoga.Edge.Left) ||
     box?.paddingLeft ||
     style?.paddingLeft ||
     style?.paddingHorizontal ||

--- a/packages/layout/src/node/setAlign.js
+++ b/packages/layout/src/node/setAlign.js
@@ -1,14 +1,14 @@
+import * as Yoga from 'yoga-layout';
 import { upperFirst } from '@react-pdf/fns';
-import Yoga from '../../yoga';
 
 const ALIGN = {
-  'flex-start': Yoga.ALIGN_FLEX_START,
-  center: Yoga.ALIGN_CENTER,
-  'flex-end': Yoga.ALIGN_FLEX_END,
-  stretch: Yoga.ALIGN_STRETCH,
-  baseline: Yoga.ALIGN_BASELINE,
-  'space-between': Yoga.ALIGN_SPACE_BETWEEN,
-  'space-around': Yoga.ALIGN_SPACE_AROUND,
+  'flex-start': Yoga.Align.FlexStart,
+  center: Yoga.Align.Center,
+  'flex-end': Yoga.Align.FlexEnd,
+  stretch: Yoga.Align.Stretch,
+  baseline: Yoga.Align.Baseline,
+  'space-between': Yoga.Align.SpaceBetween,
+  'space-around': Yoga.Align.SpaceAround,
 };
 
 /**
@@ -31,7 +31,7 @@ const ALIGN = {
  */
 const setAlign = attr => value => node => {
   const { yogaNode } = node;
-  const defaultValue = attr === 'items' ? Yoga.ALIGN_STRETCH : Yoga.ALIGN_AUTO;
+  const defaultValue = attr === 'items' ? Yoga.Align.Stretch : Yoga.Align.Auto;
 
   if (yogaNode) {
     const align = ALIGN[value] || defaultValue;

--- a/packages/layout/src/node/setBorderWidth.js
+++ b/packages/layout/src/node/setBorderWidth.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setYogaValue from './setYogaValue';
 
@@ -15,7 +15,7 @@ import setYogaValue from './setYogaValue';
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setBorderTop = setYogaValue('border', Yoga.EDGE_TOP);
+export const setBorderTop = setYogaValue('border', Yoga.Edge.Top);
 
 /**
  * Set border right attribute to node's Yoga instance
@@ -24,7 +24,7 @@ export const setBorderTop = setYogaValue('border', Yoga.EDGE_TOP);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setBorderRight = setYogaValue('border', Yoga.EDGE_RIGHT);
+export const setBorderRight = setYogaValue('border', Yoga.Edge.Right);
 
 /**
  * Set border bottom attribute to node's Yoga instance
@@ -33,7 +33,7 @@ export const setBorderRight = setYogaValue('border', Yoga.EDGE_RIGHT);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setBorderBottom = setYogaValue('border', Yoga.EDGE_BOTTOM);
+export const setBorderBottom = setYogaValue('border', Yoga.Edge.Bottom);
 
 /**
  * Set border left attribute to node's Yoga instance
@@ -42,7 +42,7 @@ export const setBorderBottom = setYogaValue('border', Yoga.EDGE_BOTTOM);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setBorderLeft = setYogaValue('border', Yoga.EDGE_LEFT);
+export const setBorderLeft = setYogaValue('border', Yoga.Edge.Left);
 
 /**
  * Set all border widths at once

--- a/packages/layout/src/node/setDisplay.js
+++ b/packages/layout/src/node/setDisplay.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 /**
  * @typedef {Function} NodeInstanceWrapper
@@ -17,7 +17,7 @@ const setDisplay = value => node => {
 
   if (yogaNode) {
     yogaNode.setDisplay(
-      value === 'none' ? Yoga.DISPLAY_NONE : Yoga.DISPLAY_FLEX,
+      value === 'none' ? Yoga.Display.None : Yoga.Display.Flex,
     );
   }
 

--- a/packages/layout/src/node/setFlexDirection.js
+++ b/packages/layout/src/node/setFlexDirection.js
@@ -1,9 +1,9 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 const FLEX_DIRECTIONS = {
-  row: Yoga.FLEX_DIRECTION_ROW,
-  'row-reverse': Yoga.FLEX_DIRECTION_ROW_REVERSE,
-  'column-reverse': Yoga.FLEX_DIRECTION_COLUMN_REVERSE,
+  row: Yoga.FlexDirection.Row,
+  'row-reverse': Yoga.FlexDirection.RowReverse,
+  'column-reverse': Yoga.FlexDirection.ColumnReverse,
 };
 
 /**
@@ -22,7 +22,7 @@ const setFlexDirection = value => node => {
   const { yogaNode } = node;
 
   if (yogaNode) {
-    const flexDirection = FLEX_DIRECTIONS[value] || Yoga.FLEX_DIRECTION_COLUMN;
+    const flexDirection = FLEX_DIRECTIONS[value] || Yoga.FlexDirection.Column;
     yogaNode.setFlexDirection(flexDirection);
   }
 

--- a/packages/layout/src/node/setFlexWrap.js
+++ b/packages/layout/src/node/setFlexWrap.js
@@ -1,8 +1,8 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 const FLEX_WRAP = {
-  wrap: Yoga.WRAP_WRAP,
-  'wrap-reverse': Yoga.WRAP_WRAP_REVERSE,
+  wrap: Yoga.Wrap.Wrap,
+  'wrap-reverse': Yoga.Wrap.WrapReverse,
 };
 
 /**
@@ -21,7 +21,7 @@ const setFlexWrap = value => node => {
   const { yogaNode } = node;
 
   if (yogaNode) {
-    const flexWrap = FLEX_WRAP[value] || Yoga.WRAP_NO_WRAP;
+    const flexWrap = FLEX_WRAP[value] || Yoga.Wrap.NoWrap;
     yogaNode.setFlexWrap(flexWrap);
   }
 

--- a/packages/layout/src/node/setGap.js
+++ b/packages/layout/src/node/setGap.js
@@ -1,5 +1,5 @@
+import * as Yoga from 'yoga-layout';
 import { isNil, matchPercent } from '@react-pdf/fns';
-import Yoga from '../../yoga';
 
 /**
  * @typedef {Function} NodeInstanceWrapper
@@ -33,7 +33,7 @@ export const setRowGap = value => node => {
 
   if (!isNil(value) && yogaNode) {
     checkPercents('rowGap', value);
-    yogaNode.setGap(Yoga.GUTTER_ROW, value);
+    yogaNode.setGap(Yoga.Gutter.Row, value);
   }
 
   return node;
@@ -50,7 +50,7 @@ export const setColumnGap = value => node => {
 
   if (!isNil(value) && yogaNode) {
     checkPercents('columnGap', value);
-    yogaNode.setGap(Yoga.GUTTER_COLUMN, value);
+    yogaNode.setGap(Yoga.Gutter.Column, value);
   }
 
   return node;

--- a/packages/layout/src/node/setJustifyContent.js
+++ b/packages/layout/src/node/setJustifyContent.js
@@ -1,12 +1,12 @@
+import * as Yoga from 'yoga-layout';
 import { isNil } from '@react-pdf/fns';
-import Yoga from '../../yoga';
 
 const JUSTIFY_CONTENT = {
-  center: Yoga.JUSTIFY_CENTER,
-  'flex-end': Yoga.JUSTIFY_FLEX_END,
-  'space-between': Yoga.JUSTIFY_SPACE_BETWEEN,
-  'space-around': Yoga.JUSTIFY_SPACE_AROUND,
-  'space-evenly': Yoga.JUSTIFY_SPACE_EVENLY,
+  center: Yoga.Justify.Center,
+  'flex-end': Yoga.Justify.FlexEnd,
+  'space-between': Yoga.Justify.SpaceBetween,
+  'space-around': Yoga.Justify.SpaceAround,
+  'space-evenly': Yoga.Justify.SpaceEvenly,
 };
 
 /**
@@ -25,7 +25,7 @@ const setJustifyContent = value => node => {
   const { yogaNode } = node;
 
   if (!isNil(value) && yogaNode) {
-    const justifyContent = JUSTIFY_CONTENT[value] || Yoga.JUSTIFY_FLEX_START;
+    const justifyContent = JUSTIFY_CONTENT[value] || Yoga.Justify.FlexStart;
     yogaNode.setJustifyContent(justifyContent);
   }
 

--- a/packages/layout/src/node/setMargin.js
+++ b/packages/layout/src/node/setMargin.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setYogaValue from './setYogaValue';
 
@@ -15,7 +15,7 @@ import setYogaValue from './setYogaValue';
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setMarginTop = setYogaValue('margin', Yoga.EDGE_TOP);
+export const setMarginTop = setYogaValue('margin', Yoga.Edge.Top);
 
 /**
  * Set margin right attribute to node's Yoga instance
@@ -24,7 +24,7 @@ export const setMarginTop = setYogaValue('margin', Yoga.EDGE_TOP);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setMarginRight = setYogaValue('margin', Yoga.EDGE_RIGHT);
+export const setMarginRight = setYogaValue('margin', Yoga.Edge.Right);
 
 /**
  * Set margin bottom attribute to node's Yoga instance
@@ -33,7 +33,7 @@ export const setMarginRight = setYogaValue('margin', Yoga.EDGE_RIGHT);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setMarginBottom = setYogaValue('margin', Yoga.EDGE_BOTTOM);
+export const setMarginBottom = setYogaValue('margin', Yoga.Edge.Bottom);
 
 /**
  * Set margin left attribute to node's Yoga instance
@@ -42,7 +42,7 @@ export const setMarginBottom = setYogaValue('margin', Yoga.EDGE_BOTTOM);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setMarginLeft = setYogaValue('margin', Yoga.EDGE_LEFT);
+export const setMarginLeft = setYogaValue('margin', Yoga.Edge.Left);
 
 /**
  * Set all margins at once

--- a/packages/layout/src/node/setOverflow.js
+++ b/packages/layout/src/node/setOverflow.js
@@ -1,9 +1,9 @@
+import * as Yoga from 'yoga-layout';
 import { isNil } from '@react-pdf/fns';
-import Yoga from '../../yoga';
 
 const OVERFLOW = {
-  hidden: Yoga.OVERFLOW_HIDDEN,
-  scroll: Yoga.OVERFLOW_SCROLL,
+  hidden: Yoga.Overflow.Hidden,
+  scroll: Yoga.Overflow.Scroll,
 };
 
 /**
@@ -22,7 +22,7 @@ const setOverflow = value => node => {
   const { yogaNode } = node;
 
   if (!isNil(value) && yogaNode) {
-    const overflow = OVERFLOW[value] || Yoga.OVERFLOW_VISIBLE;
+    const overflow = OVERFLOW[value] || Yoga.Overflow.Visible;
     yogaNode.setOverflow(overflow);
   }
 

--- a/packages/layout/src/node/setPadding.js
+++ b/packages/layout/src/node/setPadding.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setYogaValue from './setYogaValue';
 
@@ -15,7 +15,7 @@ import setYogaValue from './setYogaValue';
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPaddingTop = setYogaValue('padding', Yoga.EDGE_TOP);
+export const setPaddingTop = setYogaValue('padding', Yoga.Edge.Top);
 
 /**
  * Set padding right attribute to node's Yoga instance
@@ -24,7 +24,7 @@ export const setPaddingTop = setYogaValue('padding', Yoga.EDGE_TOP);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPaddingRight = setYogaValue('padding', Yoga.EDGE_RIGHT);
+export const setPaddingRight = setYogaValue('padding', Yoga.Edge.Right);
 
 /**
  * Set padding bottom attribute to node's Yoga instance
@@ -33,7 +33,7 @@ export const setPaddingRight = setYogaValue('padding', Yoga.EDGE_RIGHT);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPaddingBottom = setYogaValue('padding', Yoga.EDGE_BOTTOM);
+export const setPaddingBottom = setYogaValue('padding', Yoga.Edge.Bottom);
 
 /**
  * Set padding left attribute to node's Yoga instance
@@ -42,7 +42,7 @@ export const setPaddingBottom = setYogaValue('padding', Yoga.EDGE_BOTTOM);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPaddingLeft = setYogaValue('padding', Yoga.EDGE_LEFT);
+export const setPaddingLeft = setYogaValue('padding', Yoga.Edge.Left);
 
 /**
  * Set all paddings at once

--- a/packages/layout/src/node/setPosition.js
+++ b/packages/layout/src/node/setPosition.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setYogaValue from './setYogaValue';
 
@@ -15,7 +15,7 @@ import setYogaValue from './setYogaValue';
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPositionTop = setYogaValue('position', Yoga.EDGE_TOP);
+export const setPositionTop = setYogaValue('position', Yoga.Edge.Top);
 
 /**
  * Set position right attribute to node's Yoga instance
@@ -24,7 +24,7 @@ export const setPositionTop = setYogaValue('position', Yoga.EDGE_TOP);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPositionRight = setYogaValue('position', Yoga.EDGE_RIGHT);
+export const setPositionRight = setYogaValue('position', Yoga.Edge.Right);
 
 /**
  * Set position bottom attribute to node's Yoga instance
@@ -33,7 +33,7 @@ export const setPositionRight = setYogaValue('position', Yoga.EDGE_RIGHT);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPositionBottom = setYogaValue('position', Yoga.EDGE_BOTTOM);
+export const setPositionBottom = setYogaValue('position', Yoga.Edge.Bottom);
 
 /**
  * Set position left attribute to node's Yoga instance
@@ -42,7 +42,7 @@ export const setPositionBottom = setYogaValue('position', Yoga.EDGE_BOTTOM);
  * @param {Object} node node instance
  * @returns {Object} node instance
  */
-export const setPositionLeft = setYogaValue('position', Yoga.EDGE_LEFT);
+export const setPositionLeft = setYogaValue('position', Yoga.Edge.Left);
 
 /**
  * Set all positions at once

--- a/packages/layout/src/node/setPositionType.js
+++ b/packages/layout/src/node/setPositionType.js
@@ -1,5 +1,5 @@
+import * as Yoga from 'yoga-layout';
 import { isNil } from '@react-pdf/fns';
-import Yoga from '../../yoga';
 
 /**
  * @typedef {Function} NodeInstanceWrapper
@@ -19,8 +19,8 @@ const setPositionType = value => node => {
   if (!isNil(value) && yogaNode) {
     yogaNode.setPositionType(
       value === 'absolute'
-        ? Yoga.POSITION_TYPE_ABSOLUTE
-        : Yoga.POSITION_TYPE_RELATIVE,
+        ? Yoga.PositionType.Absolute
+        : Yoga.PositionType.Relative,
     );
   }
 

--- a/packages/layout/src/steps/resolveYoga.js
+++ b/packages/layout/src/steps/resolveYoga.js
@@ -1,0 +1,9 @@
+import { loadYoga } from '../yoga/index';
+
+const resolveYoga = async root => {
+  const yoga = await loadYoga();
+
+  return Object.assign({}, root, { yoga });
+};
+
+export default resolveYoga;

--- a/packages/layout/src/svg/measureSvg.js
+++ b/packages/layout/src/svg/measureSvg.js
@@ -1,4 +1,4 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 const getAspectRatio = (viewbox) => {
   if (!viewbox) return null;
@@ -26,13 +26,13 @@ const measureCanvas =
     const aspectRatio = getAspectRatio(node.props.viewBox) || 1;
 
     if (
-      widthMode === Yoga.MEASURE_MODE_EXACTLY ||
-      widthMode === Yoga.MEASURE_MODE_AT_MOST
+      widthMode === Yoga.MeasureMode.Exactly ||
+      widthMode === Yoga.MeasureMode.AtMost
     ) {
       return { width, height: width / aspectRatio };
     }
 
-    if (heightMode === Yoga.MEASURE_MODE_EXACTLY) {
+    if (heightMode === Yoga.MeasureMode.Exactly) {
       return { width: height * aspectRatio };
     }
 

--- a/packages/layout/src/text/measureText.js
+++ b/packages/layout/src/text/measureText.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-param-reassign */
 
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import layoutText from './layoutText';
 import linesWidth from './linesWidth';
@@ -25,13 +25,13 @@ const ALIGNMENT_FACTORS = { center: 0.5, right: 1 };
  * @returns {MeasureText} measure text function
  */
 const measureText = (page, node, fontStore) => (width, widthMode, height) => {
-  if (widthMode === Yoga.MEASURE_MODE_EXACTLY) {
+  if (widthMode === Yoga.MeasureMode.Exactly) {
     if (!node.lines) node.lines = layoutText(node, width, height, fontStore);
 
     return { height: linesHeight(node) };
   }
 
-  if (widthMode === Yoga.MEASURE_MODE_AT_MOST) {
+  if (widthMode === Yoga.MeasureMode.AtMost) {
     const alignFactor = ALIGNMENT_FACTORS[node.style?.textAlign] || 0;
 
     if (!node.lines) {

--- a/packages/layout/src/yoga/index.js
+++ b/packages/layout/src/yoga/index.js
@@ -1,0 +1,14 @@
+/* eslint-disable import/prefer-default-export */
+
+import * as Yoga from 'yoga-layout';
+
+export const loadYoga = async () => {
+  const instance = await Yoga.loadYoga();
+  const config = instance.Config.create();
+
+  config.setPointScaleFactor(0);
+
+  const node = { create: () => instance.Node.createWithConfig(config) };
+
+  return { node };
+};

--- a/packages/layout/tests/node/getBorderWidth.test.js
+++ b/packages/layout/tests/node/getBorderWidth.test.js
@@ -1,11 +1,11 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import getBorderWidth from '../../src/node/getBorderWidth';
 
 const getComputedBorder = value => {
-  if (value === Yoga.EDGE_TOP) return 1;
-  if (value === Yoga.EDGE_RIGHT) return 2;
-  if (value === Yoga.EDGE_BOTTOM) return 3;
+  if (value === Yoga.Edge.Top) return 1;
+  if (value === Yoga.Edge.Right) return 2;
+  if (value === Yoga.Edge.Bottom) return 3;
   return 4;
 };
 

--- a/packages/layout/tests/node/getMargin.test.js
+++ b/packages/layout/tests/node/getMargin.test.js
@@ -1,11 +1,11 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import getMargin from '../../src/node/getMargin';
 
 const getComputedMargin = value => {
-  if (value === Yoga.EDGE_TOP) return 1;
-  if (value === Yoga.EDGE_RIGHT) return 2;
-  if (value === Yoga.EDGE_BOTTOM) return 3;
+  if (value === Yoga.Edge.Top) return 1;
+  if (value === Yoga.Edge.Right) return 2;
+  if (value === Yoga.Edge.Bottom) return 3;
   return 4;
 };
 

--- a/packages/layout/tests/node/getPadding.test.js
+++ b/packages/layout/tests/node/getPadding.test.js
@@ -1,11 +1,11 @@
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import getPadding from '../../src/node/getPadding';
 
 const getComputedPadding = value => {
-  if (value === Yoga.EDGE_TOP) return 1;
-  if (value === Yoga.EDGE_RIGHT) return 2;
-  if (value === Yoga.EDGE_BOTTOM) return 3;
+  if (value === Yoga.Edge.Top) return 1;
+  if (value === Yoga.Edge.Right) return 2;
+  if (value === Yoga.Edge.Bottom) return 3;
   return 4;
 };
 

--- a/packages/layout/tests/node/setAlignContent.test.js
+++ b/packages/layout/tests/node/setAlignContent.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setAlignContent from '../../src/node/setAlignContent';
 
@@ -22,7 +22,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent(null)(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_AUTO);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Auto);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('flex-start')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_FLEX_START);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.FlexStart);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('center')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_CENTER);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Center);
     expect(result).toBe(node);
   });
 
@@ -46,7 +46,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('flex-end')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_FLEX_END);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.FlexEnd);
     expect(result).toBe(node);
   });
 
@@ -54,7 +54,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('stretch')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_STRETCH);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Stretch);
     expect(result).toBe(node);
   });
 
@@ -62,7 +62,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('baseline')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_BASELINE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Baseline);
     expect(result).toBe(node);
   });
 
@@ -70,7 +70,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('space-between')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_SPACE_BETWEEN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.SpaceBetween);
     expect(result).toBe(node);
   });
 
@@ -78,7 +78,7 @@ describe('node setAlignContent', () => {
     const result = setAlignContent('space-around')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_SPACE_AROUND);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.SpaceAround);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setAlignItems.test.js
+++ b/packages/layout/tests/node/setAlignItems.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setAlignItems from '../../src/node/setAlignItems';
 
@@ -22,7 +22,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems(null)(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_STRETCH);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Stretch);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('flex-start')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_FLEX_START);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.FlexStart);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('center')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_CENTER);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Center);
     expect(result).toBe(node);
   });
 
@@ -46,7 +46,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('flex-end')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_FLEX_END);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.FlexEnd);
     expect(result).toBe(node);
   });
 
@@ -54,7 +54,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('stretch')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_STRETCH);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Stretch);
     expect(result).toBe(node);
   });
 
@@ -62,7 +62,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('baseline')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_BASELINE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Baseline);
     expect(result).toBe(node);
   });
 
@@ -70,7 +70,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('space-between')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_SPACE_BETWEEN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.SpaceBetween);
     expect(result).toBe(node);
   });
 
@@ -78,7 +78,7 @@ describe('node setAlignItems', () => {
     const result = setAlignItems('space-around')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_SPACE_AROUND);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.SpaceAround);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setAlignSelf.test.js
+++ b/packages/layout/tests/node/setAlignSelf.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setAlignSelf from '../../src/node/setAlignSelf';
 
@@ -22,7 +22,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf(null)(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_AUTO);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Auto);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('flex-start')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_FLEX_START);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.FlexStart);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('center')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_CENTER);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Center);
     expect(result).toBe(node);
   });
 
@@ -46,7 +46,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('flex-end')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_FLEX_END);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.FlexEnd);
     expect(result).toBe(node);
   });
 
@@ -54,7 +54,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('stretch')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_STRETCH);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Stretch);
     expect(result).toBe(node);
   });
 
@@ -62,7 +62,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('baseline')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_BASELINE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.Baseline);
     expect(result).toBe(node);
   });
 
@@ -70,7 +70,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('space-between')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_SPACE_BETWEEN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.SpaceBetween);
     expect(result).toBe(node);
   });
 
@@ -78,7 +78,7 @@ describe('node setAlignSelf', () => {
     const result = setAlignSelf('space-around')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.ALIGN_SPACE_AROUND);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Align.SpaceAround);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setBorderWidth.test.js
+++ b/packages/layout/tests/node/setBorderWidth.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setBorder, {
   setBorderTop,
@@ -28,7 +28,7 @@ describe('node setBorderWidth', () => {
       const result = setBorderTop(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -50,7 +50,7 @@ describe('node setBorderWidth', () => {
       const result = setBorderRight(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -72,7 +72,7 @@ describe('node setBorderWidth', () => {
       const result = setBorderBottom(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -94,7 +94,7 @@ describe('node setBorderWidth', () => {
       const result = setBorderLeft(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -116,10 +116,10 @@ describe('node setBorderWidth', () => {
       const result = setBorder(50)(node);
 
       expect(mock.mock.calls).toHaveLength(4);
-      expect(mock.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mock.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mock.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mock.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mock.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mock.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mock.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mock.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
 

--- a/packages/layout/tests/node/setDisplay.test.js
+++ b/packages/layout/tests/node/setDisplay.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setDisplay from '../../src/node/setDisplay';
 
@@ -22,7 +22,7 @@ describe('node setDisplay', () => {
     const result = setDisplay(null)(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.DISPLAY_FLEX);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Display.Flex);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setDisplay', () => {
     const result = setDisplay('flex')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.DISPLAY_FLEX);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Display.Flex);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setDisplay', () => {
     const result = setDisplay('none')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.DISPLAY_NONE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Display.None);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setFlexDirection.test.js
+++ b/packages/layout/tests/node/setFlexDirection.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setFlexDirection from '../../src/node/setFlexDirection';
 
@@ -22,7 +22,7 @@ describe('node setFlexDirection', () => {
     const result = setFlexDirection(null)(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.FLEX_DIRECTION_COLUMN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.FlexDirection.Column);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setFlexDirection', () => {
     const result = setFlexDirection('column')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.FLEX_DIRECTION_COLUMN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.FlexDirection.Column);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setFlexDirection', () => {
     const result = setFlexDirection('row')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.FLEX_DIRECTION_ROW);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.FlexDirection.Row);
     expect(result).toBe(node);
   });
 
@@ -46,7 +46,7 @@ describe('node setFlexDirection', () => {
     const result = setFlexDirection('row-reverse')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.FLEX_DIRECTION_ROW_REVERSE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.FlexDirection.RowReverse);
     expect(result).toBe(node);
   });
 
@@ -54,7 +54,7 @@ describe('node setFlexDirection', () => {
     const result = setFlexDirection('column-reverse')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.FLEX_DIRECTION_COLUMN_REVERSE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.FlexDirection.ColumnReverse);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setFlexWrap.test.js
+++ b/packages/layout/tests/node/setFlexWrap.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setFlexWrap from '../../src/node/setFlexWrap';
 
@@ -22,7 +22,7 @@ describe('node setFlexWrap', () => {
     const result = setFlexWrap(null)(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.WRAP_NO_WRAP);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Wrap.NoWrap);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setFlexWrap', () => {
     const result = setFlexWrap('no-wrap')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.WRAP_NO_WRAP);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Wrap.NoWrap);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setFlexWrap', () => {
     const result = setFlexWrap('wrap')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.WRAP_WRAP);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Wrap.Wrap);
     expect(result).toBe(node);
   });
 
@@ -46,7 +46,7 @@ describe('node setFlexWrap', () => {
     const result = setFlexWrap('wrap-reverse')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.WRAP_WRAP_REVERSE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Wrap.WrapReverse);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setJustifyContent.test.js
+++ b/packages/layout/tests/node/setJustifyContent.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setJustifyContent from '../../src/node/setJustifyContent';
 
@@ -22,7 +22,7 @@ describe('node setJustifyContent', () => {
     const result = setJustifyContent('center')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.JUSTIFY_CENTER);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Justify.Center);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setJustifyContent', () => {
     const result = setJustifyContent('flex-end')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.JUSTIFY_FLEX_END);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Justify.FlexEnd);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setJustifyContent', () => {
     const result = setJustifyContent('flex-start')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.JUSTIFY_FLEX_START);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Justify.FlexStart);
     expect(result).toBe(node);
   });
 
@@ -46,7 +46,7 @@ describe('node setJustifyContent', () => {
     const result = setJustifyContent('space-between')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.JUSTIFY_SPACE_BETWEEN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Justify.SpaceBetween);
     expect(result).toBe(node);
   });
 
@@ -54,7 +54,7 @@ describe('node setJustifyContent', () => {
     const result = setJustifyContent('space-around')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.JUSTIFY_SPACE_AROUND);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Justify.SpaceAround);
     expect(result).toBe(node);
   });
 
@@ -62,7 +62,7 @@ describe('node setJustifyContent', () => {
     const result = setJustifyContent('space-evenly')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.JUSTIFY_SPACE_EVENLY);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Justify.SpaceEvenly);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setMargin.test.js
+++ b/packages/layout/tests/node/setMargin.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setMargin, {
   setMarginTop,
@@ -39,7 +39,7 @@ describe('node setMargin', () => {
       const result = setMarginTop('auto')(node);
 
       expect(mockAuto.mock.calls).toHaveLength(1);
-      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(result).toBe(node);
     });
 
@@ -47,7 +47,7 @@ describe('node setMargin', () => {
       const result = setMarginTop(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -56,7 +56,7 @@ describe('node setMargin', () => {
       const result = setMarginTop('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -74,7 +74,7 @@ describe('node setMargin', () => {
       const result = setMarginRight('auto')(node);
 
       expect(mockAuto.mock.calls).toHaveLength(1);
-      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(result).toBe(node);
     });
 
@@ -82,7 +82,7 @@ describe('node setMargin', () => {
       const result = setMarginRight(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -91,7 +91,7 @@ describe('node setMargin', () => {
       const result = setMarginRight('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -109,7 +109,7 @@ describe('node setMargin', () => {
       const result = setMarginBottom('auto')(node);
 
       expect(mockAuto.mock.calls).toHaveLength(1);
-      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(result).toBe(node);
     });
 
@@ -117,7 +117,7 @@ describe('node setMargin', () => {
       const result = setMarginBottom(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -126,7 +126,7 @@ describe('node setMargin', () => {
       const result = setMarginBottom('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -144,7 +144,7 @@ describe('node setMargin', () => {
       const result = setMarginLeft('auto')(node);
 
       expect(mockAuto.mock.calls).toHaveLength(1);
-      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(result).toBe(node);
     });
 
@@ -152,7 +152,7 @@ describe('node setMargin', () => {
       const result = setMarginLeft(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -161,7 +161,7 @@ describe('node setMargin', () => {
       const result = setMarginLeft('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -179,10 +179,10 @@ describe('node setMargin', () => {
       const result = setMargin('auto')(node);
 
       expect(mockAuto.mock.calls).toHaveLength(4);
-      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
-      expect(mockAuto.mock.calls[1][0]).toBe(Yoga.EDGE_RIGHT);
-      expect(mockAuto.mock.calls[2][0]).toBe(Yoga.EDGE_BOTTOM);
-      expect(mockAuto.mock.calls[3][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mockAuto.mock.calls[0][0]).toBe(Yoga.Edge.Top);
+      expect(mockAuto.mock.calls[1][0]).toBe(Yoga.Edge.Right);
+      expect(mockAuto.mock.calls[2][0]).toBe(Yoga.Edge.Bottom);
+      expect(mockAuto.mock.calls[3][0]).toBe(Yoga.Edge.Left);
       expect(result).toBe(node);
     });
 
@@ -190,10 +190,10 @@ describe('node setMargin', () => {
       const result = setMargin(50)(node);
 
       expect(mock.mock.calls).toHaveLength(4);
-      expect(mock.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mock.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mock.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mock.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mock.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mock.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mock.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mock.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
 
@@ -201,10 +201,10 @@ describe('node setMargin', () => {
       const result = setMargin('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(4);
-      expect(mockPercent.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mockPercent.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mockPercent.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mockPercent.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mockPercent.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mockPercent.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mockPercent.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mockPercent.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
   });

--- a/packages/layout/tests/node/setOverflow.test.js
+++ b/packages/layout/tests/node/setOverflow.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setOverflow from '../../src/node/setOverflow';
 
@@ -22,7 +22,7 @@ describe('node setOverflow', () => {
     const result = setOverflow('visible')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.OVERFLOW_VISIBLE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Overflow.Visible);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setOverflow', () => {
     const result = setOverflow('scroll')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.OVERFLOW_SCROLL);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Overflow.Scroll);
     expect(result).toBe(node);
   });
 
@@ -38,7 +38,7 @@ describe('node setOverflow', () => {
     const result = setOverflow('hidden')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.OVERFLOW_HIDDEN);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.Overflow.Hidden);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/node/setPadding.test.js
+++ b/packages/layout/tests/node/setPadding.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setPadding, {
   setPaddingTop,
@@ -33,7 +33,7 @@ describe('node setPadding', () => {
       const result = setPaddingTop(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -42,7 +42,7 @@ describe('node setPadding', () => {
       const result = setPaddingTop('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -60,7 +60,7 @@ describe('node setPadding', () => {
       const result = setPaddingRight(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -69,7 +69,7 @@ describe('node setPadding', () => {
       const result = setPaddingRight('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -87,7 +87,7 @@ describe('node setPadding', () => {
       const result = setPaddingBottom(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -96,7 +96,7 @@ describe('node setPadding', () => {
       const result = setPaddingBottom('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -114,7 +114,7 @@ describe('node setPadding', () => {
       const result = setPaddingLeft(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -123,7 +123,7 @@ describe('node setPadding', () => {
       const result = setPaddingLeft('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -141,10 +141,10 @@ describe('node setPadding', () => {
       const result = setPadding(50)(node);
 
       expect(mock.mock.calls).toHaveLength(4);
-      expect(mock.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mock.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mock.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mock.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mock.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mock.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mock.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mock.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
 
@@ -152,10 +152,10 @@ describe('node setPadding', () => {
       const result = setPadding('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(4);
-      expect(mockPercent.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mockPercent.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mockPercent.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mockPercent.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mockPercent.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mockPercent.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mockPercent.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mockPercent.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
   });

--- a/packages/layout/tests/node/setPosition.test.js
+++ b/packages/layout/tests/node/setPosition.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setPosition, {
   setPositionTop,
@@ -33,7 +33,7 @@ describe('node setPosition', () => {
       const result = setPositionTop(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -42,7 +42,7 @@ describe('node setPosition', () => {
       const result = setPositionTop('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_TOP);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Top);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -60,7 +60,7 @@ describe('node setPosition', () => {
       const result = setPositionRight(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -69,7 +69,7 @@ describe('node setPosition', () => {
       const result = setPositionRight('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_RIGHT);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Right);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -87,7 +87,7 @@ describe('node setPosition', () => {
       const result = setPositionBottom(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -96,7 +96,7 @@ describe('node setPosition', () => {
       const result = setPositionBottom('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_BOTTOM);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Bottom);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -114,7 +114,7 @@ describe('node setPosition', () => {
       const result = setPositionLeft(50)(node);
 
       expect(mock.mock.calls).toHaveLength(1);
-      expect(mock.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mock.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mock.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -123,7 +123,7 @@ describe('node setPosition', () => {
       const result = setPositionLeft('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(1);
-      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.EDGE_LEFT);
+      expect(mockPercent.mock.calls[0][0]).toBe(Yoga.Edge.Left);
       expect(mockPercent.mock.calls[0][1]).toBe(50);
       expect(result).toBe(node);
     });
@@ -141,10 +141,10 @@ describe('node setPosition', () => {
       const result = setPosition(50)(node);
 
       expect(mock.mock.calls).toHaveLength(4);
-      expect(mock.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mock.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mock.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mock.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mock.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mock.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mock.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mock.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
 
@@ -152,10 +152,10 @@ describe('node setPosition', () => {
       const result = setPosition('50%')(node);
 
       expect(mockPercent.mock.calls).toHaveLength(4);
-      expect(mockPercent.mock.calls[0]).toEqual([Yoga.EDGE_TOP, 50]);
-      expect(mockPercent.mock.calls[1]).toEqual([Yoga.EDGE_RIGHT, 50]);
-      expect(mockPercent.mock.calls[2]).toEqual([Yoga.EDGE_BOTTOM, 50]);
-      expect(mockPercent.mock.calls[3]).toEqual([Yoga.EDGE_LEFT, 50]);
+      expect(mockPercent.mock.calls[0]).toEqual([Yoga.Edge.Top, 50]);
+      expect(mockPercent.mock.calls[1]).toEqual([Yoga.Edge.Right, 50]);
+      expect(mockPercent.mock.calls[2]).toEqual([Yoga.Edge.Bottom, 50]);
+      expect(mockPercent.mock.calls[3]).toEqual([Yoga.Edge.Left, 50]);
       expect(result).toBe(node);
     });
   });

--- a/packages/layout/tests/node/setPositionType.test.js
+++ b/packages/layout/tests/node/setPositionType.test.js
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import Yoga from '../../yoga';
+import * as Yoga from 'yoga-layout';
 
 import setPositionType from '../../src/node/setPositionType';
 
@@ -22,7 +22,7 @@ describe('node setPositionType', () => {
     const result = setPositionType('relative')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.POSITION_TYPE_RELATIVE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.PositionType.Relative);
     expect(result).toBe(node);
   });
 
@@ -30,7 +30,7 @@ describe('node setPositionType', () => {
     const result = setPositionType('absolute')(node);
 
     expect(mock.mock.calls).toHaveLength(1);
-    expect(mock.mock.calls[0][0]).toBe(Yoga.POSITION_TYPE_ABSOLUTE);
+    expect(mock.mock.calls[0][0]).toBe(Yoga.PositionType.Absolute);
     expect(result).toBe(node);
   });
 });

--- a/packages/layout/tests/steps/resolvePagination.test.js
+++ b/packages/layout/tests/steps/resolvePagination.test.js
@@ -1,3 +1,5 @@
+import { loadYoga } from '../../src/yoga';
+
 import resolvePagination from '../../src/steps/resolvePagination';
 import resolveDimensions from '../../src/steps/resolveDimensions';
 
@@ -5,9 +7,12 @@ import resolveDimensions from '../../src/steps/resolveDimensions';
 const calcLayout = node => resolvePagination(resolveDimensions(node));
 
 describe('pagination step', () => {
-  test('should stretch absolute block to full page size', () => {
+  test('should stretch absolute block to full page size', async () => {
+    const yoga = await loadYoga();
+
     const root = {
       type: 'DOCUMENT',
+      yoga,
       children: [
         {
           type: 'PAGE',
@@ -55,9 +60,12 @@ describe('pagination step', () => {
     expect(view.box.height).toBe(100);
   });
 
-  test('should force new height for split nodes', () => {
+  test('should force new height for split nodes', async () => {
+    const yoga = await loadYoga();
+
     const root = {
       type: 'DOCUMENT',
+      yoga,
       children: [
         {
           type: 'PAGE',
@@ -102,9 +110,12 @@ describe('pagination step', () => {
     expect(view2.box.height).not.toBe(60);
   });
 
-  test('should force new height for split nodes with fixed height', () => {
+  test('should force new height for split nodes with fixed height', async () => {
+    const yoga = await loadYoga();
+
     const root = {
       type: 'DOCUMENT',
+      yoga,
       children: [
         {
           type: 'PAGE',
@@ -138,9 +149,12 @@ describe('pagination step', () => {
     expect(view3.box.height).toBe(10);
   });
 
-  test('should not wrap page with false wrap prop', () => {
+  test('should not wrap page with false wrap prop', async () => {
+    const yoga = await loadYoga();
+
     const root = {
       type: 'DOCUMENT',
+      yoga,
       children: [
         {
           type: 'PAGE',
@@ -170,9 +184,12 @@ describe('pagination step', () => {
     expect(layout.children.length).toBe(1);
   });
 
-  test('should break on a container whose children can not fit on a page', () => {
+  test('should break on a container whose children can not fit on a page', async () => {
+    const yoga = await loadYoga();
+
     const root = {
       type: 'DOCUMENT',
+      yoga,
       children: [
         {
           type: 'PAGE',
@@ -220,7 +237,6 @@ describe('pagination step', () => {
     };
 
     const layout = calcLayout(root);
-    console.log(layout.children[0].children);
 
     const page1 = layout.children[0];
     const page2 = layout.children[1];

--- a/packages/layout/tests/steps/resolveTextLayout.test.js
+++ b/packages/layout/tests/steps/resolveTextLayout.test.js
@@ -1,8 +1,10 @@
+import { loadYoga } from '../../src/yoga';
 import resolveTextLayout from '../../src/steps/resolveTextLayout';
 import resolveDimensions from '../../src/steps/resolveDimensions';
 
-const getRoot = (text = 'hello world', styles = {}) => ({
+const getRoot = async (text = 'hello world', styles = {}) => ({
   type: 'DOCUMENT',
+  yoga: await loadYoga(),
   children: [
     {
       type: 'PAGE',
@@ -32,15 +34,15 @@ const getRoot = (text = 'hello world', styles = {}) => ({
 describe('text layout step', () => {
   const getText = root => root.children[0].children[0];
 
-  test('should calculate lines for text while resolve dimensions', () => {
-    const root = getRoot('text text text');
+  test('should calculate lines for text while resolve dimensions', async () => {
+    const root = await getRoot('text text text');
     const dimensions = resolveDimensions(root);
 
     expect(getText(dimensions).lines).toBeDefined();
   });
 
-  test('should calculate lines for text width defined height', () => {
-    const root = getRoot('text text text', { height: 50 });
+  test('should calculate lines for text width defined height', async () => {
+    const root = await getRoot('text text text', { height: 50 });
     const dimensions = resolveDimensions(root);
 
     expect(getText(dimensions).lines).not.toBeDefined();
@@ -50,8 +52,8 @@ describe('text layout step', () => {
     expect(getText(textLayout).lines).toBeDefined();
   });
 
-  test('should calculate lines for empty text', () => {
-    const root = getRoot('');
+  test('should calculate lines for empty text', async () => {
+    const root = await getRoot('');
     const dimensions = resolveDimensions(root);
 
     expect(getText(dimensions).lines).toBeDefined();


### PR DESCRIPTION
Uses `loadYoga` from `yoga-layout` main entrypoint to leverage wasm internal usage.

This is supposed to ship less code and also be more performant. In tests I couldn't see much of a difference to be honest, but it's cool we run flex engine in wasm code as it's supposed to be more performant. Maybe in larger documents will be more noticeable. It does not introduce breaking changes as layout process is already async

I'd appreciate some thoughts about this :) cc/ @wojtekmaj @jeetiss 