### PR TITLE
fix: remove unnecessary check for response.buffer

### DIFF
--- a/.changeset/slimy-suns-drive.md
+++ b/.changeset/slimy-suns-drive.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/image': patch
+---
+
+Remove unnecessary check for response.buffer

--- a/packages/image/src/resolve.js
+++ b/packages/image/src/resolve.js
@@ -47,9 +47,7 @@ const fetchLocalFile = src =>
 const fetchRemoteFile = async (uri, options) => {
   const response = await fetch(uri, options);
 
-  const buffer = await (response.buffer
-    ? response.buffer()
-    : response.arrayBuffer());
+  const buffer = await response.arrayBuffer();
 
   return buffer.constructor.name === 'Buffer' ? buffer : Buffer.from(buffer);
 };


### PR DESCRIPTION
If TypeScript is to be believed, cross-fetch's Response never returns buffer, so this check is unnecessary.