### PR TITLE
fix: fix invalid display property in objectFit example

### DIFF
--- a/.changeset/tidy-houses-sleep.md
+++ b/.changeset/tidy-houses-sleep.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/examples': patch
+---
+
+Fix invalid display property in objectFit example

--- a/packages/examples/src/objectFit/index.jsx
+++ b/packages/examples/src/objectFit/index.jsx
@@ -19,12 +19,10 @@ const styles = StyleSheet.create({
     width: '200pt',
     height: '200pt',
     border: '1px solid red',
-    display: 'block',
     backgroundColor: 'tomato',
     marginBottom: '10',
   },
 });
-
 
 const Quixote = () => (
   <Document>
@@ -53,6 +51,5 @@ const Quixote = () => (
     </Page>
   </Document>
 );
-
 
 export default Quixote;


### PR DESCRIPTION
There's no display: block in react-pdf, only flex or none.