### PR TITLE
fix: creationDate and modificationDate types

### DIFF
--- a/.changeset/wet-glasses-tickle.md
+++ b/.changeset/wet-glasses-tickle.md
@@ -1,0 +1,6 @@
+---
+"@react-pdf/render": patch
+"@react-pdf/renderer": patch
+---
+
+fix: creationDate and modificationDate types

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -36,6 +36,8 @@ declare namespace ReactPDF {
     keywords?: string;
     producer?: string;
     language?: string;
+    creationDate?: Date;
+    modificationDate?: Date;
     pdfVersion?: PDFVersion;
     pageMode?: PageMode;
     pageLayout?: PageLayout;


### PR DESCRIPTION
These are still missing in the renderer, so adding them.

In general, `renderer/DocumentProps` should extend from `types/DocumentProps` ideally, but that will be a larger refactor task