### PR TITLE
feat!: add support for Next.js route handlers by bundling React

### DIFF
--- a/.changeset/calm-fireants-rule.md
+++ b/.changeset/calm-fireants-rule.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': major
+---
+
+Bundle React to make it work with Next.js RSC environment

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -45,9 +45,6 @@
     "queue": "^6.0.1",
     "scheduler": "^0.17.0"
   },
-  "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0 || ^18.0.0"
-  },
   "lint-staged": {
     "*.js": [
       "yarn run lint",
@@ -75,6 +72,7 @@
     "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "process": "^0.11.10",
+    "react": "^18.2.0",
     "react-reconciler": "0.23.0",
     "size-limit": "^11.0.1",
     "util": "^0.12.4"

--- a/packages/renderer/rollup.config.js
+++ b/packages/renderer/rollup.config.js
@@ -39,8 +39,9 @@ const getExternal = ({ browser }) => [
   /@babel\/runtime/,
   'react/jsx-runtime',
   ...(browser ? [] : ['fs', 'path', 'url']),
-  ...Object.keys(pkg.dependencies).filter(name => name !== 'react-reconciler'),
-  ...Object.keys(pkg.peerDependencies),
+  ...Object.keys(pkg.dependencies).filter(
+    name => name !== 'react' && name !== 'react-reconciler',
+  ),
 ];
 
 const getPlugins = ({ browser, declarationDests, minify = false }) => [


### PR DESCRIPTION
Fixes #2350
Fixes #2460

This proposal bundles React with @react-pdf/renderer.

The reason for that is Next.js replacing current React version with `18.3.0-canary-8c8ee9ee6-20231026`, which is not compatible with any stable version of react-reconciler available at the moment.

I realize that this is a huge change and I'm actually not convinced it's the right way to go, but if anyone would e.g. like to make a custom build on their own, this PR makes it possible to use @react-pdf/renderer in Next.js route handlers seamlessly.