### PR TITLE
chore: do not run Prettier on /lib/

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 yoga-layout
+lib


### PR DESCRIPTION
By ignoring /lib/, time it takes on my machine to run Prettier on the entire repo falls from 8.5 to 2.95s.