### PR TITLE
fix: fix require @react-pdf/primitives from CJS

### DIFF
--- a/.changeset/brown-houses-count.md
+++ b/.changeset/brown-houses-count.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/primitives': patch
+---
+
+Fix require @react-pdf/primitives from CJS

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -6,12 +6,12 @@
   "author": "Diego Muracciole <diegomuracciole@gmail.com>",
   "homepage": "https://github.com/diegomura/react-pdf#readme",
   "type": "module",
-  "main": "./lib/index.js",
+  "main": "./lib/index.cjs",
   "module": "./src/index.js",
   "exports": {
     ".": {
       "import": "./src/index.js",
-      "require": "./lib/index.js",
+      "require": "./lib/index.cjs",
       "default": "./src/index.js"
     }
   },
@@ -21,7 +21,7 @@
     "directory": "packages/primitives"
   },
   "scripts": {
-    "build": "babel src --out-dir lib",
+    "build": "babel src --out-dir lib && mv lib/index.js lib/index.cjs",
     "test": "NODE_OPTIONS=\"--experimental-vm-modules\" jest"
   },
   "files": [


### PR DESCRIPTION
In #2409 I missed changing the extension of CJS code to .cjs, resulting in (inaccurate) ERR_REQUIRE_ESM error thrown in Node in CJS environment.