### PR TITLE
fix: fix 100s of (mostly) JSDoc issues found by TypeScript

### DIFF
--- a/packages/fns/src/asyncCompose.js
+++ b/packages/fns/src/asyncCompose.js
@@ -3,9 +3,17 @@
 import reverse from './reverse';
 
 /**
+ * @typedef {Function} AsyncCompose
+ * @param {any} value
+ * @param {...any} args
+ * @returns {any} result
+ */
+
+/**
  * Performs right-to-left function composition with async functions support
  *
- * @param  {...any} functions
+ * @param {...Function} fns functions
+ * @returns {AsyncCompose} composed function
  */
 const asyncCompose = (...fns) => async (value, ...args) => {
   let result = value;

--- a/packages/fns/src/capitalize.js
+++ b/packages/fns/src/capitalize.js
@@ -1,12 +1,12 @@
 /**
  * Capitalize first letter of each word
  *
- * @param {String} string
- * @returns {String} capitalized string
+ * @param {string} value string
+ * @returns {string} capitalized string
  */
-const capitalize = value => {
+const capitalize = (value) => {
   if (!value) return value;
-  return value.replace(/(^|\s)\S/g, l => l.toUpperCase());
+  return value.replace(/(^|\s)\S/g, (l) => l.toUpperCase());
 };
 
 export default capitalize;

--- a/packages/fns/src/castArray.js
+++ b/packages/fns/src/castArray.js
@@ -1,8 +1,9 @@
 /**
  * Casts value to array
  *
- * @param {any} value
- * @returns {Array} casted value
+ * @template T
+ * @param {T|T[]} value value
+ * @returns {T[]} array
  */
 const castArray = value => {
   return Array.isArray(value) ? value : [value];

--- a/packages/fns/src/compose.js
+++ b/packages/fns/src/compose.js
@@ -3,9 +3,17 @@
 import reverse from './reverse';
 
 /**
+ * @typedef {Function} Compose
+ * @param {any} value
+ * @param {...any} args
+ * @returns {any} result
+ */
+
+/**
  * Performs right-to-left function composition
  *
- * @param  {...any} functions
+ * @param {...Function} fns functions
+ * @returns {Compose} composed function
  */
 const compose = (...fns) => (value, ...args) => {
   let result = value;

--- a/packages/fns/src/matchPercent.js
+++ b/packages/fns/src/matchPercent.js
@@ -1,16 +1,20 @@
-const isPercent = value => /((-)?\d+\.?\d*)%/g.exec(value);
+/**
+ * @param {string | number} value
+ * @returns {RegExpExecArray | null} match
+ */
+const isPercent = value => /((-)?\d+\.?\d*)%/g.exec(`${value}`);
 
 /**
  * Get percentage value of input
  *
- * @param {String} value
- * @returns {Object} percent value (if matches)
+ * @param {string | number} value
+ * @returns {{ percent: number, value: number } | null} percent value (if matches)
  */
 const matchPercent = value => {
   const match = isPercent(value);
 
   if (match) {
-    const f = parseFloat(match[1], 10);
+    const f = parseFloat(match[1]);
     const percent = f / 100;
 
     return { percent, value: f };

--- a/packages/fns/src/upperFirst.js
+++ b/packages/fns/src/upperFirst.js
@@ -1,10 +1,10 @@
 /**
  * Capitalize first letter of string
  *
- * @param {String} string
- * @returns {String} capitalized string
+ * @param {string} value string
+ * @returns {string} capitalized string
  */
-const upperFirst = value => {
+const upperFirst = (value) => {
   if (!value) return value;
   return value.charAt(0).toUpperCase() + value.slice(1);
 };

--- a/packages/layout/src/canvas/measureCanvas.js
+++ b/packages/layout/src/canvas/measureCanvas.js
@@ -6,7 +6,7 @@ import isHeightAuto from '../page/isHeightAuto';
 
 const SAFETY_HEIGHT = 10;
 
-const getMax = values => Math.max(-Infinity, ...values);
+const getMax = (values) => Math.max(-Infinity, ...values);
 
 /**
  * Helper object to predict canvas size
@@ -88,22 +88,23 @@ const measureCtx = () => {
   ctx.linearGradient = nil;
   ctx.radialGradient = nil;
 
-  ctx.getWidth = () => getMax(points.map(p => p[0]));
-  ctx.getHeight = () => getMax(points.map(p => p[1]));
+  ctx.getWidth = () => getMax(points.map((p) => p[0]));
+  ctx.getHeight = () => getMax(points.map((p) => p[1]));
 
   return ctx;
 };
+
+/**
+ * @typedef {Function} MeasureCanvas
+ * @returns {{ width: number, height: number }} canvas width and height
+ */
 
 /**
  * Yoga canvas measure function
  *
  * @param {Object} page
  * @param {Object} node
- * @param {Number} width
- * @param {Number} widthMode
- * @param {Number} height
- * @param {Number} heightMode
- * @returns {Object} canvas width and height
+ * @returns {MeasureCanvas} measure canvas
  */
 const measureCanvas = (page, node) => () => {
   const imageMargin = getMargin(node);
@@ -124,7 +125,7 @@ const measureCanvas = (page, node) => () => {
   const width = ctx.getWidth();
   const height = Math.min(pageArea, ctx.getHeight());
 
-  return { height, width };
+  return { width, height };
 };
 
 export default measureCanvas;

--- a/packages/layout/src/image/getRatio.js
+++ b/packages/layout/src/image/getRatio.js
@@ -1,10 +1,10 @@
 /**
  * Get image ratio
  *
- * @param {Object} image node
- * @returns {Number} image ratio
+ * @param {Object} node image node
+ * @returns {number} image ratio
  */
-const getRatio = node => {
+const getRatio = (node) => {
   return node.image?.data ? node.image.width / node.image.height : 1;
 };
 

--- a/packages/layout/src/image/getSource.js
+++ b/packages/layout/src/image/getSource.js
@@ -1,10 +1,10 @@
 /**
  * Get image source
  *
- * @param {Object} image node
- * @returns {String | Object} image src
+ * @param {Object} node image node
+ * @returns {string | Object} image src
  */
-const getSource = node =>
+const getSource = (node) =>
   node.props?.src || node.props?.source || node.props?.href;
 
 export default getSource;

--- a/packages/layout/src/image/measureImage.js
+++ b/packages/layout/src/image/measureImage.js
@@ -8,15 +8,20 @@ import isHeightAuto from '../page/isHeightAuto';
 const SAFETY_HEIGHT = 10;
 
 /**
+ * @typedef {Function} MeasureImage
+ * @param {number} width
+ * @param {number} widthMode
+ * @param {number} height
+ * @param {number} heightMode
+ * @returns {{ width: number, height: number }} image width and height
+ */
+
+/**
  * Yoga image measure function
  *
- * @param {Object} page
- * @param {Object} node
- * @param {Number} width
- * @param {Number} widthMode
- * @param {Number} height
- * @param {Number} heightMode
- * @returns {Object} image width and height
+ * @param {Object} page page
+ * @param {Object} node node
+ * @returns {MeasureImage} measure image
  */
 const measureImage = (page, node) => (width, widthMode, height, heightMode) => {
   const imageRatio = getRatio(node);

--- a/packages/layout/src/image/resolveSource.js
+++ b/packages/layout/src/image/resolveSource.js
@@ -4,7 +4,7 @@
  * Also it handles factories and async sources.
  *
  * @param {string | Object | Function} src
- * @returns {object} resolved src
+ * @returns {Promise<Object>} resolved src
  */
 const resolveSource = async src => {
   const source = typeof src === 'function' ? await src() : await src;

--- a/packages/layout/src/node/createInstances.js
+++ b/packages/layout/src/node/createInstances.js
@@ -1,11 +1,11 @@
 import { castArray } from '@react-pdf/fns';
 import { TextInstance } from '@react-pdf/primitives';
 
-const isString = value => typeof value === 'string';
+const isString = (value) => typeof value === 'string';
 
-const isNumber = value => typeof value === 'number';
+const isNumber = (value) => typeof value === 'number';
 
-const isFragment = value =>
+const isFragment = (value) =>
   value && value.type === Symbol.for('react.fragment');
 
 /**
@@ -13,10 +13,10 @@ const isFragment = value =>
  *
  * Can return multiple instances in the case of arrays or fragments.
  *
- * @param {Object} React element
- * @returns {Array} parsed react elements
+ * @param {Object} element React element
+ * @returns {Object[]} parsed React elements
  */
-const createInstances = element => {
+const createInstances = (element) => {
   if (!element) return [];
 
   if (isString(element) || isNumber(element)) {

--- a/packages/layout/src/node/getBorderWidth.js
+++ b/packages/layout/src/node/getBorderWidth.js
@@ -7,9 +7,9 @@ const getComputedBorder = (yogaNode, edge) =>
  * Get Yoga computed border width. Zero otherwise
  *
  * @param {Object} node
- * @return {Object} border widths
+ * @returns {{ borderTopWidth: number, borderRightWidth: number, borderBottomWidth: number, borderLeftWidth: number }} border widths
  */
-const getBorderWidth = node => {
+const getBorderWidth = (node) => {
   const { yogaNode } = node;
 
   return {

--- a/packages/layout/src/node/getDimension.js
+++ b/packages/layout/src/node/getDimension.js
@@ -7,9 +7,9 @@ const DEFAULT_DIMENSION = {
  * Get Yoga computed dimensions. Zero otherwise
  *
  * @param {Object} node
- * @return {Object} dimensions
+ * @returns {{ width: number, height: number }} dimensions
  */
-const getDimension = node => {
+const getDimension = (node) => {
   const { yogaNode } = node;
 
   if (!yogaNode) return DEFAULT_DIMENSION;

--- a/packages/layout/src/node/getMargin.js
+++ b/packages/layout/src/node/getMargin.js
@@ -9,9 +9,9 @@ const getComputedMargin = (node, edge) => {
  * Get Yoga computed magins. Zero otherwise
  *
  * @param {Object} node
- * @return {Object} margins
+ * @returns {{ marginTop: number, marginRight: number, marginBottom: number, marginLeft: number }} margins
  */
-const getMargin = node => {
+const getMargin = (node) => {
   const { style, box } = node;
 
   const marginTop =

--- a/packages/layout/src/node/getOrigin.js
+++ b/packages/layout/src/node/getOrigin.js
@@ -1,15 +1,15 @@
 import { isNil, matchPercent } from '@react-pdf/fns';
 
-const getTransformStyle = s => node =>
+const getTransformStyle = (s) => (node) =>
   isNil(node.style?.[s]) ? '50%' : node.style?.[s];
 
 /**
  * Get node origin
  *
  * @param {Object} node
- * @returns {Object} node origin
+ * @returns {{ left?: number, top?: number }} node origin
  */
-const getOrigin = node => {
+const getOrigin = (node) => {
   if (!node.box) return {};
 
   const { left, top, width, height } = node.box;

--- a/packages/layout/src/node/getPadding.js
+++ b/packages/layout/src/node/getPadding.js
@@ -9,9 +9,9 @@ const getComputedPadding = (node, edge) => {
  * Get Yoga computed paddings. Zero otherwise
  *
  * @param {Object} node
- * @return {Object} paddings
+ * @returns {{ paddingTop: number, paddingRight: number, paddingBottom: number, paddingLeft: number }} paddings
  */
-const getPadding = node => {
+const getPadding = (node) => {
   const { style, box } = node;
 
   const paddingTop =

--- a/packages/layout/src/node/getPosition.js
+++ b/packages/layout/src/node/getPosition.js
@@ -2,9 +2,9 @@
  * Get Yoga computed position. Zero otherwise
  *
  * @param {Object} node
- * @return {Object} position
+ * @returns {{ top: number, right: number, bottom: number, left: number }} position
  */
-const getPosition = node => {
+const getPosition = (node) => {
   const { yogaNode } = node;
 
   return {

--- a/packages/layout/src/node/setAlign.js
+++ b/packages/layout/src/node/setAlign.js
@@ -12,12 +12,22 @@ const ALIGN = {
 };
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
+ * @typedef {Function} AlignSetter
+ * @param {string} value align value
+ * @returns {NodeInstanceWrapper} node instance wrapper
+ */
+
+/**
  * Set generic align attribute to node's Yoga instance
  *
- * @param {String} specific align property
- * @param {String} align value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} attr specific align property
+ * @returns {AlignSetter} align setter
  */
 const setAlign = attr => value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setAlignContent.js
+++ b/packages/layout/src/node/setAlignContent.js
@@ -3,9 +3,9 @@ import setAlign from './setAlign';
 /**
  * Set align content attribute to node's Yoga instance
  *
- * @param {String} align value
+ * @param {string} align value
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 const setAlignContent = setAlign('content');
 

--- a/packages/layout/src/node/setAlignItems.js
+++ b/packages/layout/src/node/setAlignItems.js
@@ -3,9 +3,9 @@ import setAlign from './setAlign';
 /**
  * Set align items attribute to node's Yoga instance
  *
- * @param {String} align value
+ * @param {string} align value
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 const setAlignItems = setAlign('items');
 

--- a/packages/layout/src/node/setAlignSelf.js
+++ b/packages/layout/src/node/setAlignSelf.js
@@ -3,9 +3,9 @@ import setAlign from './setAlign';
 /**
  * Set align self attribute to node's Yoga instance
  *
- * @param {String} align value
+ * @param {string} align value
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 const setAlignSelf = setAlign('self');
 

--- a/packages/layout/src/node/setAspectRatio.js
+++ b/packages/layout/src/node/setAspectRatio.js
@@ -1,11 +1,16 @@
 import { isNil } from '@react-pdf/fns';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set aspect ratio attribute to node's Yoga instance
  *
- * @param {Number} ratio
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} value ratio
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setAspectRatio = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setBorderWidth.js
+++ b/packages/layout/src/node/setBorderWidth.js
@@ -3,47 +3,52 @@ import Yoga from '../../yoga';
 import setYogaValue from './setYogaValue';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set border top attribute to node's Yoga instance
  *
- * @param {Number} border top width
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} border border top width
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setBorderTop = setYogaValue('border', Yoga.EDGE_TOP);
 
 /**
  * Set border right attribute to node's Yoga instance
  *
- * @param {Number} border right width
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} border border right width
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setBorderRight = setYogaValue('border', Yoga.EDGE_RIGHT);
 
 /**
  * Set border bottom attribute to node's Yoga instance
  *
- * @param {Number} border bottom width
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} border border bottom width
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setBorderBottom = setYogaValue('border', Yoga.EDGE_BOTTOM);
 
 /**
  * Set border left attribute to node's Yoga instance
  *
- * @param {Number} border left width
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} border border left width
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setBorderLeft = setYogaValue('border', Yoga.EDGE_LEFT);
 
 /**
  * Set all border widths at once
  *
- * @param {Number} border width
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number | string} width border width
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 export const setBorder = width => node => {
   setBorderTop(width)(node);

--- a/packages/layout/src/node/setDimension.js
+++ b/packages/layout/src/node/setDimension.js
@@ -3,53 +3,53 @@ import setYogaValue from './setYogaValue';
 /**
  * Set width to node's Yoga instance
  *
- * @param {Number} width
+ * @param {number} width
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 export const setWidth = setYogaValue('width');
 
 /**
  * Set min width to node's Yoga instance
  *
- * @param {Number} min width
+ * @param {number} min width
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 export const setMinWidth = setYogaValue('minWidth');
 
 /**
  * Set max width to node's Yoga instance
  *
- * @param {Number} max width
+ * @param {number} max width
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 export const setMaxWidth = setYogaValue('maxWidth');
 
 /**
  * Set height to node's Yoga instance
  *
- * @param {Number} height
+ * @param {number} height
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 export const setHeight = setYogaValue('height');
 
 /**
  * Set min height to node's Yoga instance
  *
- * @param {Number} min height
+ * @param {number} min height
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 export const setMinHeight = setYogaValue('minHeight');
 
 /**
  * Set max height to node's Yoga instance
  *
- * @param {Number} max height
+ * @param {number} max height
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 export const setMaxHeight = setYogaValue('maxHeight');

--- a/packages/layout/src/node/setDisplay.js
+++ b/packages/layout/src/node/setDisplay.js
@@ -1,11 +1,16 @@
 import Yoga from '../../yoga';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set display attribute to node's Yoga instance
  *
- * @param {String} display
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} value display
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setDisplay = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setFlexBasis.js
+++ b/packages/layout/src/node/setFlexBasis.js
@@ -3,9 +3,9 @@ import setYogaValue from './setYogaValue';
 /**
  * Set flex basis attribute to node's Yoga instance
  *
- * @param {Number} flex basis value
+ * @param {number} flex basis value
  * @param {Object} node instance
- * @return {Object} node instance
+ * @returns {Object} node instance
  */
 const setFlexBasis = setYogaValue('flexBasis');
 

--- a/packages/layout/src/node/setFlexDirection.js
+++ b/packages/layout/src/node/setFlexDirection.js
@@ -7,11 +7,16 @@ const FLEX_DIRECTIONS = {
 };
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set flex direction attribute to node's Yoga instance
  *
- * @param {String} flex direction value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} value flex direction value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setFlexDirection = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setFlexGrow.js
+++ b/packages/layout/src/node/setFlexGrow.js
@@ -1,11 +1,16 @@
 import setYogaValue from './setYogaValue';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set flex grow attribute to node's Yoga instance
  *
- * @param {Number} flex grow value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} value flex grow value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setFlexGrow = value => node => {
   return setYogaValue('flexGrow')(value || 0)(node);

--- a/packages/layout/src/node/setFlexShrink.js
+++ b/packages/layout/src/node/setFlexShrink.js
@@ -1,11 +1,16 @@
 import setYogaValue from './setYogaValue';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set flex shrink attribute to node's Yoga instance
  *
- * @param {Number} flex shrink value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} value flex shrink value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setFlexShrink = value => node => {
   return setYogaValue('flexShrink')(value || 1)(node);

--- a/packages/layout/src/node/setFlexWrap.js
+++ b/packages/layout/src/node/setFlexWrap.js
@@ -6,11 +6,16 @@ const FLEX_WRAP = {
 };
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set flex wrap attribute to node's Yoga instance
  *
- * @param {String} flex wrap value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} value flex wrap value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setFlexWrap = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setGap.js
+++ b/packages/layout/src/node/setGap.js
@@ -1,6 +1,19 @@
 import { isNil, matchPercent } from '@react-pdf/fns';
 import Yoga from '../../yoga';
 
+/**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
+ * Check if value is a percentage and throw error if so
+ *
+ * @param {string} attr property
+ * @param {unknown} value
+ * @returns {void}
+ */
 const checkPercents = (attr, value) => {
   const percent = matchPercent(value);
 
@@ -12,9 +25,8 @@ const checkPercents = (attr, value) => {
 /**
  * Set rowGap value to node's Yoga instance
  *
- * @param {Number} gap value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} value gap value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 export const setRowGap = value => node => {
   const { yogaNode } = node;
@@ -30,9 +42,8 @@ export const setRowGap = value => node => {
 /**
  * Set columnGap value to node's Yoga instance
  *
- * @param {Number} gap value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} value gap value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 export const setColumnGap = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setJustifyContent.js
+++ b/packages/layout/src/node/setJustifyContent.js
@@ -10,11 +10,16 @@ const JUSTIFY_CONTENT = {
 };
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set justify content attribute to node's Yoga instance
  *
- * @param {String} justify content value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} value justify content value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setJustifyContent = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setMargin.js
+++ b/packages/layout/src/node/setMargin.js
@@ -3,47 +3,52 @@ import Yoga from '../../yoga';
 import setYogaValue from './setYogaValue';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set margin top attribute to node's Yoga instance
  *
- * @param {Number} margin top
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} margin margin top
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setMarginTop = setYogaValue('margin', Yoga.EDGE_TOP);
 
 /**
  * Set margin right attribute to node's Yoga instance
  *
- * @param {Number} margin right
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} margin margin right
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setMarginRight = setYogaValue('margin', Yoga.EDGE_RIGHT);
 
 /**
  * Set margin bottom attribute to node's Yoga instance
  *
- * @param {Number} margin bottom
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} margin margin bottom
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setMarginBottom = setYogaValue('margin', Yoga.EDGE_BOTTOM);
 
 /**
  * Set margin left attribute to node's Yoga instance
  *
- * @param {Number} margin left
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} margin margin left
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setMarginLeft = setYogaValue('margin', Yoga.EDGE_LEFT);
 
 /**
  * Set all margins at once
  *
- * @param {Number} margin
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number | string} margin margin
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 export const setMargin = margin => node => {
   setMarginTop(margin)(node);

--- a/packages/layout/src/node/setOverflow.js
+++ b/packages/layout/src/node/setOverflow.js
@@ -7,11 +7,16 @@ const OVERFLOW = {
 };
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set overflow attribute to node's Yoga instance
  *
- * @param {String} overflow value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} value overflow value
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setOverflow = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setPadding.js
+++ b/packages/layout/src/node/setPadding.js
@@ -3,47 +3,52 @@ import Yoga from '../../yoga';
 import setYogaValue from './setYogaValue';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set padding top attribute to node's Yoga instance
  *
- * @param {Number} padding top
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} padding padding top
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPaddingTop = setYogaValue('padding', Yoga.EDGE_TOP);
 
 /**
  * Set padding right attribute to node's Yoga instance
  *
- * @param {Number} padding right
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} padding padding right
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPaddingRight = setYogaValue('padding', Yoga.EDGE_RIGHT);
 
 /**
  * Set padding bottom attribute to node's Yoga instance
  *
- * @param {Number} padding bottom
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} padding padding bottom
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPaddingBottom = setYogaValue('padding', Yoga.EDGE_BOTTOM);
 
 /**
  * Set padding left attribute to node's Yoga instance
  *
- * @param {Number} padding left
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} padding padding left
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPaddingLeft = setYogaValue('padding', Yoga.EDGE_LEFT);
 
 /**
  * Set all paddings at once
  *
- * @param {Number} margin
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number | string} padding padding
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 export const setPadding = padding => node => {
   setPaddingTop(padding)(node);

--- a/packages/layout/src/node/setPosition.js
+++ b/packages/layout/src/node/setPosition.js
@@ -3,47 +3,52 @@ import Yoga from '../../yoga';
 import setYogaValue from './setYogaValue';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set position top attribute to node's Yoga instance
  *
- * @param {Number} position top
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} position position top
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPositionTop = setYogaValue('position', Yoga.EDGE_TOP);
 
 /**
  * Set position right attribute to node's Yoga instance
  *
- * @param {Number} position right
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} position position right
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPositionRight = setYogaValue('position', Yoga.EDGE_RIGHT);
 
 /**
  * Set position bottom attribute to node's Yoga instance
  *
- * @param {Number} position bottom
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} position position bottom
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPositionBottom = setYogaValue('position', Yoga.EDGE_BOTTOM);
 
 /**
  * Set position left attribute to node's Yoga instance
  *
- * @param {Number} position left
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number} position position left
+ * @param {Object} node node instance
+ * @returns {Object} node instance
  */
 export const setPositionLeft = setYogaValue('position', Yoga.EDGE_LEFT);
 
 /**
  * Set all positions at once
  *
- * @param {Number} position
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {number | string} position position
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 export const setPosition = position => node => {
   setPositionTop(position)(node);

--- a/packages/layout/src/node/setPositionType.js
+++ b/packages/layout/src/node/setPositionType.js
@@ -2,11 +2,16 @@ import { isNil } from '@react-pdf/fns';
 import Yoga from '../../yoga';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
  * Set position type attribute to node's Yoga instance
  *
- * @param {String} position type
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} value position position type
+ * @returns {NodeInstanceWrapper} node instance wrapper
  */
 const setPositionType = value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/node/setYogaValue.js
+++ b/packages/layout/src/node/setYogaValue.js
@@ -2,13 +2,23 @@
 import { isNil, upperFirst, matchPercent } from '@react-pdf/fns';
 
 /**
+ * @typedef {Function} NodeInstanceWrapper
+ * @param {Object} node node instance
+ * @returns {Object} node instance
+ */
+
+/**
+ * @typedef {Function} YogaValueSetter
+ * @param {any} value
+ * @returns {NodeInstanceWrapper} node instance wrapper
+ */
+
+/**
  * Set generic yoga attribute to node's Yoga instance, handing `auto`, edges and percentage cases
  *
- * @param {String} property
- * @param {Number} edge
- * @param {any} value
- * @param {Object} node instance
- * @return {Object} node instance
+ * @param {string} attr property
+ * @param {number} [edge] edge
+ * @returns {YogaValueSetter} node instance wrapper
  */
 const setYogaValue = (attr, edge) => value => node => {
   const { yogaNode } = node;

--- a/packages/layout/src/page/getOrientation.js
+++ b/packages/layout/src/page/getOrientation.js
@@ -3,10 +3,10 @@ const VALID_ORIENTATIONS = ['portrait', 'landscape'];
 /**
  * Get page orientation. Defaults to portrait
  *
- * @param { Object } page object
- * @returns { String } page orientation
+ * @param {Object} page object
+ * @returns {string} page orientation
  */
-const getOrientation = page => {
+const getOrientation = (page) => {
   const value = page.props?.orientation || 'portrait';
   return VALID_ORIENTATIONS.includes(value) ? value : 'portrait';
 };

--- a/packages/layout/src/page/getSize.js
+++ b/packages/layout/src/page/getSize.js
@@ -57,25 +57,25 @@ const PAGE_SIZES = {
 /**
  * Transforms array into size object
  *
- * @param {Array} array
- * @returns {Object} size object with width and height
+ * @param {number[]} v array
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const toSizeObject = v => ({ width: v[0], height: v[1] });
+const toSizeObject = (v) => ({ width: v[0], height: v[1] });
 
 /**
  * Flip size object
  *
- * @param {Object} size object
- * @returns {Object} flipped size object
+ * @param {{ width: number, height: number }} v size object
+ * @returns {{ width: number, height: number }} flipped size object
  */
-const flipSizeObject = v => ({ width: v.height, height: v.width });
+const flipSizeObject = (v) => ({ width: v.height, height: v.width });
 
 /**
  * Adjust page size to passed DPI
  *
- * @param {Object} size object
- * @param {number} dpi
- * @returns {Object} adjusted size object
+ * @param {{ width: number, height: number }} v size object
+ * @param {number} dpi DPI
+ * @returns {{ width: number, height: number }} adjusted size object
  */
 const adjustDpi = (v, dpi) => ({
   width: v.width ? v.width * dpi : v.width,
@@ -85,34 +85,37 @@ const adjustDpi = (v, dpi) => ({
 /**
  * Returns size object from a given string
  *
- * @param {String} page size string
- * @returns {Object} size object with width and height
+ * @param {string} v page size string
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const getStringSize = v => {
+const getStringSize = (v) => {
   return toSizeObject(PAGE_SIZES[v.toUpperCase()]);
 };
 
 /**
  * Returns size object from a single number
  *
- * @param {Number} page size number
- * @returns {Object} size object with width and height
+ * @param {number} n page size number
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const getNumberSize = n => toSizeObject([n]);
+const getNumberSize = (n) => toSizeObject([n]);
 
 /**
  * Return page size in an object { width, height }
  *
  * @param {Object} page instance
- * @returns {Object} size object with width and height
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const getSize = page => {
+const getSize = (page) => {
   const value = page.props?.size || 'A4';
   const dpi = parseFloat(page.props?.dpi || 72);
 
   const type = typeof value;
 
-  let size = value;
+  /**
+   * @type {{ width: number, height: number }}
+   */
+  let size;
 
   if (type === 'string') {
     size = getStringSize(value);
@@ -120,6 +123,8 @@ const getSize = page => {
     size = toSizeObject(value);
   } else if (type === 'number') {
     size = getNumberSize(value);
+  } else {
+    size = value;
   }
 
   size = adjustDpi(size, dpi / 72);

--- a/packages/layout/src/page/isHeightAuto.js
+++ b/packages/layout/src/page/isHeightAuto.js
@@ -4,7 +4,7 @@ import { isNil } from '@react-pdf/fns';
  * Checks if page has auto height
  *
  * @param {Object} page
- * @returns {Boolean} is page height auto
+ * @returns {boolean} is page height auto
  */
 const isHeightAuto = page => isNil(page.box?.height);
 

--- a/packages/layout/src/page/isLandscape.js
+++ b/packages/layout/src/page/isLandscape.js
@@ -4,7 +4,7 @@ import getOrientation from './getOrientation';
  * Return true if page is landscape
  *
  * @param {Object} page instance
- * @returns {Boolean} is page landscape
+ * @returns {boolean} is page landscape
  */
 const isLandscape = page => getOrientation(page) === 'landscape';
 

--- a/packages/layout/src/page/isPortrait.js
+++ b/packages/layout/src/page/isPortrait.js
@@ -4,7 +4,7 @@ import getOrientation from './getOrientation';
  * Return true if page is portrait
  *
  * @param {Object} page instance
- * @returns {Boolean} is page portrait
+ * @returns {boolean} is page portrait
  */
 const isPortrait = page => getOrientation(page) === 'portrait';
 

--- a/packages/layout/src/steps/resolveAssets.js
+++ b/packages/layout/src/steps/resolveAssets.js
@@ -3,13 +3,14 @@ import * as P from '@react-pdf/primitives';
 import fetchEmojis from '../text/emoji';
 import fetchImage from '../image/fetchImage';
 
-const isImage = node => node.type === P.Image;
+const isImage = (node) => node.type === P.Image;
 
 /**
  * Get all asset promises that need to be resolved
  *
- * @param {Object} root node
- * @returns {Array} asset promises
+ * @param {Object} fontStore font store
+ * @param {Object} node root node
+ * @returns {Promise<void>[]} asset promises
  */
 const fetchAssets = (fontStore, node) => {
   const promises = [];
@@ -36,7 +37,7 @@ const fetchAssets = (fontStore, node) => {
     }
 
     if (n.children) {
-      n.children.forEach(childNode => {
+      n.children.forEach((childNode) => {
         listToExplore.push(childNode);
       });
     }
@@ -49,9 +50,9 @@ const fetchAssets = (fontStore, node) => {
  * Fetch image, font and emoji assets in parallel.
  * Layout process will not be resumed until promise resolves.
  *
- * @param {Object} root node
+ * @param {Object} node root node
  * @param {Object} fontStore font store
- * @returns {Object} root node
+ * @returns {Promise<Object>} root node
  */
 const resolveAssets = async (node, fontStore) => {
   const promises = fetchAssets(fontStore, node);

--- a/packages/layout/src/steps/resolveDimensions.js
+++ b/packages/layout/src/steps/resolveDimensions.js
@@ -126,11 +126,16 @@ const setYogaValues = node => {
 };
 
 /**
+ * @typedef {Function} InsertYogaNodes
+ * @param {Object} child child node
+ * @returns {Object} node
+ */
+
+/**
  * Inserts child into parent' yoga node
  *
- * @param {Object} parent
- * @param {Object} node
- * @param {Object} node
+ * @param {Object} parent parent
+ * @returns {InsertYogaNodes} insert yoga nodes
  */
 const insertYogaNodes = parent => child => {
   parent.insertChild(child.yogaNode, parent.getChildCount());
@@ -162,11 +167,16 @@ const setMeasureFunc = (node, page, fontStore) => {
 const isLayoutElement = node => !isText(node) && !isNote(node) && !isSvg(node);
 
 /**
+ * @typedef {Function} CreateYogaNodes
+ * @param {Object} node
+ * @returns {Object} node with appended yoga node
+ */
+
+/**
  * Creates and add yoga node to document tree
  * Handles measure function for text and image nodes
  *
- * @param {Object} node
- * @returns {Object} node with appended yoga node
+ * @returns {CreateYogaNodes} create yoga nodes
  */
 const createYogaNodes = (page, fontStore) => node => {
   const yogaNode = Yoga.Node.createWithConfig(YOGA_CONFIG);
@@ -192,8 +202,8 @@ const createYogaNodes = (page, fontStore) => node => {
 /**
  * Performs yoga calculation
  *
- * @param {Object} node
- * @returns {Object} node
+ * @param {Object} page page node
+ * @returns {Object} page node
  */
 const calculateLayout = page => {
   page.yogaNode.calculateLayout();
@@ -278,7 +288,8 @@ export const resolvePageDimensions = (page, fontStore) => {
 /**
  * Calculates root object layout using Yoga.
  *
- * @param {Object} root object
+ * @param {Object} node root object
+ * @param {Object} fontStore font store
  * @returns {Object} root object with correct 'box' layout attributes
  */
 const resolveDimensions = (node, fontStore) => {

--- a/packages/layout/src/steps/resolveInheritance.js
+++ b/packages/layout/src/steps/resolveInheritance.js
@@ -54,11 +54,16 @@ const merge = (inheritedStyles, style) => {
 };
 
 /**
- * Merges styles with node
- *
- * @param {Object} style object
+ * @typedef {Function} MergeStyles
  * @param {Object} node
  * @returns {Object} node with styles merged
+ */
+
+/**
+ * Merges styles with node
+ *
+ * @param {Object} inheritedStyles style object
+ * @returns {MergeStyles} merge styles function
  */
 const mergeStyles = inheritedStyles => node => {
   const style = merge(inheritedStyles, node.style || {});
@@ -68,7 +73,7 @@ const mergeStyles = inheritedStyles => node => {
 /**
  * Inherit style values from the root to the leafs
  *
- * @param {Object} document root
+ * @param {Object} node document root
  * @returns {Object} document root with inheritance
  *
  */

--- a/packages/layout/src/steps/resolveLinkSubstitution.js
+++ b/packages/layout/src/steps/resolveLinkSubstitution.js
@@ -13,7 +13,7 @@ const isTextInstance = isType(P.TextInstance);
  * Checks if node has render prop
  *
  * @param {Object} node
- * @returns {Boolean} has render prop?
+ * @returns {boolean} has render prop?
  */
 const hasRenderProp = node => !!node.props?.render;
 
@@ -21,7 +21,7 @@ const hasRenderProp = node => !!node.props?.render;
  * Checks if node is text type (Text or TextInstance)
  *
  * @param {Object} node
- * @returns {Boolean} are all children text instances?
+ * @returns {boolean} are all children text instances?
  */
 const isTextType = node => isText(node) || isTextInstance(node);
 
@@ -29,7 +29,7 @@ const isTextType = node => isText(node) || isTextInstance(node);
  * Checks if is tet link that needs to be wrapped in Text
  *
  * @param {Object} node
- * @returns {Boolean} are all children text instances?
+ * @returns {boolean} are all children text instances?
  */
 const isTextLink = node => {
   const children = node.children || [];
@@ -47,7 +47,7 @@ const isTextLink = node => {
  * Wraps node children inside Text node
  *
  * @param {Object} node
- * @returns {Boolean} node with intermediate Text child
+ * @returns {boolean} node with intermediate Text child
  */
 const wrapText = node => {
   const textElement = {

--- a/packages/layout/src/steps/resolveOrigins.js
+++ b/packages/layout/src/steps/resolveOrigins.js
@@ -21,8 +21,8 @@ const resolveNodeOrigin = node => {
 /**
  * Resolve document origins
  *
- * @param {Object} document root
- * @returns {Object} documrnt root
+ * @param {Object} root document root
+ * @returns {Object} document root
  */
 
 const resolveOrigin = root => {

--- a/packages/layout/src/steps/resolvePagePaddings.js
+++ b/packages/layout/src/steps/resolvePagePaddings.js
@@ -1,25 +1,35 @@
 import { evolve, matchPercent } from '@react-pdf/fns';
 
-/*
- * Translates page percentage horizontal paddings in fixed ones
- *
- * @param {Object} page container
- * @param {String} padding value
+/**
+ * @typedef {Function} ResolvePageHorizontalPadding
+ * @param {string} value padding value
  * @returns {Object} translated padding value
  */
-const resolvePageHorizontalPadding = container => value => {
+
+/**
+ * Translates page percentage horizontal paddings in fixed ones
+ *
+ * @param {Object} container page container
+ * @returns {ResolvePageHorizontalPadding} resolve page horizontal padding
+ */
+const resolvePageHorizontalPadding = (container) => (value) => {
   const match = matchPercent(value);
   return match ? match.percent * container.width : value;
 };
 
 /**
- * Translates page percentage vertical paddings in fixed ones
- *
- * @param {Object} page container
- * @param {String} padding value
+ * @typedef {Function} ResolvePageVerticalPadding
+ * @param {string} padding value
  * @returns {Object} translated padding value
  */
-const resolvePageVerticalPadding = container => value => {
+
+/**
+ * Translates page percentage vertical paddings in fixed ones
+ *
+ * @param {Object} container page container
+ * @returns {ResolvePageVerticalPadding} resolve page vertical padding
+ */
+const resolvePageVerticalPadding = (container) => (value) => {
   const match = matchPercent(value);
   return match ? match.percent * container.height : value;
 };
@@ -30,7 +40,7 @@ const resolvePageVerticalPadding = container => value => {
  * @param {Object} page
  * @returns {Object} page with fixed paddings
  */
-const resolvePagePaddings = page => {
+const resolvePagePaddings = (page) => {
   const container = page.style;
 
   const style = evolve(
@@ -51,10 +61,10 @@ const resolvePagePaddings = page => {
  * This has to be computed from pages calculated size and not by Yoga
  * because at this point we didn't performed pagination yet.
  *
- * @param {Object} document root
+ * @param {Object} root document root
  * @returns {Object} document root with translated page paddings
  */
-const resolvePagesPaddings = root => {
+const resolvePagesPaddings = (root) => {
   if (!root.children) return root;
 
   const children = root.children.map(resolvePagePaddings);

--- a/packages/layout/src/steps/resolvePageSizes.js
+++ b/packages/layout/src/steps/resolvePageSizes.js
@@ -17,7 +17,7 @@ export const resolvePageSize = page => {
 /**
  * Resolves page sizes
  *
- * @param {Object} document root
+ * @param {Object} root document root
  * @returns {Object} document root with resolved page sizes
  */
 const resolvePageSizes = root => {

--- a/packages/layout/src/steps/resolvePagination.js
+++ b/packages/layout/src/steps/resolvePagination.js
@@ -17,19 +17,19 @@ import resolveTextLayout from './resolveTextLayout';
 import resolveInheritance from './resolveInheritance';
 import { resolvePageDimensions } from './resolveDimensions';
 
-const isText = node => node.type === P.Text;
+const isText = (node) => node.type === P.Text;
 
 // Prevent splitting elements by low decimal numbers
-const SAFTY_THRESHOLD = 0.001;
+const SAFETY_THRESHOLD = 0.001;
 
 const assingChildren = (children, node) =>
   Object.assign({}, node, { children });
 
-const getTop = node => node.box?.top || 0;
+const getTop = (node) => node.box?.top || 0;
 
-const allFixed = nodes => nodes.every(isFixed);
+const allFixed = (nodes) => nodes.every(isFixed);
 
-const isDynamic = node => !isNil(node.props?.render);
+const isDynamic = (node) => !isNil(node.props?.render);
 
 const relayoutPage = compose(
   resolveTextLayout,
@@ -37,7 +37,7 @@ const relayoutPage = compose(
   resolvePageDimensions,
 );
 
-const warnUnavailableSpace = node => {
+const warnUnavailableSpace = (node) => {
   console.warn(
     `Node of type ${node.type} can't wrap between pages and it's bigger than available page height`,
   );
@@ -56,7 +56,7 @@ const splitNodes = (height, contentArea, nodes) => {
     const nodeHeight = child.box.height;
     const isOutside = height <= nodeTop;
     const shouldBreak = shouldNodeBreak(child, futureNodes, height);
-    const shouldSplit = height + SAFTY_THRESHOLD < nodeTop + nodeHeight;
+    const shouldSplit = height + SAFETY_THRESHOLD < nodeTop + nodeHeight;
     const canWrap = canNodeWrap(child);
     const fitsInsidePage = nodeHeight <= contentArea;
 
@@ -143,7 +143,7 @@ const splitView = (node, height, contentArea) => {
 const split = (node, height, contentArea) =>
   isText(node) ? splitText(node, height) : splitView(node, height, contentArea);
 
-const shouldResolveDynamicNodes = node => {
+const shouldResolveDynamicNodes = (node) => {
   const children = node.children || [];
   return isDynamic(node) || children.some(shouldResolveDynamicNodes);
 };
@@ -157,10 +157,10 @@ const resolveDynamicNodes = (props, node) => {
       const res = node.props.render(props);
       return createInstances(res)
         .filter(Boolean)
-        .map(n => resolveDynamicNodes(props, n));
+        .map((n) => resolveDynamicNodes(props, n));
     }
 
-    return children.map(c => resolveDynamicNodes(props, c));
+    return children.map((c) => resolveDynamicNodes(props, c));
   };
 
   // We reset dynamic text box so it can be computed again later on
@@ -194,7 +194,7 @@ const splitPage = (page, pageNumber, fontStore) => {
     dynamicPage.children,
   );
 
-  const relayout = node => relayoutPage(node, fontStore);
+  const relayout = (node) => relayoutPage(node, fontStore);
 
   const currentBox = { ...page.box, height };
   const currentPage = relayout(
@@ -231,7 +231,7 @@ const resolvePageIndices = (fontStore, page, pageNumber, pages) => {
   return resolveDynamicPage(props, page, fontStore);
 };
 
-const assocSubPageData = subpages => {
+const assocSubPageData = (subpages) => {
   return subpages.map((page, i) => ({
     ...page,
     subPageNumber: i,
@@ -239,7 +239,7 @@ const assocSubPageData = subpages => {
   }));
 };
 
-const dissocSubPageData = page => {
+const dissocSubPageData = (page) => {
   return omit(['subPageNumber', 'subPageTotalPages'], page);
 };
 
@@ -267,7 +267,7 @@ const paginate = (page, pageNumber, fontStore) => {
  * Performs pagination. This is the step responsible of breaking the whole document
  * into pages following pagiation rules, such as `fixed`, `break` and dynamic nodes.
  *
- * @param {Object} node
+ * @param {Object} doc node
  * @param {Object} fontStore font store
  * @returns {Object} layout node
  */

--- a/packages/layout/src/steps/resolvePercentHeight.js
+++ b/packages/layout/src/steps/resolvePercentHeight.js
@@ -3,8 +3,8 @@ import { isNil, matchPercent } from '@react-pdf/fns';
 /**
  * Transform percent height into fixed
  *
- * @param {String | number} height
- * @return {number} height
+ * @param {number} height
+ * @returns {number} height
  */
 const transformHeight = (pageArea, height) => {
   const match = matchPercent(height);
@@ -15,7 +15,7 @@ const transformHeight = (pageArea, height) => {
  * Get page area (height minus paddings)
  *
  * @param {Object} page
- * @return {number} page area
+ * @returns {number} page area
  */
 const getPageArea = page => {
   const pageHeight = page.style.height;
@@ -30,7 +30,7 @@ const getPageArea = page => {
  *
  * @param {Object} page
  * @param {Object} node
- * @return {Object} transformed node
+ * @returns {Object} transformed node
  */
 const resolveNodePercentHeight = (page, node) => {
   if (isNil(page.style?.height)) return node;
@@ -47,7 +47,7 @@ const resolveNodePercentHeight = (page, node) => {
  * Transform page immediate children with percent height to fixed
  *
  * @param {Object} page
- * @return {Object} transformed page
+ * @returns {Object} transformed page
  */
 const resolvePagePercentHeight = page => {
   if (!page.children) return page;
@@ -62,8 +62,8 @@ const resolvePagePercentHeight = page => {
  * Transform all page immediate children with percent height to fixed.
  * This is needed for computing correct dimensions on pre-pagination layout.
  *
- * @param {Object} document root
- * @return {Object} transformed document root
+ * @param {Object} root document root
+ * @returns {Object} transformed document root
  */
 const resolvePercentHeight = root => {
   if (!root.children) return root;

--- a/packages/layout/src/steps/resolvePercentRadius.js
+++ b/packages/layout/src/steps/resolvePercentRadius.js
@@ -1,12 +1,17 @@
 import { evolve, matchPercent } from '@react-pdf/fns';
 
 /**
- *
- * @param {Object} container width and height
- * @param {String | Number} value border radius value
- * @returns {Number} fixed border radius value
+ * @typedef {Function} ResolveRadius
+ * @param {string | number} value border radius value
+ * @returns {number} resolved radius value
  */
-const resolveRadius = container => value => {
+
+/**
+ *
+ * @param {{ width: number, height: number }} container width and height
+ * @returns {ResolveRadius} resolve radius function
+ */
+const resolveRadius = (container) => (value) => {
   if (!value) return undefined;
 
   const match = matchPercent(value);
@@ -22,7 +27,7 @@ const resolveRadius = container => value => {
  * @param {Object} node
  * @returns {Object} node
  */
-const resolvePercentRadius = node => {
+const resolvePercentRadius = (node) => {
   const style = evolve(
     {
       borderTopLeftRadius: resolveRadius(node.box),

--- a/packages/layout/src/steps/resolveStyles.js
+++ b/packages/layout/src/steps/resolveStyles.js
@@ -12,7 +12,7 @@ const DEFAULT_LINK_STYLES = {
  * Computes styles using stylesheet
  *
  * @param {Object} container
- * @param {Object} document node
+ * @param {Object} node document node
  * @returns {Object} computed styles
  */
 const computeStyle = (container, node) => {
@@ -28,11 +28,16 @@ const computeStyle = (container, node) => {
 };
 
 /**
+ * @typedef {Function} ResolveNodeStyles
+ * @param {Object} node document node
+ * @returns {Object} node (and subnodes) with resolved styles
+ */
+
+/**
  * Resolves node styles
  *
  * @param {Object} container
- * @param {Object} document node
- * @returns {Object} node (and subnodes) with resolved styles
+ * @returns {ResolveNodeStyles} resolve node styles
  */
 const resolveNodeStyles = container => node => {
   const style = computeStyle(container, node);
@@ -47,7 +52,7 @@ const resolveNodeStyles = container => node => {
 /**
  * Resolves page styles
  *
- * @param {Object} document page
+ * @param {Object} page document page
  * @returns {Object} document page with resolved styles
  */
 const resolvePageStyles = page => {
@@ -63,7 +68,7 @@ const resolvePageStyles = page => {
 /**
  * Resolves document styles
  *
- * @param {Object} document root
+ * @param {Object} root document root
  * @returns {Object} document root with resolved styles
  */
 const resolveStyles = root => {

--- a/packages/layout/src/steps/resolveSvg.js
+++ b/packages/layout/src/steps/resolveSvg.js
@@ -192,7 +192,7 @@ const resolveSvgRoot = (node, fontStore) => {
 /**
  * Pre-process SVG nodes so they can be rendered in the next steps
  *
- * @param {Object} root node
+ * @param {Object} node root node
  * @param {Object} fontStore font store
  * @returns {Object} root node
  */

--- a/packages/layout/src/svg/measureSvg.js
+++ b/packages/layout/src/svg/measureSvg.js
@@ -1,41 +1,42 @@
 import Yoga from '../../yoga';
 
-const getAspectRatio = viewbox => {
+const getAspectRatio = (viewbox) => {
   if (!viewbox) return null;
   return (viewbox.maxX - viewbox.minX) / (viewbox.maxY - viewbox.minY);
 };
+
+/**
+ * @typedef {Function} MeasureSvg
+ * @param {number} width
+ * @param {number} widthMode
+ * @param {number} height
+ * @param {number} heightMode
+ * @returns {{ width: number, height: number }} svg width and height
+ */
 
 /**
  * Yoga svg measure function
  *
  * @param {Object} page
  * @param {Object} node
- * @param {Number} width
- * @param {Number} widthMode
- * @param {Number} height
- * @param {Number} heightMode
- * @returns {Object} canvas width and height
+ * @returns {MeasureSvg} measure svg
  */
-const measureCanvas = (page, node) => (
-  width,
-  widthMode,
-  height,
-  heightMode,
-) => {
-  const aspectRatio = getAspectRatio(node.props.viewBox) || 1;
+const measureCanvas =
+  (page, node) => (width, widthMode, height, heightMode) => {
+    const aspectRatio = getAspectRatio(node.props.viewBox) || 1;
 
-  if (
-    widthMode === Yoga.MEASURE_MODE_EXACTLY ||
-    widthMode === Yoga.MEASURE_MODE_AT_MOST
-  ) {
-    return { width, height: width / aspectRatio };
-  }
+    if (
+      widthMode === Yoga.MEASURE_MODE_EXACTLY ||
+      widthMode === Yoga.MEASURE_MODE_AT_MOST
+    ) {
+      return { width, height: width / aspectRatio };
+    }
 
-  if (heightMode === Yoga.MEASURE_MODE_EXACTLY) {
-    return { width: height * aspectRatio };
-  }
+    if (heightMode === Yoga.MEASURE_MODE_EXACTLY) {
+      return { width: height * aspectRatio };
+    }
 
-  return {};
-};
+    return {};
+  };
 
 export default measureCanvas;

--- a/packages/layout/src/text/fromFragments.js
+++ b/packages/layout/src/text/fromFragments.js
@@ -1,15 +1,15 @@
 /**
  * Create attributed string from text fragments
  *
- * @param  {Array}  fragments
- * @return {Object} attributed string
+ * @param {Object[]} fragments fragments
+ * @returns {Object} attributed string
  */
-const fromFragments = fragments => {
+const fromFragments = (fragments) => {
   let offset = 0;
   let string = '';
   const runs = [];
 
-  fragments.forEach(fragment => {
+  fragments.forEach((fragment) => {
     string += fragment.string;
 
     runs.push({

--- a/packages/layout/src/text/getAttributedString.js
+++ b/packages/layout/src/text/getAttributedString.js
@@ -7,16 +7,18 @@ import transformText from './transformText';
 
 const PREPROCESSORS = [ignoreChars, embedEmojis];
 
-const isImage = node => node.type === P.Image;
+const isImage = (node) => node.type === P.Image;
 
-const isTextInstance = node => node.type === P.TextInstance;
+const isTextInstance = (node) => node.type === P.TextInstance;
 
 /**
  * Get textkit fragments of given node object
  *
- * @param {Object} font store
+ * @param {Object} fontStore font store
  * @param {Object} instance node
- * @returns {Array} text fragments
+ * @param {string} [parentLink] parent link
+ * @param {number} [level] fragment level
+ * @returns {Object[]} text fragments
  */
 const getFragments = (fontStore, instance, parentLink, level = 0) => {
   if (!instance) return [{ string: '' }];
@@ -112,7 +114,7 @@ const getFragments = (fontStore, instance, parentLink, level = 0) => {
 /**
  * Get textkit attributed string from text node
  *
- * @param {Object} font store
+ * @param {Object} fontStore font store
  * @param {Object} instance node
  * @returns {Object} attributed string
  */

--- a/packages/layout/src/text/heightAtLineIndex.js
+++ b/packages/layout/src/text/heightAtLineIndex.js
@@ -2,7 +2,7 @@
  * Get height for given text line index
  *
  * @param {Object} node
- * @param {Number} index
+ * @param {number} index
  */
 const heightAtLineIndex = (node, index) => {
   let counter = 0;

--- a/packages/layout/src/text/layoutText.js
+++ b/packages/layout/src/text/layoutText.js
@@ -20,15 +20,15 @@ const engines = {
 
 const engine = layoutEngine(engines);
 
-const getMaxLines = node => node.style?.maxLines;
+const getMaxLines = (node) => node.style?.maxLines;
 
-const getTextOverflow = node => node.style?.textOverflow;
+const getTextOverflow = (node) => node.style?.textOverflow;
 
 /**
  * Get layout container for specific text node
  *
- * @param {Number} width
- * @param {Number} height
+ * @param {number} width
+ * @param {number} height
  * @param {Object} node
  * @returns {Object} layout container
  */
@@ -64,11 +64,11 @@ const getLayoutOptions = (fontStore, node) => ({
 /**
  * Get text lines for given node
  *
- * @param {Object} node
- * @param {Number} container width
- * @param {Number} container height
- * @param {Number} fontStore font store
- * @returns {Array} layout lines
+ * @param {Object} node node
+ * @param {number} width container width
+ * @param {number} height container height
+ * @param {number} fontStore font store
+ * @returns {Object[]} layout lines
  */
 const layoutText = (node, width, height, fontStore) => {
   const attributedString = getAttributedString(fontStore, node);

--- a/packages/layout/src/text/lineIndexAtHeight.js
+++ b/packages/layout/src/text/lineIndexAtHeight.js
@@ -2,7 +2,7 @@
  * Get line index at given height
  *
  * @param {Object} node
- * @param {Number} height
+ * @param {number} height
  */
 const lineIndexAtHeight = (node, height) => {
   let y = 0;

--- a/packages/layout/src/text/linesHeight.js
+++ b/packages/layout/src/text/linesHeight.js
@@ -2,9 +2,9 @@
  * Get lines height (if any)
  *
  * @param {Object} node
- * @returns {Number} lines height
+ * @returns {number} lines height
  */
-const linesHeight = node => {
+const linesHeight = (node) => {
   if (!node.lines) return -1;
   return node.lines.reduce((acc, line) => acc + line.box.height, 0);
 };

--- a/packages/layout/src/text/linesWidth.js
+++ b/packages/layout/src/text/linesWidth.js
@@ -2,12 +2,12 @@
  * Get lines width (if any)
  *
  * @param {Object} node
- * @returns {Number} lines width
+ * @returns {number} lines width
  */
-const linesWidth = node => {
+const linesWidth = (node) => {
   if (!node.lines) return 0;
 
-  return Math.max(0, ...node.lines.map(line => line.xAdvance));
+  return Math.max(0, ...node.lines.map((line) => line.xAdvance));
 };
 
 export default linesWidth;

--- a/packages/layout/src/text/measureText.js
+++ b/packages/layout/src/text/measureText.js
@@ -9,15 +9,20 @@ import linesHeight from './linesHeight';
 const ALIGNMENT_FACTORS = { center: 0.5, right: 1 };
 
 /**
+ * @typedef {Function} MeasureText
+ * @param {number} width
+ * @param {number} widthMode
+ * @param {number} height
+ * @returns {{ width: number, height: number }} text width and height
+ */
+
+/**
  * Yoga text measure function
  *
  * @param {Object} page
  * @param {Object} node
- * @param {Number} width
- * @param {Number} widthMode
- * @param {Number} height
- * @param {Number} heightMode
- * @returns {Object} text width and height
+ * @param {Object} fontStore
+ * @returns {MeasureText} measure text function
  */
 const measureText = (page, node, fontStore) => (width, widthMode, height) => {
   if (widthMode === Yoga.MEASURE_MODE_EXACTLY) {

--- a/packages/layout/src/text/transformText.js
+++ b/packages/layout/src/text/transformText.js
@@ -3,9 +3,9 @@ import { capitalize, upperFirst } from '@react-pdf/fns';
 /**
  * Apply transformation to text string
  *
- * @param {String} text
- * @param {String} transformation type
- * @returns {String} transformed text
+ * @param {string} text
+ * @param {string} transformation type
+ * @returns {string} transformed text
  */
 const transformText = (text, transformation) => {
   switch (transformation) {

--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -323,9 +323,36 @@ class PDFDocument extends stream.Readable {
   toString() {
     return '[object PDFDocument]';
   }
+
+  initColor() {}
+
+  initVector() {}
+
+  initFonts() {}
+
+  initText() {}
+
+  initImages() {}
+
+  initOutline() {}
+
+  /**
+   * @param {number} m11
+   * @param {number} m12
+   * @param {number} m21
+   * @param {number} m22
+   * @param {number} dx
+   * @param {number} dy
+   */
+  // eslint-disable-next-line no-unused-vars
+  transform(m11, m12, m21, m22, dx, dy) {}
+
+  endOutline() {}
+
+  endAcroForm() {}
 }
 
-const mixin = methods => {
+const mixin = (methods) => {
   Object.assign(PDFDocument.prototype, methods);
 };
 

--- a/packages/pdfkit/src/mixins/text.js
+++ b/packages/pdfkit/src/mixins/text.js
@@ -58,7 +58,10 @@ export default {
       x = null;
     }
 
-    // clone options object
+    // shallow clone options object
+    /**
+     * @type {Object}
+     */
     const result = Object.assign({}, options);
 
     // extend options with previous values for continued text
@@ -152,7 +155,7 @@ export default {
     }
 
     // Adds a segment of text to the TJ command buffer
-    const addSegment = cur => {
+    const addSegment = (cur) => {
       if (last < cur) {
         const hex = encoded.slice(last, cur).join('');
         const advance =
@@ -164,7 +167,7 @@ export default {
     };
 
     // Flushes the current TJ commands to the output stream
-    const flush = i => {
+    const flush = (i) => {
       addSegment(i);
 
       if (commands.length > 0) {

--- a/packages/pdfkit/src/tree.js
+++ b/packages/pdfkit/src/tree.js
@@ -53,7 +53,12 @@ class PDFTree {
     return out.join('\n');
   }
 
-  _compareKeys() {
+  /**
+   * @param {string} a
+   * @param {string} b
+   * @returns {number}
+   */
+  _compareKeys(a, b) {
     throw new Error('Must be implemented by subclasses');
   }
 
@@ -61,7 +66,10 @@ class PDFTree {
     throw new Error('Must be implemented by subclasses');
   }
 
-  _dataForKey() {
+  /**
+   * @param {string} key
+   */
+  _dataForKey(key) {
     throw new Error('Must be implemented by subclasses');
   }
 }

--- a/packages/render/src/svg/parsePoints.js
+++ b/packages/render/src/svg/parsePoints.js
@@ -1,3 +1,10 @@
+/**
+ * Create pairs from array
+ *
+ * @template T
+ * @param {T[]} values array
+ * @returns {T[][]} pairs
+ */
 const pairs = values => {
   const result = [];
 
@@ -11,8 +18,8 @@ const pairs = values => {
 /**
  * Parse svg-like points into number arrays
  *
- * @param {String} points string ex. "20,30 50,60"
- * @return {Array} points array ex. [[20, 30], [50, 60]]
+ * @param {string} points string ex. "20,30 50,60"
+ * @returns {number[][]} points array ex. [[20, 30], [50, 60]]
  */
 const parsePoints = points => {
   let values = (points || '')
@@ -25,9 +32,9 @@ const parsePoints = points => {
     values = values.slice(0, -1);
   }
 
-  values = values.map(parseFloat);
+  const mappedValues = values.map(parseFloat);
 
-  return pairs(values);
+  return pairs(mappedValues);
 };
 
 export default parsePoints;

--- a/packages/renderer/src/dom/usePDF.js
+++ b/packages/renderer/src/dom/usePDF.js
@@ -5,6 +5,12 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 
 import { pdf } from '../index';
 
+/**
+ * PDF hook
+ *
+ * @param {Object} [options] hook options
+ * @returns {[Object, Function]} pdf state and update function
+ */
 export const usePDF = ({ document } = {}) => {
   const pdfInstance = useRef(null);
 

--- a/packages/renderer/src/node/renderTo.js
+++ b/packages/renderer/src/node/renderTo.js
@@ -3,12 +3,21 @@ import { Buffer } from 'buffer';
 
 import { pdf } from '../index';
 
+/**
+ * @param {React.ReactElement} element
+ * @returns {Promise<NodeJS.ReadableStream>}
+ */
 export const renderToStream = async element => {
   const instance = pdf(element);
   const stream = await instance.toBuffer();
   return stream;
 };
 
+/**
+ * @param {React.ReactElement} element
+ * @param {string} filePath
+ * @param {Function} [callback]
+ */
 export const renderToFile = async (element, filePath, callback) => {
   const output = await renderToStream(element);
   const stream = fs.createWriteStream(filePath);
@@ -24,6 +33,10 @@ export const renderToFile = async (element, filePath, callback) => {
   });
 };
 
+/**
+ * @param {React.ReactElement} element
+ * @returns {Promise<Buffer>}
+ */
 export const renderToBuffer = element =>
   renderToStream(element).then(
     stream =>

--- a/packages/renderer/src/utils/propsEqual.js
+++ b/packages/renderer/src/utils/propsEqual.js
@@ -3,9 +3,9 @@
 /**
  * Checks if two sets of props are equal (recursively)
  *
- * @param {Object} props A
- * @param {Object} props B
- * @returns {Boolean} props equals?
+ * @param {Object} a props A
+ * @param {Object} b props B
+ * @returns {boolean} props equals?
  *
  */
 const propsEqual = (a, b) => {

--- a/packages/renderer/tests/node.test.js
+++ b/packages/renderer/tests/node.test.js
@@ -10,6 +10,9 @@ const { Document, Page, View } = ReactPDF;
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
+/**
+ * @param {Object} props
+ */
 const TestDocument = ({ onRender }) => {
   return (
     <Document onRender={onRender}>

--- a/packages/stylesheet/src/expand/boxModel.js
+++ b/packages/stylesheet/src/expand/boxModel.js
@@ -18,6 +18,12 @@ const logError = (style, value) => {
   `);
 };
 
+/**
+ * @param {Object} options
+ * @param {Function} [options.expandsTo]
+ * @param {number} [options.maxValues]
+ * @param {boolean} [options.autoSupported]
+ */
 const expandBoxModel = ({
   expandsTo,
   maxValues = 1,

--- a/packages/stylesheet/src/expand/flex.js
+++ b/packages/stylesheet/src/expand/flex.js
@@ -2,9 +2,15 @@
 
 // TODO: change flex defaults to [0, 1, 'auto'] as in spec in next major release
 const flexDefaults = [1, 1, 0];
+/**
+ * @type {(number | 'auto')[]}
+ */
 const flexAuto = [1, 1, 'auto'];
 
 const expandFlex = (key, value) => {
+  /**
+   * @type {(number | 'auto')[]}
+   */
   let defaults = flexDefaults;
   let matches = [];
   if (value === 'auto') {

--- a/packages/stylesheet/src/expand/index.js
+++ b/packages/stylesheet/src/expand/index.js
@@ -49,9 +49,9 @@ const shorthands = {
 /**
  * Transforms style key-value
  *
- * @param {String} key style key
- * @param {String} value style value
- * @returns {String | Number} transformed style values
+ * @param {string} key style key
+ * @param {string} value style value
+ * @returns {string | Number} transformed style values
  */
 const expandStyle = (key, value) => {
   return shorthands[key] ? shorthands[key](key, value) : { [key]: value };
@@ -60,10 +60,10 @@ const expandStyle = (key, value) => {
 /**
  * Expand the shorthand properties.
  *
- * @param { Object } style object
- * @returns { Object } expanded style object
+ * @param {Object} style object
+ * @returns {Object} expanded style object
  */
-const expand = style => {
+const expand = (style) => {
   if (!style) return style;
 
   const propsArray = Object.keys(style);

--- a/packages/stylesheet/src/flatten/index.js
+++ b/packages/stylesheet/src/flatten/index.js
@@ -3,22 +3,23 @@ import { compose, castArray } from '@react-pdf/fns';
 /**
  * Remove nil values from array
  *
- * @param {Array} array
- * @returns {Array} array without nils
+ * @template T
+ * @param {(T | null | undefined)[]} array
+ * @returns {T[]} array without nils
  */
-const compact = array => array.filter(Boolean);
+const compact = (array) => array.filter(Boolean);
 
 /**
  * Merges style objects array
  *
- * @param {Array} style objects array
+ * @param {Object[]} styles style objects array
  * @returns {Object} merged style object
  */
-const mergeStyles = styles =>
+const mergeStyles = (styles) =>
   styles.reduce((acc, style) => {
     const s = Array.isArray(style) ? flatten(style) : style;
 
-    Object.keys(s).forEach(key => {
+    Object.keys(s).forEach((key) => {
       if (s[key] !== null && s[key] !== undefined) {
         acc[key] = s[key];
       }
@@ -30,8 +31,8 @@ const mergeStyles = styles =>
 /**
  * Flattens an array of style objects, into one aggregated style object.
  *
- * @param {Array} style objects array
- * @returns {Object} flatted style object
+ * @param {Object[]} styles style objects array
+ * @returns {Object} flattened style object
  */
 const flatten = compose(mergeStyles, compact, castArray);
 

--- a/packages/stylesheet/src/transform/colors.js
+++ b/packages/stylesheet/src/transform/colors.js
@@ -7,7 +7,7 @@ const isHsl = value => /hsla?/g.test(value);
 /**
  * Transform rgb color to hexa
  *
- * @param {String} styles value
+ * @param {string} value styles value
  * @returns {Object} transformed value
  */
 const parseRgb = value => {
@@ -18,7 +18,7 @@ const parseRgb = value => {
 /**
  * Transform Hsl color to hexa
  *
- * @param {String} styles value
+ * @param {string} value styles value
  * @returns {Object} transformed value
  */
 const parseHsl = value => {
@@ -31,7 +31,7 @@ const parseHsl = value => {
 /**
  * Transform given color to hexa
  *
- * @param {String} styles value
+ * @param {string} value styles value
  * @returns {Object} transformed value
  */
 const transformColor = value => {

--- a/packages/stylesheet/src/transform/index.js
+++ b/packages/stylesheet/src/transform/index.js
@@ -22,12 +22,18 @@ const transformStyle = (key, value, container) => {
 };
 
 /**
- * Transform styles values
- *
- * @param {Object} styles object
+ * @typedef {Function} Transform
+ * @param {Object} style styles object
  * @returns {Object} transformed styles
  */
-const transform = container => style => {
+
+/**
+ * Transform styles values
+ *
+ * @param {Object} container
+ * @returns {Transform} transform function
+ */
+const transform = (container) => (style) => {
   if (!style) return style;
 
   const propsArray = Object.keys(style);

--- a/packages/stylesheet/src/transform/units.js
+++ b/packages/stylesheet/src/transform/units.js
@@ -1,14 +1,14 @@
 /**
  * Parses scalar value in value and unit pairs
  *
- * @param {String} scalar value
+ * @param {string} value scalar value
  * @returns {Object} parsed value
  */
 const parseValue = value => {
   const match = /^(-?\d*\.?\d+)(in|mm|cm|pt|vh|vw|px)?$/g.exec(value);
 
   return match
-    ? { value: parseFloat(match[1], 10), unit: match[2] || 'pt' }
+    ? { value: parseFloat(match[1]), unit: match[2] || 'pt' }
     : { value, unit: undefined };
 };
 
@@ -16,7 +16,7 @@ const parseValue = value => {
  * Transform given scalar value
  *
  * @param {Object} container
- * @param {String} styles value
+ * @param {string} value styles value
  * @returns {Object} transformed value
  */
 const transformUnit = (container, value) => {

--- a/packages/stylesheet/src/utils/castFloat.js
+++ b/packages/stylesheet/src/utils/castFloat.js
@@ -1,9 +1,9 @@
-const matchNumber = value =>
+const matchNumber = (value) =>
   typeof value === 'string' && /^-?\d*\.?\d*$/.test(value);
 
-const castFloat = value => {
+const castFloat = (value) => {
   if (typeof value !== 'string') return value;
-  if (matchNumber(value)) return parseFloat(value, 10);
+  if (matchNumber(value)) return parseFloat(value);
   return value;
 };
 

--- a/packages/stylesheet/tests/resolve.test.js
+++ b/packages/stylesheet/tests/resolve.test.js
@@ -19,7 +19,7 @@ describe('stylesheet resolve', () => {
     const style = {};
     const result = resolve({}, style);
 
-    expect(result).toEqual({}, {});
+    expect(result).toEqual({});
   });
 
   test('should return identity for single style object', () => {

--- a/packages/svgkit/src/document/index.js
+++ b/packages/svgkit/src/document/index.js
@@ -9,10 +9,22 @@ import serialize from './serialize';
 import { LinearGradient, RadialGradient } from '../gradient';
 
 class SVGDocument {
+  /**
+   * @param {{ font?: Object }} [options]
+   */
   constructor({ font } = {}) {
     this.info = {};
+    /**
+     * @type {Object[]}
+     */
     this.pages = [];
+    /**
+     * @type {Object}
+     */
     this.currentPage = null;
+    /**
+     * @type {Object}
+     */
     this.defaultFont = font;
   }
 
@@ -268,7 +280,7 @@ class SVGDocument {
   }
 
   end() {
-    this.serialized = this.pages.map(page => serialize(page.root)).join('');
+    this.serialized = this.pages.map((page) => serialize(page.root)).join('');
   }
 }
 

--- a/packages/svgkit/src/page/index.js
+++ b/packages/svgkit/src/page/index.js
@@ -76,9 +76,18 @@ class SVGPage {
     const state = this.stack.pop();
     this.applyStyleState(state);
   }
+
+  // eslint-disable-next-line class-methods-use-this
+  setDefaultStyles() {}
+
+  // eslint-disable-next-line class-methods-use-this, no-unused-vars
+  applyStyleState(state) {}
+
+  // eslint-disable-next-line class-methods-use-this
+  getStyleState() {}
 }
 
-const mixin = methods => {
+const mixin = (methods) => {
   return (() => {
     const result = [];
     for (const name in methods) {

--- a/packages/svgkit/src/utils/getPageSize.js
+++ b/packages/svgkit/src/utils/getPageSize.js
@@ -55,53 +55,59 @@ const PAGE_SIZES = {
 /**
  * Transforms array into size object
  *
- * @param {Array} array
- * @returns {Object} size object with width and height
+ * @param {number[]} v array
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const toSizeObject = v => ({ width: v[0], height: v[1] });
+const toSizeObject = (v) => ({ width: v[0], height: v[1] });
 
 /**
  * Flip size object
  *
- * @param {Object} size object
- * @returns {Object} flipped size object
+ * @param {{ width: number, height: number }} v size object
+ * @returns {{ width: number, height: number }} flipped size object
  */
-const flipSizeObject = v => ({ width: v.height, height: v.width });
+const flipSizeObject = (v) => ({ width: v.height, height: v.width });
 
 /**
  * Returns size object from a given string
  *
- * @param {String} page size string
- * @returns {Object} size object with width and height
+ * @param {string} v page size string
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const getStringSize = v => {
+const getStringSize = (v) => {
   return toSizeObject(PAGE_SIZES[v.toUpperCase()]);
 };
 
 /**
  * Returns size object from a single number
  *
- * @param {Number} page size number
- * @returns {Object} size object with width and height
+ * @param {number} n page size number
+ * @returns {{ width: number, height: number }} size object with width and height
  */
-const getNumberSize = n => toSizeObject([n]);
+const getNumberSize = (n) => toSizeObject([n]);
 
 /**
- * // TODO: Move this to separate pacjage to reuse with layout
+ * // TODO: Move this to separate package to reuse with layout
  * Return page size in an object { width, height }
  *
- * @param {Object} page instance
- * @returns {Object} size object with width and height
+ * @param {string | number[] | number | { width: number, height: number }} value page instance
+ * @param {string} orientation page orientation
+ * @returns {{ width: number, height: number }} size object with width and height
  */
 const getSize = (value, orientation) => {
-  let size = value;
+  /**
+   * @type {{ width: number, height: number }}
+   */
+  let size;
 
-  if (typeof size === 'string') {
+  if (typeof value === 'string') {
     size = getStringSize(value);
   } else if (Array.isArray(value)) {
     size = toSizeObject(value);
-  } else if (typeof size === 'number') {
+  } else if (typeof value === 'number') {
     size = getNumberSize(value);
+  } else {
+    size = value;
   }
 
   return orientation === 'landscape' ? flipSizeObject(size) : size;

--- a/packages/textkit/src/attributedString/advanceWidth.js
+++ b/packages/textkit/src/attributedString/advanceWidth.js
@@ -3,12 +3,12 @@ import runAdvanceWidth from '../run/advanceWidth';
 /**
  * Returns attributed string advancewidth
  *
- * @param {Object} attributed string
- * @return {number} advance width
+ * @param {Object} attributedString attributed string
+ * @returns {number} advance width
  */
-const advanceWidth = attributeString => {
+const advanceWidth = attributedString => {
   const reducer = (acc, run) => acc + runAdvanceWidth(run);
-  return attributeString.runs.reduce(reducer, 0);
+  return attributedString.runs.reduce(reducer, 0);
 };
 
 export default advanceWidth;

--- a/packages/textkit/src/attributedString/advanceWidthBetween.js
+++ b/packages/textkit/src/attributedString/advanceWidthBetween.js
@@ -6,10 +6,10 @@ import runAdvanceWidthBetween from '../run/advanceWidthBetween';
  * Does not consider ligature splitting for the moment.
  * Check performance impact on supporting this
  *
- * @param  {number}  start offset
- * @param  {number}  end offset
- * @param  {Object}  attributedString
- * @return {number} advance width
+ * @param {number} start offset
+ * @param {number} end offset
+ * @param {Object} attributedString
+ * @returns {number} advance width
  */
 const advanceWidthBetween = (start, end, attributedString) => {
   const runs = filterRuns(start, end, attributedString.runs);

--- a/packages/textkit/src/attributedString/append.js
+++ b/packages/textkit/src/attributedString/append.js
@@ -8,8 +8,8 @@ import stringFromCodePoints from '../utils/stringFromCodePoints';
  * Append glyph into last run of attributed string
  *
  * @param {Object} glyph
- * @param {Object} attributed string
- * @return {Object} attributed string with new glyph
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string with new glyph
  */
 const append = (glyph, attributedString) => {
   const codePoints = glyph?.codePoints || [];

--- a/packages/textkit/src/attributedString/ascent.js
+++ b/packages/textkit/src/attributedString/ascent.js
@@ -3,12 +3,12 @@ import runAscent from '../run/ascent';
 /**
  * Returns attributed string ascent
  *
- * @param {Object} attributed string
- * @return {number} ascent
+ * @param {Object} attributedString attributed string
+ * @returns {number} ascent
  */
-const ascent = attributeString => {
+const ascent = attributedString => {
   const reducer = (acc, run) => Math.max(acc, runAscent(run));
-  return attributeString.runs.reduce(reducer, 0);
+  return attributedString.runs.reduce(reducer, 0);
 };
 
 export default ascent;

--- a/packages/textkit/src/attributedString/descent.js
+++ b/packages/textkit/src/attributedString/descent.js
@@ -3,12 +3,12 @@ import runDescent from '../run/descent';
 /**
  * Returns attributed string descent
  *
- * @param {Object} attributed string
- * @return {number} descent
+ * @param {Object} attributedString attributed string
+ * @returns {number} descent
  */
-const descent = attributeString => {
+const descent = attributedString => {
   const reducer = (acc, run) => Math.min(acc, runDescent(run));
-  return attributeString.runs.reduce(reducer, 0);
+  return attributedString.runs.reduce(reducer, 0);
 };
 
 export default descent;

--- a/packages/textkit/src/attributedString/dropLast.js
+++ b/packages/textkit/src/attributedString/dropLast.js
@@ -5,14 +5,14 @@ import runDropLast from '../run/dropLast';
 /**
  * Drop last glyph
  *
- * @param {Object} attributed string
- * @return {Object} attributed string with new glyph
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string with new glyph
  */
-const dropLast = attributeString => {
-  const string = arrayDropLast(attributeString.string);
-  const runs = adjust(-1, runDropLast, attributeString.runs);
+const dropLast = attributedString => {
+  const string = arrayDropLast(attributedString.string);
+  const runs = adjust(-1, runDropLast, attributedString.runs);
 
-  return Object.assign({}, attributeString, { string, runs });
+  return Object.assign({}, attributedString, { string, runs });
 };
 
 export default dropLast;

--- a/packages/textkit/src/attributedString/empty.js
+++ b/packages/textkit/src/attributedString/empty.js
@@ -1,7 +1,7 @@
 /**
  * Returns empty attributed string
  *
- * @return {Object} empty attributed string
+ * @returns {Object} empty attributed string
  */
 const empty = () => ({ string: '', runs: [] });
 

--- a/packages/textkit/src/attributedString/end.js
+++ b/packages/textkit/src/attributedString/end.js
@@ -3,8 +3,8 @@ import { last } from '@react-pdf/fns';
 /**
  * Get attributed string end value
  *
- * @param  {Object}  attributed string
- * @return {number} end
+ * @param {Object} attributedString attributed string
+ * @returns {number} end
  */
 const end = attributedString => {
   const { runs } = attributedString;

--- a/packages/textkit/src/attributedString/fromFragments.js
+++ b/packages/textkit/src/attributedString/fromFragments.js
@@ -1,15 +1,15 @@
 /**
  * Create attributed string from text fragments
  *
- * @param  {Array}  fragments
- * @return {Object} attributed string
+ * @param {Object[]} fragments fragments
+ * @returns {Object} attributed string
  */
-const fromFragments = fragments => {
+const fromFragments = (fragments) => {
   let offset = 0;
   let string = '';
   const runs = [];
 
-  fragments.forEach(fragment => {
+  fragments.forEach((fragment) => {
     string += fragment.string;
 
     runs.push({

--- a/packages/textkit/src/attributedString/glyphWidthAt.js
+++ b/packages/textkit/src/attributedString/glyphWidthAt.js
@@ -4,9 +4,9 @@ import glyphIndexAt from '../run/glyphIndexAt';
 /**
  * Get glyph width at string index
  *
- * @param {number} string index
- * @param {Object} attributed string
- * @return {number} glyph width
+ * @param {number} index string index
+ * @param {Object} string attributed string
+ * @returns {number} glyph width
  */
 const glyphWidthAt = (index, string) => {
   const run = runAt(index, string);

--- a/packages/textkit/src/attributedString/height.js
+++ b/packages/textkit/src/attributedString/height.js
@@ -3,12 +3,12 @@ import runHeight from '../run/height';
 /**
  * Returns attributed string height
  *
- * @param {Object} attributed string
- * @return {number} height
+ * @param {Object} attributedString attributed string
+ * @returns {number} height
  */
-const height = attributeString => {
+const height = attributedString => {
   const reducer = (acc, run) => Math.max(acc, runHeight(run));
-  return attributeString.runs.reduce(reducer, 0);
+  return attributedString.runs.reduce(reducer, 0);
 };
 
 export default height;

--- a/packages/textkit/src/attributedString/indexAtOffset.js
+++ b/packages/textkit/src/attributedString/indexAtOffset.js
@@ -5,9 +5,9 @@ import runIndexAtOffset from '../run/indexAtOffset';
 /**
  * Get string index at offset
  *
- * @param  {Object}  attributed string
- * @param  {number}  offset
- * @return {number} string index at offset N
+ * @param {number} offset offset
+ * @param {Object} string attributed string
+ * @returns {number} string index at offset N
  */
 const indexAtOffset = (offset, string) => {
   let index = 0;

--- a/packages/textkit/src/attributedString/insertGlyph.js
+++ b/packages/textkit/src/attributedString/insertGlyph.js
@@ -9,8 +9,8 @@ import stringFromCodePoints from '../utils/stringFromCodePoints';
  *
  * @param {number} index
  * @param {Object} glyph
- * @param {Object} attributed string
- * @return {Object} attributed string with new glyph
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string with new glyph
  */
 const insertGlyph = (index, glyph, attributedString) => {
   const runIndex = runIndexAt(index, attributedString);

--- a/packages/textkit/src/attributedString/leadingOffset.js
+++ b/packages/textkit/src/attributedString/leadingOffset.js
@@ -3,8 +3,8 @@ import runLeadingOffset from '../run/leadingOffset';
 /**
  * Get attributed string leading white space offset
  *
- * @param  {Object}  attributed string
- * @return {number} leading white space offset
+ * @param {Object} attributedString attributed string
+ * @returns {number} leading white space offset
  */
 const leadingOffset = attributedString => {
   const runs = attributedString.runs || [];

--- a/packages/textkit/src/attributedString/length.js
+++ b/packages/textkit/src/attributedString/length.js
@@ -4,8 +4,8 @@ import end from './end';
 /**
  * Get attributed string length
  *
- * @param  {Object}  glyph string
- * @return {number} end
+ * @param {Object} attributedString glyph string
+ * @returns {number} end
  */
 const length = attributedString => {
   return end(attributedString) - start(attributedString);

--- a/packages/textkit/src/attributedString/prepend.js
+++ b/packages/textkit/src/attributedString/prepend.js
@@ -7,8 +7,8 @@ import stringFromCodePoints from '../utils/stringFromCodePoints';
  * prepend glyph into last run of attributed string
  *
  * @param {Object} glyph
- * @param {Object} attributed string
- * @return {Object} attributed string with new glyph
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string with new glyph
  */
 const prepend = (glyph, attributedString) => {
   const codePoints = glyph?.codePoints || [];

--- a/packages/textkit/src/attributedString/runAt.js
+++ b/packages/textkit/src/attributedString/runAt.js
@@ -3,9 +3,9 @@ import runIndexAt from './runIndexAt';
 /**
  * Get run at char index
  *
- * @param  {number}  char index
- * @param  {Object}  attributedString
- * @return {Object} run
+ * @param {number} n char index
+ * @param {Object} attributedString attributed string
+ * @returns {Object} run
  */
 const runAt = (n, attributedString) => {
   const runIndex = runIndexAt(n, attributedString);

--- a/packages/textkit/src/attributedString/runIndexAt.js
+++ b/packages/textkit/src/attributedString/runIndexAt.js
@@ -3,9 +3,9 @@ import runIndexAtInternal from '../run/runIndexAt';
 /**
  * Get run index at char index
  *
- * @param  {number}  char index
- * @param  {Object}  attributedString
- * @return {number} run index
+ * @param {number} n char index
+ * @param {Object} string attributed string
+ * @returns {number} run index
  */
 const runIndexAt = (n, string) => {
   return runIndexAtInternal(n, string.runs);

--- a/packages/textkit/src/attributedString/slice.js
+++ b/packages/textkit/src/attributedString/slice.js
@@ -5,14 +5,14 @@ import subtractRun from '../run/subtract';
 /**
  * Slice array of runs
  *
- * @param  {number}  start offset
- * @param  {number}  end offset
- * @param  {Array}  runs
- * @return {Array} sliced runs
+ * @param {number} start offset
+ * @param {number} end offset
+ * @param {Object[]} runs
+ * @returns {Object[]} sliced runs
  */
 const sliceRuns = (start, end, runs) => {
-  const sliceFirstRun = a => sliceRun(start - a.start, end - a.start, a);
-  const sliceLastRun = a => sliceRun(0, end - a.start, a);
+  const sliceFirstRun = (a) => sliceRun(start - a.start, end - a.start, a);
+  const sliceLastRun = (a) => sliceRun(0, end - a.start, a);
 
   return runs.map((run, i) => {
     let result = run;
@@ -30,10 +30,10 @@ const sliceRuns = (start, end, runs) => {
 /**
  * Slice attributed string between two indices
  *
- * @param  {number}  start offset
- * @param  {number}  end offset
- * @param  {Object}  attributedString
- * @return {Object} attributedString
+ * @param {number} start offset
+ * @param {number} end offset
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributedString
  */
 const slice = (start, end, attributedString) => {
   if (attributedString.string.length === 0) return attributedString;

--- a/packages/textkit/src/attributedString/sliceAtOffset.js
+++ b/packages/textkit/src/attributedString/sliceAtOffset.js
@@ -4,9 +4,9 @@ import indexAtOffset from './indexAtOffset';
 /**
  * Slice attributed string at given offset
  *
- * @param  {number}  offset
- * @param  {Object}  attributedString
- * @return {Object} attributedString
+ * @param {number} offset offset
+ * @param {Object} string attributedString
+ * @returns {Object} attributedString
  */
 const sliceAtOffset = (offset, string) => {
   const index = indexAtOffset(offset, string);

--- a/packages/textkit/src/attributedString/start.js
+++ b/packages/textkit/src/attributedString/start.js
@@ -1,8 +1,8 @@
 /**
  * Get attributed string start value
  *
- * @param  {Object}  attributed string
- * @return {number} start
+ * @param {Object} attributedString attributed string
+ * @returns {number} start
  */
 const start = attributedString => {
   const { runs } = attributedString;

--- a/packages/textkit/src/attributedString/trailingOffset.js
+++ b/packages/textkit/src/attributedString/trailingOffset.js
@@ -5,8 +5,8 @@ import runTrailingOffset from '../run/trailingOffset';
 /**
  * Get attributed string trailing white space offset
  *
- * @param  {Object}  attributed string
- * @return {number} trailing white space offset
+ * @param {Object} attributedString attributed string
+ * @returns {number} trailing white space offset
  */
 const trailingOffset = attributedString => {
   const runs = attributedString.runs || [];

--- a/packages/textkit/src/attributedString/trim.js
+++ b/packages/textkit/src/attributedString/trim.js
@@ -10,8 +10,8 @@ const findLastCharIndex = string => {
 /**
  * Removes (strips) whitespace from both ends of the attributted string.
  *
- * @param  {Object}  attributedString
- * @return {Object} attributedString
+ * @param {Object}  attributedString
+ * @returns {Object} attributedString
  */
 const trim = attributedString => {
   const start = findCharIndex(attributedString.string);

--- a/packages/textkit/src/block/height.js
+++ b/packages/textkit/src/block/height.js
@@ -1,8 +1,8 @@
 /**
  * Get paragraph block height
  *
- * @param  {Object}  paragraph block
- * @return {number} paragraph block height
+ * @param {Object}  paragraph block
+ * @returns {number} paragraph block height
  */
 const height = paragraph => {
   return paragraph.reduce((acc, block) => acc + block.box.height, 0);

--- a/packages/textkit/src/block/sliceAtHeight.js
+++ b/packages/textkit/src/block/sliceAtHeight.js
@@ -1,9 +1,9 @@
 /**
  * Slice block at given height
  *
- * @param  {number}  height
- * @param  {Object}  paragraph block
- * @return {number} sliced paragraph block
+ * @param {number} height height
+ * @param {Object} block paragraph block
+ * @returns {number[]} sliced paragraph block
  */
 const sliceAtHeight = (height, block) => {
   const newBlock = [];

--- a/packages/textkit/src/block/truncate.js
+++ b/packages/textkit/src/block/truncate.js
@@ -9,8 +9,8 @@ const ELLIPSIS_STRING = String.fromCharCode(ELLIPSIS_UNICODE);
 /**
  * Get ellipsis codepoint. This may be different in standard and embedded fonts
  *
- * @param  {number}  font
- * @return {Object} ellipsis codepoint
+ * @param {Object} font
+ * @returns {Object} ellipsis codepoint
  */
 const getEllipsisCodePoint = font => {
   if (!font.encode) return ELLIPSIS_UNICODE;
@@ -23,9 +23,8 @@ const getEllipsisCodePoint = font => {
 /**
  * Trucante block with ellipsis
  *
- * @param  {number}  lines quantity
- * @param  {Object}  paragraph block
- * @return {Object} sliced paragraph block
+ * @param {Object} block paragraph block
+ * @returns {Object} sliced paragraph block
  */
 const truncate = block => {
   const runs = last(block)?.runs || [];

--- a/packages/textkit/src/engines/fontSubstitution/index.js
+++ b/packages/textkit/src/engines/fontSubstitution/index.js
@@ -7,12 +7,16 @@ import empty from '../../attributedString/empty';
 const getFontSize = value => value.attributes.fontSize || 12;
 
 /**
+ * @typedef {Function} FontSubstitution
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string
+ */
+
+/**
  * Resolve font runs in an AttributedString, grouping equal
  * runs and performing font substitution where necessary.
  *
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @return {Object} attributed string
+ * @returns {FontSubstitution} font substitution
  */
 const fontSubstitution = () => attributedString => {
   const { string, runs } = attributedString;

--- a/packages/textkit/src/engines/justification/index.js
+++ b/packages/textkit/src/engines/justification/index.js
@@ -9,7 +9,7 @@ import advanceWidth from '../../attributedString/advanceWidth';
 /**
  * Adjust run positions by given distances
  *
- * @param {Array} distances
+ * @param {number[]} distances
  * @param {Object} line
  * @returns {Object} line
  */
@@ -25,17 +25,22 @@ const justifyLine = (distances, line) => {
 };
 
 /**
+ * @typedef {Function} Justification
+ * @param {Object} line
+ * @returns {Object} line
+ */
+
+/**
  * A JustificationEngine is used by a Typesetter to perform line fragment
  * justification. This implementation is based on a description of Apple's
  * justification algorithm from a PDF in the Apple Font Tools package.
  *
- * //TODO: Make it immutable
+ * // TODO: Make it immutable
  *
- * @param {Object} layout options
- * @param {Object} line
- * @returns {Object} line
+ * @param {Object} options layout options
+ * @returns {Justification} justification engine
  */
-const justification = options => line => {
+const justification = (options) => (line) => {
   const gap = line.box.width - advanceWidth(line);
 
   if (gap === 0) return; // Exact fit

--- a/packages/textkit/src/engines/linebreaker/index.js
+++ b/packages/textkit/src/engines/linebreaker/index.js
@@ -17,10 +17,10 @@ const opts = {
 /**
  * Slice attributed string to many lines
  *
- * @param {Object} attributed string
- * @param  {Array}  nodes
- * @param  {Array}  breaks
- * @return {Array} attributed strings
+ * @param {Object} string attributed string
+ * @param {Object[]} nodes
+ * @param {Object[]} breaks
+ * @returns {Object[]} attributed strings
  */
 const breakLines = (string, nodes, breaks) => {
   let start = 0;
@@ -57,10 +57,10 @@ const breakLines = (string, nodes, breaks) => {
 /**
  * Return Knuth & Plass nodes based on line and previously calculated syllables
  *
- * @param {Object} attributed string
- * @param  {Object}  attributed string
- * @param  {Object}  layout options
- * @return {Array} attributed strings
+ * @param {Object} attributedString attributed string
+ * @param {Object} args attributed string args
+ * @param {Object} options layout options
+ * @returns {Object[]} attributed strings
  */
 const getNodes = (attributedString, { align }, options) => {
   let start = 0;
@@ -105,24 +105,30 @@ const getNodes = (attributedString, { align }, options) => {
   return result;
 };
 
-const getStyles = attributedString =>
+const getStyles = (attributedString) =>
   attributedString.runs?.[0]?.attributes || {};
+
+/**
+ * @typedef {Function} LineBreaker
+ * @param {Object} attributedString attributed string
+ * @param {Object} availableWidths available widths
+ * @returns {Object[]} attributed strings
+ */
 
 /**
  * Performs Knuth & Plass line breaking algorithm
  * Fallbacks to best fit algorithm if latter not successful
  *
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @param {Object} attributed string
- * @return {Array} attributed strings
+ * @param {Object} options layout options
+ * @returns {LineBreaker} line breaker
  */
-const linebreaker = options => (attributedString, availableWidths) => {
+const linebreaker = (options) => (attributedString, availableWidths) => {
   let tolerance = options.tolerance || 4;
 
   const style = getStyles(attributedString);
   const nodes = getNodes(attributedString, style, options);
 
+  /** @type {Object[]} */
   let breaks = linebreak(nodes, availableWidths, { tolerance });
 
   // Try again with a higher tolerance if the line breaking failed.

--- a/packages/textkit/src/engines/linebreaker/linebreak.js
+++ b/packages/textkit/src/engines/linebreaker/linebreak.js
@@ -131,12 +131,18 @@ const linebreak = (nodes, lines, settings) => {
     let next = null;
     let ratio = 0;
     let demerits = 0;
+    /**
+     * @type {Object[]}
+     */
     let candidates = [];
     let badness;
     let currentLine = 0;
     let tmpSum;
     let currentClass = 0;
     let fitnessClass;
+    /**
+     * @type {Object}
+     */
     let candidate;
     let newNode;
 

--- a/packages/textkit/src/engines/linebreaker/linkedList.js
+++ b/packages/textkit/src/engines/linebreaker/linkedList.js
@@ -19,6 +19,7 @@ class LinkedList {
     this.head = null;
     this.tail = null;
     this.listSize = 0;
+    this.listLength = 0;
   }
 
   isLinked(node) {

--- a/packages/textkit/src/engines/scriptItemizer/index.js
+++ b/packages/textkit/src/engines/scriptItemizer/index.js
@@ -5,11 +5,15 @@ import empty from '../../attributedString/empty';
 const ignoredScripts = ['Common', 'Inherited', 'Unknown'];
 
 /**
+ * @typedef {Function} ScriptItemizer
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string
+ */
+
+/**
  * Resolves unicode script in runs, grouping equal runs together
  *
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @return {Object} attributed string
+ * @returns {ScriptItemizer} script itemizer
  */
 const scriptItemizer = () => attributedString => {
   const { string } = attributedString;

--- a/packages/textkit/src/glyph/fromCodePoint.js
+++ b/packages/textkit/src/glyph/fromCodePoint.js
@@ -1,9 +1,9 @@
 /**
  * Get glyph for a given code point
  *
- * @param  {number}  codePoint
- * @param  {Object}  font
- * @return {Object}  glyph
+ * @param {number} [value] codePoint
+ * @param {Object} [font] font
+ * @returns {Object} glyph
  * */
 const fromCodePoint = (value, font) =>
   font && value ? font.glyphForCodePoint(value) : null;

--- a/packages/textkit/src/glyph/isWhiteSpace.js
+++ b/packages/textkit/src/glyph/isWhiteSpace.js
@@ -3,10 +3,10 @@ const WHITE_SPACES_CODE = 32;
 /**
  * Check if glyph is white space
  *
- * @param  {Object}  glyph
- * @return {Boolean}  is white space
+ * @param {Object} glyph
+ * @returns {boolean}  is white space
  * */
-const isWhiteSpace = glyph => {
+const isWhiteSpace = (glyph) => {
   const codePoints = glyph?.codePoints || [];
   return codePoints.includes(WHITE_SPACES_CODE);
 };

--- a/packages/textkit/src/glyph/slice.js
+++ b/packages/textkit/src/glyph/slice.js
@@ -2,11 +2,11 @@
  * Slice glyph between codePoints range
  * Util for breaking ligatures
  *
- * @param  {number}  start code point index
- * @param  {number}  end code point index
- * @param  {Object}  font to generate new glyph
- * @param  {Object} glyph to be sliced
- * @return {Array} sliced glyph parts
+ * @param {number} start code point index
+ * @param {number} end code point index
+ * @param {Object} font to generate new glyph
+ * @param {Object} glyph to be sliced
+ * @returns {Object[]} sliced glyph parts
  */
 const slice = (start, end, font, glyph) => {
   if (!glyph) return [];

--- a/packages/textkit/src/indices/append.js
+++ b/packages/textkit/src/indices/append.js
@@ -5,9 +5,9 @@ import { isNil, last } from '@react-pdf/fns';
  *
  * Ex. appendIndices(3, [0, 1, 2, 2]) => [0, 1, 2, 2, 3, 3, 3]
  *
- * @param  {number}  length
- * @param  {Array}  glyph indices
- * @return {Array}  extended glyph indices
+ * @param {number} length length
+ * @param {number[]} indices glyph indices
+ * @returns {number[]} extended glyph indices
  */
 const appendIndices = (length, indices) => {
   const lastIndex = last(indices);

--- a/packages/textkit/src/indices/normalize.js
+++ b/packages/textkit/src/indices/normalize.js
@@ -1,8 +1,8 @@
 /**
  * Returns new array starting with zero, and keeping same relation between consecutive values
  *
- * @param  {Array[number]}  list
- * @return {boolean} normalized array
+ * @param {number[]} array list
+ * @returns {number[]} normalized array
  */
 const normalize = array => {
   const head = array[0];

--- a/packages/textkit/src/indices/prepend.js
+++ b/packages/textkit/src/indices/prepend.js
@@ -3,15 +3,15 @@
  *
  * Ex. prepend(3, [0, 1, 2, 2]) => [0, 0, 0, 1, 2, 3, 3]
  *
- * @param  {number}  length
- * @param  {Array}  glyph indices
- * @return {Array}  extended glyph indices
+ * @param {number} length length
+ * @param {number[]} indices glyph indices
+ * @returns {number[]}  extended glyph indices
  */
 const prepend = (length, indices) => {
   if (length === 0) return indices;
 
   const newIndices = Array(length).fill(0);
-  const lastIndices = indices.map(value => value + 1);
+  const lastIndices = indices.map((value) => value + 1);
 
   return newIndices.concat(lastIndices);
 };

--- a/packages/textkit/src/indices/resolve.js
+++ b/packages/textkit/src/indices/resolve.js
@@ -1,10 +1,10 @@
-const DUMMY_CODEPOINT = 123
+const DUMMY_CODEPOINT = 123;
 
 /**
  * Resolve string indices based on glyphs code points
  *
- * @param  {Array}  glyphs
- * @return {Array} glyph indices
+ * @param {Object[]} glyphs
+ * @returns {number[]} glyph indices
  */
 const resolve = (glyphs = []) => {
   return glyphs.reduce((acc, glyph) => {
@@ -15,7 +15,7 @@ const resolve = (glyphs = []) => {
     const last = acc[acc.length - 1];
     const next = codePoints.map(() => last + 1);
 
-    return [...acc, ...next]
+    return [...acc, ...next];
   }, []);
 };
 

--- a/packages/textkit/src/layout/applyDefaultStyles.js
+++ b/packages/textkit/src/layout/applyDefaultStyles.js
@@ -1,3 +1,7 @@
+/**
+ * @param {Object} a attributes
+ * @returns {Object} attributes with defaults
+ */
 const applyAttributes = a => ({
   align: a.align || 'left',
   alignLastLine:
@@ -41,8 +45,8 @@ const applyAttributes = a => ({
 /**
  * Apply default style to run
  *
- * @param  {Object}  run
- * @return {Object} run with styles
+ * @param {Object} run run
+ * @returns {Object} run with styles
  */
 const applyRunStyles = run => {
   const attributes = applyAttributes(run.attributes);
@@ -50,12 +54,15 @@ const applyRunStyles = run => {
 };
 
 /**
+ * @typedef {Function} ApplyDefaultStyles
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string
+ */
+
+/**
  * Apply default attributes for an attributed string
  *
- * @param  {Object}  engines
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @return {Object} attributed string
+ * @returns {ApplyDefaultStyles} applyDefaultStyles
  */
 const applyDefaultStyles = () => attributedString => {
   const string = attributedString.string || '';

--- a/packages/textkit/src/layout/generateGlyphs.js
+++ b/packages/textkit/src/layout/generateGlyphs.js
@@ -1,14 +1,14 @@
 import scale from '../run/scale';
 import resolveGlyphIndices from '../indices/resolve';
 
-const getCharacterSpacing = run => run.attributes?.characterSpacing || 0;
+const getCharacterSpacing = (run) => run.attributes?.characterSpacing || 0;
 
 /**
  * Scale run positions
  *
- * @param  {Object}  run
- * @param  {Array}  positions
- * @return {Array} scaled positions
+ * @param {Object} run
+ * @param {Object[]} positions
+ * @returns {Object[]} scaled positions
  */
 const scalePositions = (run, positions) => {
   const runScale = scale(run);
@@ -28,13 +28,18 @@ const scalePositions = (run, positions) => {
 };
 
 /**
+ * @typedef {Function} LayoutRun
+ * @param {Object} run run
+ * @returns {Object} glyph run
+ */
+
+/**
  * Create glyph run
  *
- * @param  {String}  string
- * @param  {Object}  run
- * @return {Object}  glyph run
+ * @param {string} string string
+ * @returns {LayoutRun} layout run
  */
-const layoutRun = string => run => {
+const layoutRun = (string) => (run) => {
   const { start, end, attributes = {} } = run;
   const { font } = attributes;
 
@@ -54,14 +59,17 @@ const layoutRun = string => run => {
 };
 
 /**
+ * @typedef {Function} GenerateGlyphs
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string with glyphs
+ */
+
+/**
  * Generate glyphs for single attributed string
  *
- * @param  {Object}  layout engines
- * @param  {Object}  layout options
- * @param  {Array}  attributed strings
- * @return {Array} attributed string with glyphs
+ * @returns {GenerateGlyphs} generate glyphs
  */
-const generateGlyphs = () => attributedString => {
+const generateGlyphs = () => (attributedString) => {
   const runs = attributedString.runs.map(layoutRun(attributedString.string));
   return Object.assign({}, attributedString, { runs });
 };

--- a/packages/textkit/src/layout/index.js
+++ b/packages/textkit/src/layout/index.js
@@ -12,24 +12,29 @@ import applyDefaultStyles from './applyDefaultStyles';
 import verticalAlignment from './verticalAlign';
 
 /**
+ * @typedef {Function} LayoutEngine
+ * @param {Object} attributedString attributed string
+ * @param {Object} container container rect
+ * @param {Object} options layout options
+ * @returns {Object[]} paragraph blocks
+ */
+
+/**
  * A LayoutEngine is the main object that performs text layout.
  * It accepts an AttributedString and a Container object
  * to layout text into, and uses several helper objects to perform
  * various layout tasks. These objects can be overridden to customize
  * layout behavior.
  *
- * @param  {Object}  engines
- * @param  {Object}  attributed string
- * @param  {Object}  container rect
- * @param  {Object}  layout options
- * @return {Array} paragraph blocks
+ * @param {Object} engines engines
+ * @returns {LayoutEngine} layout engine
  */
 const layoutEngine = engines => (attributedString, container, options = {}) => {
   const processParagraph = compose(
-    resolveYOffset(engines, options),
-    resolveAttachments(engines, options),
-    generateGlyphs(engines, options),
-    verticalAlignment(options),
+    resolveYOffset(),
+    resolveAttachments(),
+    generateGlyphs(),
+    verticalAlignment(),
     wrapWords(engines, options),
   );
 
@@ -39,9 +44,9 @@ const layoutEngine = engines => (attributedString, container, options = {}) => {
     finalizeFragments(engines, options),
     typesetter(engines, options, container),
     processParagraphs,
-    splitParagraphs(engines, options),
+    splitParagraphs(),
     preprocessRuns(engines, options),
-    applyDefaultStyles(engines, options),
+    applyDefaultStyles(),
   )(attributedString);
 };
 

--- a/packages/textkit/src/layout/layoutParagraph.js
+++ b/packages/textkit/src/layout/layoutParagraph.js
@@ -7,15 +7,15 @@ const ATTACHMENT_CODE = '\ufffc'; // 65532
 /**
  * Remove attachment attribute if no char present
  *
- * @param  {Object} attributed string
- * @return {Object} attributed string
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string
  */
-const purgeAttachments = attributedString => {
+const purgeAttachments = (attributedString) => {
   const shouldPurge = !attributedString.string.includes(ATTACHMENT_CODE);
 
   if (!shouldPurge) return attributedString;
 
-  const runs = attributedString.runs.map(run => omit('attachment', run));
+  const runs = attributedString.runs.map((run) => omit('attachment', run));
 
   return Object.assign({}, attributedString, { runs });
 };
@@ -23,9 +23,10 @@ const purgeAttachments = attributedString => {
 /**
  * Layout paragraphs inside rectangle
  *
- * @param  {Object} rect
- * @param  {Array} attributed strings
- * @return {Object} layout blocks
+ * @param {Object} rects rect
+ * @param {Object[]} lines attributed strings
+ * @param {number} indent
+ * @returns {Object} layout blocks
  */
 const layoutLines = (rects, lines, indent) => {
   let rect = rects.shift();
@@ -59,20 +60,25 @@ const layoutLines = (rects, lines, indent) => {
 };
 
 /**
+ * @typedef {Function} LayoutParagraph
+ * @param {Object} container rect
+ * @param {Object} paragraph attributed string
+ * @returns {Object} layout block
+ */
+
+/**
  * Performs line breaking and layout
  *
- * @param  {Object} engines
- * @param  {Object}  layout options
- * @param  {Object} rect
- * @param  {Object} attributed string
- * @return {Object} layout block
+ * @param {Object} engines engines
+ * @param {Object} options layout options
+ * @returns {LayoutParagraph} layout paragraph
  */
 const layoutParagraph = (engines, options) => (container, paragraph) => {
   const height = stringHeight(paragraph);
   const indent = paragraph.runs?.[0]?.attributes?.indent || 0;
   const rects = generateLineRects(container, height);
 
-  const availableWidths = rects.map(r => r.width);
+  const availableWidths = rects.map((r) => r.width);
   availableWidths[0] -= indent;
 
   const lines = engines.linebreaker(options)(paragraph, availableWidths);

--- a/packages/textkit/src/layout/preprocessRuns.js
+++ b/packages/textkit/src/layout/preprocessRuns.js
@@ -10,12 +10,17 @@ const omitFont = attributedString => {
 };
 
 /**
+ * @typedef {Function} PreprocessRuns
+ * @param {Object} attributedString attributed string
+ * @returns {Object} processed attributed string
+ */
+
+/**
  * Performs font substitution and script itemization on attributed string
  *
- * @param  {Object}  engines
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @return {Object} processed attributed string
+ * @param {Object} engines engines
+ * @param {Object} options layout options
+ * @returns {PreprocessRuns} preprocess runs
  */
 const preprocessRuns = (engines, options) => attributedString => {
   if (isNil(attributedString)) return empty();

--- a/packages/textkit/src/layout/resolveAttachments.js
+++ b/packages/textkit/src/layout/resolveAttachments.js
@@ -5,8 +5,8 @@ const isReplaceGlyph = glyph => glyph.codePoints.includes(ATTACHMENT_CODE);
 /**
  * Resolve attachments of run
  *
- * @param  {Object}  run
- * @return {Object} run
+ * @param {Object}  run
+ * @returns {Object} run
  */
 const resolveRunAttachments = run => {
   if (!run.positions) return run;
@@ -28,12 +28,15 @@ const resolveRunAttachments = run => {
 };
 
 /**
+ * @typedef {Function} AttachmentResolver
+ * @param {string} attributedString attributed string
+ * @returns {string} attributed string
+ */
+
+/**
  * Resolve attachments for multiple paragraphs
  *
- * @param  {Object} layout engines
- * @param  {Object}  layout options
- * @param  {Array}  attributed strings (paragraphs)
- * @return {Array} attributed strings (paragraphs)
+ * @returns {AttachmentResolver} attachmentResolver
  */
 const resolveAttachments = () => attributedString => {
   const runs = attributedString.runs.map(resolveRunAttachments);

--- a/packages/textkit/src/layout/resolveYOffset.js
+++ b/packages/textkit/src/layout/resolveYOffset.js
@@ -1,8 +1,8 @@
 /**
  * Resolves yOffset for run
  *
- * @param  {Object}  run
- * @return {Object} run
+ * @param {Object}  run
+ * @returns {Object} run
  */
 const resolveRunYOffset = run => {
   if (!run.positions) return run;
@@ -15,12 +15,15 @@ const resolveRunYOffset = run => {
 };
 
 /**
+ * @typedef {Function} YOffsetResolver
+ * @param {string} attributedString attributed string
+ * @returns {string} attributed string
+ */
+
+/**
  * Resolves yOffset for multiple paragraphs
  *
- * @param  {Object} layout engines
- * @param  {Object}  layout options
- * @param  {Array}  attributed strings (paragraphs)
- * @return {Array} attributed strings (paragraphs)
+ * @returns {YOffsetResolver} yOffsetResolver
  */
 const resolveYOffset = () => attributedString => {
   const runs = attributedString.runs.map(resolveRunYOffset);

--- a/packages/textkit/src/layout/splitParagraphs.js
+++ b/packages/textkit/src/layout/splitParagraphs.js
@@ -2,14 +2,17 @@ import length from '../attributedString/length';
 import slice from '../attributedString/slice';
 
 /**
+ * @typedef {Function} SplitParagraphs
+ * @param {Object} attributedString attributed string
+ * @returns {Object[]} attributed string array
+ */
+
+/**
  * Breaks attributed string into paragraphs
  *
- * @param  {Object}  engines
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @return {Array} attributed string array
+ * @returns {SplitParagraphs} split paragraphs
  */
-const splitParagraphs = () => attributedString => {
+const splitParagraphs = () => (attributedString) => {
   const res = [];
 
   let start = 0;

--- a/packages/textkit/src/layout/typesetter.js
+++ b/packages/textkit/src/layout/typesetter.js
@@ -8,16 +8,21 @@ import layoutParagraph from './layoutParagraph';
 import sliceBlockAtHeight from '../block/sliceAtHeight';
 
 /**
+ * @typedef {Function} TypeSetter
+ * @param {Object} attributedStrings attributed strings (paragraphs)
+ * @returns {Object[]} paragraph blocks
+ */
+
+/**
  * Layout paragraphs inside container until it does not
  * fit anymore, performing line wrapping in the process.
  *
- * @param  {Object}  engines
- * @param  {Object}  layout options
- * @param  {Object}  container rect
- * @param  {Object}  attributed strings (paragraphs)
- * @return {Array} paragraph blocks
+ * @param {Object} engines engines
+ * @param {Object} options layout options
+ * @param {Object} container container rect
+ * @returns {TypeSetter} type setter
  */
-const typesetter = (engines, options, container) => attributedStrings => {
+const typesetter = (engines, options, container) => (attributedStrings) => {
   const blocks = [];
   const paragraphs = [...attributedStrings];
   const layoutBlock = layoutParagraph(engines, options);

--- a/packages/textkit/src/layout/verticalAlign.js
+++ b/packages/textkit/src/layout/verticalAlign.js
@@ -1,11 +1,15 @@
 /* eslint-disable no-restricted-syntax */
 
 /**
+ * @typedef {Function} VerticalAlignment
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string
+ */
+
+/**
  * Apply scaling and yOffset for verticalAlign 'sub' and 'super'.
  *
- * @param  {Object} layout options
- * @param  {Object} attributed string
- * @return {Object} attributed string
+ * @returns {VerticalAlignment} verticalAlignment
  */
 const verticalAlignment = () => attributedString => {
   attributedString.runs.forEach(run => {

--- a/packages/textkit/src/layout/wrapWords.js
+++ b/packages/textkit/src/layout/wrapWords.js
@@ -4,48 +4,55 @@ import fromFragments from '../attributedString/fromFragments';
  * Default word hyphenation engine used when no one provided.
  * Does not perform word hyphenation at all
  *
- * @param  {String} word
- * @return {Array} same word
+ * @param {string} word
+ * @returns {[string]} same word
  */
-const defaultHyphenationEngine = word => [word];
+const defaultHyphenationEngine = (word) => [word];
+
+/**
+ * @typedef {Function} HyphenationCallback
+ * @param {Object} attributedString attributed string
+ * @returns {Object} attributed string including syllables
+ */
 
 /**
  * Wrap words of attribute string
  *
- * @param  {Object} layout engines
- * @param  {Object}  layout options
- * @param  {Object}  attributed string
- * @return {Object} attributed string including syllables
+ * @param {Object} engines layout engines
+ * @param {Object} options layout options
+ * @returns {HyphenationCallback} hyphenation callback
  */
-const wrapWords = (engines = {}, options = {}) => attributedString => {
-  const syllables = [];
-  const fragments = [];
+const wrapWords =
+  (engines = {}, options = {}) =>
+  (attributedString) => {
+    const syllables = [];
+    const fragments = [];
 
-  const hyphenateWord =
-    options.hyphenationCallback ||
-    engines.wordHyphenation?.(options) ||
-    defaultHyphenationEngine;
+    const hyphenateWord =
+      options.hyphenationCallback ||
+      engines.wordHyphenation?.(options) ||
+      defaultHyphenationEngine;
 
-  for (let i = 0; i < attributedString.runs.length; i += 1) {
-    let string = '';
-    const run = attributedString.runs[i];
-    const words = attributedString.string
-      .slice(run.start, run.end)
-      .split(/([ ]+)/g)
-      .filter(Boolean);
+    for (let i = 0; i < attributedString.runs.length; i += 1) {
+      let string = '';
+      const run = attributedString.runs[i];
+      const words = attributedString.string
+        .slice(run.start, run.end)
+        .split(/([ ]+)/g)
+        .filter(Boolean);
 
-    for (let j = 0; j < words.length; j += 1) {
-      const word = words[j];
-      const parts = hyphenateWord(word);
+      for (let j = 0; j < words.length; j += 1) {
+        const word = words[j];
+        const parts = hyphenateWord(word);
 
-      syllables.push(...parts);
-      string += parts.join('');
+        syllables.push(...parts);
+        string += parts.join('');
+      }
+
+      fragments.push({ string, attributes: run.attributes });
     }
 
-    fragments.push({ string, attributes: run.attributes });
-  }
-
-  return { ...fromFragments(fragments), syllables };
-};
+    return { ...fromFragments(fragments), syllables };
+  };
 
 export default wrapWords;

--- a/packages/textkit/src/positions/advanceWidth.js
+++ b/packages/textkit/src/positions/advanceWidth.js
@@ -1,8 +1,8 @@
 /**
  * Return positions advance width
  *
- * @param  {Object}  positions
- * @return {number} advance width
+ * @param {Object}  positions
+ * @returns {number} advance width
  */
 const advanceWidth = positions => {
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);

--- a/packages/textkit/src/rect/area.js
+++ b/packages/textkit/src/rect/area.js
@@ -1,8 +1,8 @@
 /**
  * Returns rect area
  *
- * @param  {Object}  rect
- * @return {number} rect area
+ * @param {Object}  rect
+ * @returns {number} rect area
  */
 const area = rect => {
   return rect ? rect.height * rect.width : 0;

--- a/packages/textkit/src/rect/bottomLeft.js
+++ b/packages/textkit/src/rect/bottomLeft.js
@@ -5,8 +5,8 @@ const ZERO = { x: 0, y: 0 };
 /**
  * Returns rect bottom left point
  *
- * @param  {Object}  rect
- * @return {number} bottom left point
+ * @param {Object} rect rect
+ * @returns {{ x: number, y: number }} bottom left point
  */
 const bottomLeft = rect => {
   return rect ? { x: rect.x || 0, y: maxY(rect) } : ZERO;

--- a/packages/textkit/src/rect/bottomRight.js
+++ b/packages/textkit/src/rect/bottomRight.js
@@ -4,8 +4,8 @@ import maxY from './maxY';
 /**
  * Returns rect bottom right point
  *
- * @param  {Object}  rect
- * @return {number} bottom right point
+ * @param {Object} rect rect
+ * @returns {{ x:number, y:number }} bottom right point
  */
 const bottomRight = rect => ({ x: maxX(rect), y: maxY(rect) });
 

--- a/packages/textkit/src/rect/copy.js
+++ b/packages/textkit/src/rect/copy.js
@@ -1,8 +1,8 @@
 /**
  * Clone rect
  *
- * @param  {Object}  rect
- * @return {Object} cloned rect
+ * @param {Object}  rect
+ * @returns {Object} cloned rect
  */
 const copy = rect => Object.assign({}, rect);
 

--- a/packages/textkit/src/rect/crop.js
+++ b/packages/textkit/src/rect/crop.js
@@ -3,8 +3,8 @@ import partition from './partition';
 /**
  * Crop upper section of rect
  *
- * @param  {Object}  rect
- * @return {Object} cropped rect
+ * @param {Object}  rect
+ * @returns {Object} cropped rect
  */
 const crop = (height, rect) => {
   const [, result] = partition(rect, height);

--- a/packages/textkit/src/rect/empty.js
+++ b/packages/textkit/src/rect/empty.js
@@ -1,7 +1,7 @@
 /**
  * Returns empty rect
  *
- * @return {Object} empty rect
+ * @returns {Object} empty rect
  */
 const empty = () => ({
   x: 0,

--- a/packages/textkit/src/rect/equals.js
+++ b/packages/textkit/src/rect/equals.js
@@ -1,9 +1,9 @@
 /**
  * Check if two rect are equal
  *
- * @param  {Object}  rect A
- * @param  {Object}  rect B
- * @return {Boolean} rects are equal
+ * @param {Object} a rect A
+ * @param {Object} b rect B
+ * @returns {boolean} rects are equal
  *
  */
 const equals = (a, b) => {

--- a/packages/textkit/src/rect/intersects.js
+++ b/packages/textkit/src/rect/intersects.js
@@ -1,9 +1,17 @@
 /**
+ * @typedef {Object} Rect
+ * @property {number} x
+ * @property {number} y
+ * @property {number} width
+ * @property {number} height
+ */
+
+/**
  * Checks if two rects intersect each other
  *
  * @param {Rect} a
  * @param {Rect} b
- * @returns {Boolean} rects intersects
+ * @returns {boolean} rects intersects
  */
 const intersects = (a, b) => {
   const x = Math.max(a.x, b.x);

--- a/packages/textkit/src/rect/maxX.js
+++ b/packages/textkit/src/rect/maxX.js
@@ -1,8 +1,8 @@
 /**
  * Returns max rect X coordinate
  *
- * @param  {Object}  rect
- * @return {number} x coordinate
+ * @param {Object}  rect
+ * @returns {number} x coordinate
  */
 const maxX = rect => {
   return rect ? rect.x + rect.width : 0;

--- a/packages/textkit/src/rect/maxY.js
+++ b/packages/textkit/src/rect/maxY.js
@@ -1,8 +1,8 @@
 /**
  * Returns max rect Y coordinate
  *
- * @param  {Object}  rect
- * @return {number} y coordinate
+ * @param {Object}  rect
+ * @returns {number} y coordinate
  */
 const maxY = rect => {
   return rect ? rect.y + rect.height : 0;

--- a/packages/textkit/src/run/add.js
+++ b/packages/textkit/src/run/add.js
@@ -1,9 +1,9 @@
 /**
  * Add scalar to run
  *
- * @param  {number}  scalar
- * @param  {Object}  run
- * @return {Object} added run
+ * @param {number} n scalar
+ * @param {Object} run run
+ * @returns {Object} added run
  */
 const add = (n, run) => {
   const start = run.start + n;

--- a/packages/textkit/src/run/advanceWidth.js
+++ b/packages/textkit/src/run/advanceWidth.js
@@ -3,8 +3,8 @@ import positionsAdvanceWidth from '../positions/advanceWidth';
 /**
  * Return run advance width
  *
- * @param  {Object}  run
- * @return {number} advance width
+ * @param {Object}  run
+ * @returns {number} advance width
  */
 const advanceWidth = run => {
   return positionsAdvanceWidth(run.positions || []);

--- a/packages/textkit/src/run/advanceWidthBetween.js
+++ b/packages/textkit/src/run/advanceWidthBetween.js
@@ -4,10 +4,10 @@ import positionsAdvanceWidth from '../positions/advanceWidth';
 /**
  * Advance width between two string indices
  *
- * @param  {number}  start glyph index
- * @param  {number}  end glyph index
- * @param  {Object}  run
- * @return {Object} advanced width run
+ * @param {number}  start glyph index
+ * @param {number}  end glyph index
+ * @param {Object}  run
+ * @returns {Object} advanced width run
  */
 const advanceWidthBetween = (start, end, run) => {
   const runStart = run.start || 0;

--- a/packages/textkit/src/run/append.js
+++ b/packages/textkit/src/run/append.js
@@ -7,9 +7,9 @@ import glyphFromCodePoint from '../glyph/fromCodePoint';
 /**
  * Append glyph to run
  *
- * @param  {Object}  glyph
- * @param  {Object}  run
- * @return {Object} run with glyph
+ * @param {Object}  glyph
+ * @param {Object}  run
+ * @returns {Object} run with glyph
  */
 const appendGlyph = (glyph, run) => {
   const glyphLength = glyph.codePoints?.length || 0;
@@ -30,9 +30,9 @@ const appendGlyph = (glyph, run) => {
 /**
  * Append glyph or code point to run
  *
- * @param  {Object | number}  glyph | codePoint
- * @param  {Object}  run
- * @return {Object} run with glyph
+ * @param {Object | number} value glyph | codePoint
+ * @param {Object} run
+ * @returns {Object} run with glyph
  */
 const append = (value, run) => {
   if (!value) return run;

--- a/packages/textkit/src/run/ascent.js
+++ b/packages/textkit/src/run/ascent.js
@@ -3,8 +3,8 @@ import scale from './scale';
 /**
  * Get run ascent
  *
- * @param  {Object}  run
- * @return {boolean} ascent
+ * @param {Object} run
+ * @returns {number} ascent
  */
 const ascent = run => {
   const attachmentHeight = run.attributes?.attachment?.height || 0;

--- a/packages/textkit/src/run/concat.js
+++ b/packages/textkit/src/run/concat.js
@@ -6,9 +6,9 @@ import normalizeIndices from '../indices/normalize';
 /**
  * Concats two runs into one
  *
- * @param  {Object}  first run
- * @param  {Object}  second run
- * @return {Object}  concatenated run
+ * @param {Object} runA first run
+ * @param {Object} runB second run
+ * @returns {Object} concatenated run
  */
 const concat = (runA, runB) => {
   const end = runA.end + length(runB);

--- a/packages/textkit/src/run/descent.js
+++ b/packages/textkit/src/run/descent.js
@@ -3,8 +3,8 @@ import scale from './scale';
 /**
  * Get run descent
  *
- * @param  {Object}  run
- * @return {number} descent
+ * @param {Object}  run
+ * @returns {number} descent
  */
 const descent = run => {
   const fontDescent = run.attributes?.font?.descent || 0;

--- a/packages/textkit/src/run/dropLast.js
+++ b/packages/textkit/src/run/dropLast.js
@@ -3,8 +3,8 @@ import slice from './slice';
 /**
  * Drop last char of run
  *
- * @param  {Object}  run
- * @return {boolean} run without last char
+ * @param {Object} run
+ * @returns {Object} run without last char
  */
 const dropLast = run => slice(0, run.end - run.start - 1, run);
 

--- a/packages/textkit/src/run/empty.js
+++ b/packages/textkit/src/run/empty.js
@@ -1,7 +1,7 @@
 /**
  * Returns empty run
  *
- * @return {Object} empty run
+ * @returns {Object} empty run
  */
 const empty = () => ({
   start: 0,

--- a/packages/textkit/src/run/filter.js
+++ b/packages/textkit/src/run/filter.js
@@ -3,10 +3,10 @@ import runIndexAt from './runIndexAt';
 /**
  * Filter runs contained between start and end
  *
- * @param  {number}  start
- * @param  {number}  end
- * @param  {Array}  runs
- * @return {boolean} filtered runs
+ * @param {number}  start
+ * @param {number}  end
+ * @param {Object[]}   runs
+ * @returns {Object} filtered runs
  */
 const filter = (start, end, runs) => {
   const startIndex = runIndexAt(start, runs);

--- a/packages/textkit/src/run/flatten.js
+++ b/packages/textkit/src/run/flatten.js
@@ -3,7 +3,7 @@ import isEmpty from './isEmpty';
 
 const sortPoints = (a, b) => a[1] - b[1] || a[3] - b[3];
 
-const generatePoints = runs => {
+const generatePoints = (runs) => {
   const result = runs.reduce((acc, run, i) => {
     return acc.concat([
       ['start', run.start, run.attributes, i],
@@ -14,13 +14,13 @@ const generatePoints = runs => {
   return result.sort(sortPoints);
 };
 
-const mergeRuns = runs =>
+const mergeRuns = (runs) =>
   runs.reduce((acc, run) => {
     const attributes = Object.assign({}, acc.attributes, run.attributes);
     return Object.assign({}, run, { attributes });
   }, {});
 
-const groupEmptyRuns = runs => {
+const groupEmptyRuns = (runs) => {
   const groups = runs.reduce((acc, run) => {
     if (!acc[run.start]) acc[run.start] = [];
     acc[run.start].push(run);
@@ -30,11 +30,11 @@ const groupEmptyRuns = runs => {
   return Object.values(groups);
 };
 
-const flattenEmptyRuns = runs => {
+const flattenEmptyRuns = (runs) => {
   return groupEmptyRuns(runs).map(mergeRuns);
 };
 
-const flattenRegularRuns = runs => {
+const flattenRegularRuns = (runs) => {
   const res = [];
   const points = generatePoints(runs);
 
@@ -74,12 +74,12 @@ const flattenRegularRuns = runs => {
 /**
  * Flatten many runs
  *
- * @param  {Array}  runs
- * @return {Array} flatten runs
+ * @param {Object[]} runs
+ * @returns {Object[]} flatten runs
  */
 const flatten = (runs = []) => {
-  const emptyRuns = flattenEmptyRuns(runs.filter(run => isEmpty(run)));
-  const regularRuns = flattenRegularRuns(runs.filter(run => !isEmpty(run)));
+  const emptyRuns = flattenEmptyRuns(runs.filter((run) => isEmpty(run)));
+  const regularRuns = flattenRegularRuns(runs.filter((run) => !isEmpty(run)));
 
   return sort(emptyRuns.concat(regularRuns));
 };

--- a/packages/textkit/src/run/getFont.js
+++ b/packages/textkit/src/run/getFont.js
@@ -1,8 +1,8 @@
 /**
  * Get run font
  *
- * @param  {Object}  run
- * @return {Object} font
+ * @param {Object}  run
+ * @returns {Object} font
  */
 const getFont = run => run.attributes?.font || null;
 

--- a/packages/textkit/src/run/glyphIndexAt.js
+++ b/packages/textkit/src/run/glyphIndexAt.js
@@ -4,9 +4,9 @@ import { isNil } from '@react-pdf/fns';
  * Return glyph index at string index, if glyph indices present.
  * Otherwise return string index
  *
- * @param  {number}  string index
- * @param  {Object}  run
- * @return {number}  glyph index
+ * @param {number}  index index
+ * @param {Object}  run
+ * @returns {number}  glyph index
  */
 const glyphIndexAt = (index, run) => {
   const result = run?.glyphIndices?.[index];

--- a/packages/textkit/src/run/height.js
+++ b/packages/textkit/src/run/height.js
@@ -5,8 +5,8 @@ import lineGap from './lineGap';
 /**
  * Get run height
  *
- * @param  {Object}  run
- * @return {number} height
+ * @param {Object} run
+ * @returns {number} height
  */
 const height = run => {
   const lineHeight = run.attributes?.lineHeight;

--- a/packages/textkit/src/run/indexAtOffset.js
+++ b/packages/textkit/src/run/indexAtOffset.js
@@ -1,9 +1,9 @@
 /**
  * Get string index at offset
  *
- * @param  {Object}  run
- * @param  {number}  offset
- * @return {number} string index at offset N
+ * @param {number} offset
+ * @param {Object} run
+ * @returns {number} string index at offset N
  */
 const indexAtOffset = (offset, run) => {
   let counter = 0;

--- a/packages/textkit/src/run/insert.js
+++ b/packages/textkit/src/run/insert.js
@@ -8,10 +8,10 @@ import glyphFromCodePoint from '../glyph/fromCodePoint';
 /**
  * Insert glyph to run in the given index
  *
- * @param  {number}  string index
- * @param  {Object}  glyph
- * @param  {Object}  run
- * @return {Object}  run with glyph
+ * @param {number} index index
+ * @param {Object} glyph
+ * @param {Object} run
+ * @returns {Object} run with glyph
  */
 const insertGlyph = (index, glyph, run) => {
   if (!glyph) return run;
@@ -26,10 +26,10 @@ const insertGlyph = (index, glyph, run) => {
 /**
  * Insert either glyph or code point to run in the given index
  *
- * @param  {number}  string index
- * @param  {Object | number}  glyph | codePoint
- * @param  {Object}  run
- * @return {Object}  run with glyph
+ * @param {number} index index
+ * @param {Object | number} value glyph | codePoint
+ * @param {Object} run
+ * @returns {Object} run with glyph
  */
 const insert = (index, value, run) => {
   const font = getFont(run);

--- a/packages/textkit/src/run/isEmpty.js
+++ b/packages/textkit/src/run/isEmpty.js
@@ -1,8 +1,8 @@
 /**
  * Is run empty (start === end)
  *
- * @param  {Object}  run
- * @return {Object} is run empty
+ * @param {Object}  run
+ * @returns {Object} is run empty
  */
 const isEmpty = run => {
   return run.start === run.end;

--- a/packages/textkit/src/run/leadingOffset.js
+++ b/packages/textkit/src/run/leadingOffset.js
@@ -3,13 +3,13 @@ import isWhiteSpace from '../glyph/isWhiteSpace';
 /**
  * Get white space leading positions
  *
- * @param  {Object}  run
- * @return {Array} white space leading positions
+ * @param {Object} run
+ * @returns {Object[]} white space leading positions
  */
-const leadingPositions = run => {
+const leadingPositions = (run) => {
   const glyphs = run.glyphs || [];
   const positions = run.positions || [];
-  const leadingWhitespaces = glyphs.findIndex(g => !isWhiteSpace(g));
+  const leadingWhitespaces = glyphs.findIndex((g) => !isWhiteSpace(g));
 
   return positions.slice(0, leadingWhitespaces);
 };
@@ -17,10 +17,10 @@ const leadingPositions = run => {
 /**
  * Get run leading white space offset
  *
- * @param  {Object}  run
- * @return {number} leading white space offset
+ * @param {Object}  run
+ * @returns {number} leading white space offset
  */
-const leadingOffset = run => {
+const leadingOffset = (run) => {
   const positions = leadingPositions(run);
 
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);

--- a/packages/textkit/src/run/length.js
+++ b/packages/textkit/src/run/length.js
@@ -1,8 +1,8 @@
 /**
  * Get run length
  *
- * @param  {Object}  run
- * @return {number} length
+ * @param {Object}  run
+ * @returns {number} length
  */
 const length = run => {
   return run.end - run.start;

--- a/packages/textkit/src/run/lineGap.js
+++ b/packages/textkit/src/run/lineGap.js
@@ -3,8 +3,8 @@ import scale from './scale';
 /**
  * Get run lineGap
  *
- * @param  {Object}  run
- * @return {number} lineGap
+ * @param {Object}  run
+ * @returns {number} lineGap
  */
 const lineGap = run => {
   return (run.attributes?.font?.lineGap || 0) * scale(run);

--- a/packages/textkit/src/run/offset.js
+++ b/packages/textkit/src/run/offset.js
@@ -7,9 +7,9 @@
  *   glyphIndices:   0  1  2  2  2  3
  *   offset:         0  0  0  1  2  0
  *
- * @param  {number}  index
- * @param  {Object}  run
- * @return {number} ligature offset
+ * @param {number}  index
+ * @param {Object}  run
+ * @returns {number} ligature offset
  */
 const offset = (index, run) => {
   if (!run) return 0;

--- a/packages/textkit/src/run/omit.js
+++ b/packages/textkit/src/run/omit.js
@@ -1,8 +1,8 @@
 /**
  * Omit attribute from run
  *
- * @param  {Object}  run
- * @return {Object} run without ommited attribute
+ * @param {Object}  run
+ * @returns {Object} run without ommited attribute
  */
 const omit = (value, run) => {
   const attributes = Object.assign({}, run.attributes);

--- a/packages/textkit/src/run/prepend.js
+++ b/packages/textkit/src/run/prepend.js
@@ -7,9 +7,9 @@ import glyphFromCodePoint from '../glyph/fromCodePoint';
 /**
  * Prepend glyph to run
  *
- * @param  {Object}  glyph
- * @param  {Object}  run
- * @return {Object} run with glyph
+ * @param {Object} glyph
+ * @param {Object} run
+ * @returns {Object} run with glyph
  */
 const prependGlyph = (glyph, run) => {
   const runScale = scale(run);
@@ -28,9 +28,9 @@ const prependGlyph = (glyph, run) => {
 /**
  * Prepend glyph or code point on run
  *
- * @param  {Object | number}  glyph | codePoint
- * @param  {Object}  run
- * @return {Object} run with glyph
+ * @param {Object | number} value glyph or codePoint
+ * @param {Object} run
+ * @returns {Object} run with glyph
  */
 const prepend = (value, run) => {
   if (!value) return run;

--- a/packages/textkit/src/run/runIndexAt.js
+++ b/packages/textkit/src/run/runIndexAt.js
@@ -1,14 +1,14 @@
 /**
  * Get run index that contains passed index
  *
- * @param  {number}  char index
- * @param  {Array}  runs array
- * @return {Array} run index
+ * @param {number} n index
+ * @param {{ start: number, end: number }[]} runs array
+ * @returns {number} run index
  */
 const runIndexAt = (n, runs) => {
   if (!runs) return -1;
 
-  return runs.findIndex(run => run.start <= n && n < run.end);
+  return runs.findIndex((run) => run.start <= n && n < run.end);
 };
 
 export default runIndexAt;

--- a/packages/textkit/src/run/scale.js
+++ b/packages/textkit/src/run/scale.js
@@ -1,8 +1,8 @@
 /**
  * Calculate run scale
  *
- * @param  {Object}  run
- * @return {number} scale
+ * @param {Object}  run
+ * @returns {number} scale
  */
 const calculateScale = run => {
   const attributes = run.attributes || {};
@@ -15,8 +15,8 @@ const calculateScale = run => {
 /**
  * Get run scale
  *
- * @param  {Object}  run
- * @return {number} scale
+ * @param {Object}  run
+ * @returns {number} scale
  */
 const scale = run => {
   return run.attributes?.scale || calculateScale(run);

--- a/packages/textkit/src/run/slice.js
+++ b/packages/textkit/src/run/slice.js
@@ -8,10 +8,10 @@ import normalizeIndices from '../indices/normalize';
 /**
  * Slice run between glyph indices range
  *
- * @param  {number}  start glyph index
- * @param  {number}  end glyph index
- * @param  {Object}  run
- * @return {Object} sliced run
+ * @param {number} start glyph index
+ * @param {number} end glyph index
+ * @param {Object} run
+ * @returns {Object} sliced run
  */
 const slice = (start, end, run) => {
   const runScale = scale(run);

--- a/packages/textkit/src/run/sort.js
+++ b/packages/textkit/src/run/sort.js
@@ -1,9 +1,10 @@
 /**
  * Sort runs in ascending order
  *
- * @param  {Array}  runs
- * @return {Array} sorted runs
+ * @template {{ start: number, end: number }} T
+ * @param {T[]} runs
+ * @returns {T[]} sorted runs
  */
-const sort = runs => runs.sort((a, b) => a.start - b.start || a.end - b.end);
+const sort = (runs) => runs.sort((a, b) => a.start - b.start || a.end - b.end);
 
 export default sort;

--- a/packages/textkit/src/run/subtract.js
+++ b/packages/textkit/src/run/subtract.js
@@ -1,9 +1,9 @@
 /**
  * Subtract scalar to run
  *
- * @param  {number}  scalar
- * @param  {Object}  run
- * @return {Object} subtracted run
+ * @param {number} n scalar
+ * @param {Object} run
+ * @returns {Object} subtracted run
  */
 const subtract = (n, run) => {
   const start = run.start - n;

--- a/packages/textkit/src/run/trailingOffset.js
+++ b/packages/textkit/src/run/trailingOffset.js
@@ -1,17 +1,22 @@
 import isWhiteSpace from '../glyph/isWhiteSpace';
 
-const reverse = array => [...array].reverse();
+/**
+ * @template T
+ * @param {T[]} array
+ * @returns {T[]} reversed array
+ */
+const reverse = (array) => [...array].reverse();
 
 /**
  * Get white space trailing positions
  *
- * @param  {Object}  run
- * @return {Array} white space trailing positions
+ * @param {Object} run
+ * @returns {Object[]} white space trailing positions
  */
-const trailingPositions = run => {
+const trailingPositions = (run) => {
   const glyphs = reverse(run.glyphs || []);
   const positions = reverse(run.positions || []);
-  const leadingWhitespaces = glyphs.findIndex(g => !isWhiteSpace(g));
+  const leadingWhitespaces = glyphs.findIndex((g) => !isWhiteSpace(g));
 
   return positions.slice(0, leadingWhitespaces);
 };
@@ -19,10 +24,10 @@ const trailingPositions = run => {
 /**
  * Get run trailing white space offset
  *
- * @param  {Object}  run
- * @return {number} trailing white space offset
+ * @param {Object}  run
+ * @returns {number} trailing white space offset
  */
-const trailingOffset = run => {
+const trailingOffset = (run) => {
   const positions = trailingPositions(run);
 
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);

--- a/packages/textkit/src/utils/stringFromCodePoints.js
+++ b/packages/textkit/src/utils/stringFromCodePoints.js
@@ -1,8 +1,8 @@
 /**
  * Get string from array of code points
  *
- * @param {Array} code points
- * @return {String} string
+ * @param {number[]} codePoints points
+ * @returns {string} string
  */
 const stringFromCodePoints = codePoints => String.fromCodePoint(...codePoints);
 

--- a/packages/textkit/tests/engines/fontSubstitution.test.js
+++ b/packages/textkit/tests/engines/fontSubstitution.test.js
@@ -1,7 +1,7 @@
 import empty from '../../src/attributedString/empty';
 import fontSubstitution from '../../src/engines/fontSubstitution';
 
-const instance = fontSubstitution({});
+const instance = fontSubstitution();
 
 describe('FontSubstitution', () => {
   test('should return empty array if no runs passed', () => {

--- a/packages/textkit/tests/engines/scriptItemizer.test.js
+++ b/packages/textkit/tests/engines/scriptItemizer.test.js
@@ -1,6 +1,6 @@
 import scriptItemizer from '../../src/engines/scriptItemizer';
 
-const instance = scriptItemizer({});
+const instance = scriptItemizer();
 
 describe('scriptItemizer', () => {
   test('should return empty array for empty string', () => {

--- a/packages/textkit/tests/engines/wordHyphenation.test.js
+++ b/packages/textkit/tests/engines/wordHyphenation.test.js
@@ -14,7 +14,7 @@ jest.unstable_mockModule('hyphen', () => ({ default: () => hyphenator }));
 const wordHyphenation = (await import('../../src/engines/wordHyphenation'))
   .default;
 
-const instance = wordHyphenation({});
+const instance = wordHyphenation();
 
 describe('wordHyphenation', () => {
   beforeEach(() => {

--- a/packages/textkit/tests/internal/fontSubstitutionEngine.js
+++ b/packages/textkit/tests/internal/fontSubstitutionEngine.js
@@ -7,8 +7,8 @@ import { jest } from '@jest/globals';
  *   L     o     r     e     m
  * |- Courier -|-- Helvetica --|
  *
- * @param  {Object}  attributed string
- * @return {Object} attributed string
+ * @param {Object}  attributed string
+ * @returns {Object} attributed string
  */
 export const fontSubstitutionImpl = jest.fn(string => {
   const runs =

--- a/packages/textkit/tests/internal/scriptItemizer.js
+++ b/packages/textkit/tests/internal/scriptItemizer.js
@@ -7,8 +7,8 @@ import { jest } from '@jest/globals';
  *   L     o     r     e     m
  * |---- Latin ----|- Non-latin-|
  *
- * @param  {Object}  attributed string
- * @return {Object} attributed string
+ * @param {Object}  attributed string
+ * @returns {Object} attributed string
  */
 export const scriptItemizerImpl = jest.fn(string => {
   const runs =

--- a/packages/textkit/tests/run/indexAtOffset.test.js
+++ b/packages/textkit/tests/run/indexAtOffset.test.js
@@ -26,7 +26,7 @@ describe('run indexAtOffset operator', () => {
       ],
     };
 
-    expect(indexAtOffset(run, 5)).toBe(0);
+    expect(indexAtOffset(5, run)).toBe(0);
   });
 
   test('should return 0 if glyphs empty', () => {
@@ -43,7 +43,7 @@ describe('run indexAtOffset operator', () => {
       ],
     };
 
-    expect(indexAtOffset(run, 5)).toBe(0);
+    expect(indexAtOffset(5, run)).toBe(0);
   });
 
   test('should return correct index', () => {


### PR DESCRIPTION
This is a DX improvement and a preparation PR if we ever decide to land TypeScript in this repository (@diegomura, let me know your thoughts!).

In this PR:

- I added TypeScript dependency and configured it to non-strict JS type checking (not included in the PR)
- I went through errors one by one and fixed them.
- I pushed it a bit more by changing generic Array type to something[] to improve type accuracy.

Before:
> Found 379 errors in 148 files.

After (incl. other fixes I've raised PRs for):
> Found 24 errors in 8 files.

Much more manageable, isn't it.

Typical issues found:

- parseFloat does not receive second argument. parseInt does.
  ```js
  parseFloat(num, 10);
  ```
- Incorrectly typed definitions: param name not provided (only description)
  ```js
  /**
   * @param {Object} parent document
   */
  const foo = (node) => // …
  ```
- Incorrectly typed definitions: params defined at top level when function returned a function
  ```js
  /**
   * @param {string} bar
   * @param {string} baz
   */
  const foo = (bar) => (baz) => …
  ```

This is by no means a finished job, but it's a clear improvement that pushes us in the right direction, TypeScript or not.