### PR TITLE
fix: props unnecessarily required in LinearGradient and RadialGradient in TypeScript

### DIFF
--- a/.changeset/pretty-moons-hang.md
+++ b/.changeset/pretty-moons-hang.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/renderer': patch
+---
+
+Fix props unnecessarily required in LinearGradient and RadialGradient in TypeScript

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -401,10 +401,10 @@ declare namespace ReactPDF {
 
   interface LinearGradientProps {
     id: string;
-    x1: string | number;
-    x2: string | number;
-    y1: string | number;
-    y2: string | number;
+    x1?: string | number;
+    x2?: string | number;
+    y1?: string | number;
+    y2?: string | number;
   }
 
   /**
@@ -416,11 +416,11 @@ declare namespace ReactPDF {
 
   interface RadialGradientProps {
     id: string;
-    cx: string | number;
-    cy: string | number;
-    fr: string | number;
-    fx: string | number;
-    fy: string | number;
+    cx?: string | number;
+    cy?: string | number;
+    fr?: string | number;
+    fx?: string | number;
+    fy?: string | number;
   }
 
   /**


### PR DESCRIPTION
Examples show that this is totally fine:

https://react-pdf.org/repl?example=lineargradient
https://react-pdf.org/repl?example=radialgradient