### PR TITLE
chore: add JSDoc types to @react-pdf/textkit

### DIFF
--- a/packages/image/src/jpeg.js
+++ b/packages/image/src/jpeg.js
@@ -35,7 +35,7 @@ class JPEG {
   }
 }
 
-JPEG.isValid = data => {
+JPEG.isValid = (data) => {
   return data && Buffer.isBuffer(data) && data.readUInt16BE(0) === 0xffd8;
 };
 

--- a/packages/renderer/tests/dom.test.jsx
+++ b/packages/renderer/tests/dom.test.jsx
@@ -16,14 +16,17 @@ describe('dom', () => {
   });
 
   test('should throw error when trying to use renderToString', () => {
+    // @ts-expect-error - intentionally invalid call
     expect(() => ReactPDF.renderToString()).toThrow();
   });
 
   test('should throw error when trying to use renderToStream', () => {
+    // @ts-expect-error - intentionally invalid call
     expect(() => ReactPDF.renderToStream()).toThrow();
   });
 
   test('should throw error when trying to use renderToFile', () => {
+    // @ts-expect-error - intentionally invalid call
     expect(() => ReactPDF.renderToFile()).toThrow();
   });
 });

--- a/packages/textkit/src/attributedString/advanceWidth.js
+++ b/packages/textkit/src/attributedString/advanceWidth.js
@@ -10,7 +10,9 @@ import runAdvanceWidth from '../run/advanceWidth';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} advance width
  */
-export default function advanceWidth(attributedString) {
+const advanceWidth = (attributedString) => {
   const reducer = (acc, run) => acc + runAdvanceWidth(run);
   return attributedString.runs.reduce(reducer, 0);
-}
+};
+
+export default advanceWidth;

--- a/packages/textkit/src/attributedString/advanceWidth.js
+++ b/packages/textkit/src/attributedString/advanceWidth.js
@@ -1,14 +1,16 @@
 import runAdvanceWidth from '../run/advanceWidth';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Returns attributed string advancewidth
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} advance width
  */
-const advanceWidth = (attributedString) => {
+export default function advanceWidth(attributedString) {
   const reducer = (acc, run) => acc + runAdvanceWidth(run);
   return attributedString.runs.reduce(reducer, 0);
-};
-
-export default advanceWidth;
+}

--- a/packages/textkit/src/attributedString/advanceWidthBetween.js
+++ b/packages/textkit/src/attributedString/advanceWidthBetween.js
@@ -2,21 +2,23 @@ import filterRuns from '../run/filter';
 import runAdvanceWidthBetween from '../run/advanceWidthBetween';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Advance width between start and end
  * Does not consider ligature splitting for the moment.
  * Check performance impact on supporting this
  *
  * @param {number} start offset
  * @param {number} end offset
- * @param {Object} attributedString
+ * @param {AttributedString} attributedString
  * @returns {number} advance width
  */
-const advanceWidthBetween = (start, end, attributedString) => {
+export default function advanceWidthBetween(start, end, attributedString) {
   const runs = filterRuns(start, end, attributedString.runs);
   return runs.reduce(
     (acc, run) => acc + runAdvanceWidthBetween(start, end, run),
     0,
   );
-};
-
-export default advanceWidthBetween;
+}

--- a/packages/textkit/src/attributedString/advanceWidthBetween.js
+++ b/packages/textkit/src/attributedString/advanceWidthBetween.js
@@ -15,10 +15,12 @@ import runAdvanceWidthBetween from '../run/advanceWidthBetween';
  * @param {AttributedString} attributedString
  * @returns {number} advance width
  */
-export default function advanceWidthBetween(start, end, attributedString) {
+const advanceWidthBetween = (start, end, attributedString) => {
   const runs = filterRuns(start, end, attributedString.runs);
   return runs.reduce(
     (acc, run) => acc + runAdvanceWidthBetween(start, end, run),
     0,
   );
-}
+};
+
+export default advanceWidthBetween;

--- a/packages/textkit/src/attributedString/append.js
+++ b/packages/textkit/src/attributedString/append.js
@@ -16,7 +16,7 @@ import stringFromCodePoints from '../utils/stringFromCodePoints';
  * @param {AttributedString} attributedString attributed string
  * @returns {AttributedString} attributed string with new glyph
  */
-export default function append(glyph, attributedString) {
+const append = (glyph, attributedString) => {
   const codePoints = glyph?.codePoints || [];
   const codePointsString = stringFromCodePoints(codePoints);
   const string = attributedString.string + codePointsString;
@@ -26,4 +26,6 @@ export default function append(glyph, attributedString) {
   const runs = firstRuns.concat(appendToRun(glyph, lastRun));
 
   return Object.assign({}, attributedString, { string, runs });
-}
+};
+
+export default append;

--- a/packages/textkit/src/attributedString/append.js
+++ b/packages/textkit/src/attributedString/append.js
@@ -5,13 +5,18 @@ import appendToRun from '../run/append';
 import stringFromCodePoints from '../utils/stringFromCodePoints';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
+/**
  * Append glyph into last run of attributed string
  *
- * @param {Object} glyph
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string with new glyph
+ * @param {Glyph} glyph glyph
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string with new glyph
  */
-const append = (glyph, attributedString) => {
+export default function append(glyph, attributedString) {
   const codePoints = glyph?.codePoints || [];
   const codePointsString = stringFromCodePoints(codePoints);
   const string = attributedString.string + codePointsString;
@@ -21,6 +26,4 @@ const append = (glyph, attributedString) => {
   const runs = firstRuns.concat(appendToRun(glyph, lastRun));
 
   return Object.assign({}, attributedString, { string, runs });
-};
-
-export default append;
+}

--- a/packages/textkit/src/attributedString/ascent.js
+++ b/packages/textkit/src/attributedString/ascent.js
@@ -1,14 +1,16 @@
 import runAscent from '../run/ascent';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Returns attributed string ascent
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} ascent
  */
-const ascent = (attributedString) => {
+export default function ascent(attributedString) {
   const reducer = (acc, run) => Math.max(acc, runAscent(run));
   return attributedString.runs.reduce(reducer, 0);
-};
-
-export default ascent;
+}

--- a/packages/textkit/src/attributedString/ascent.js
+++ b/packages/textkit/src/attributedString/ascent.js
@@ -10,7 +10,9 @@ import runAscent from '../run/ascent';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} ascent
  */
-export default function ascent(attributedString) {
+const ascent = (attributedString) => {
   const reducer = (acc, run) => Math.max(acc, runAscent(run));
   return attributedString.runs.reduce(reducer, 0);
-}
+};
+
+export default ascent;

--- a/packages/textkit/src/attributedString/descent.js
+++ b/packages/textkit/src/attributedString/descent.js
@@ -1,14 +1,16 @@
 import runDescent from '../run/descent';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Returns attributed string descent
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} descent
  */
-const descent = (attributedString) => {
+export default function descent(attributedString) {
   const reducer = (acc, run) => Math.min(acc, runDescent(run));
   return attributedString.runs.reduce(reducer, 0);
-};
-
-export default descent;
+}

--- a/packages/textkit/src/attributedString/descent.js
+++ b/packages/textkit/src/attributedString/descent.js
@@ -10,7 +10,9 @@ import runDescent from '../run/descent';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} descent
  */
-export default function descent(attributedString) {
+const descent = (attributedString) => {
   const reducer = (acc, run) => Math.min(acc, runDescent(run));
   return attributedString.runs.reduce(reducer, 0);
-}
+};
+
+export default descent;

--- a/packages/textkit/src/attributedString/dropLast.js
+++ b/packages/textkit/src/attributedString/dropLast.js
@@ -3,16 +3,18 @@ import { adjust, dropLast as arrayDropLast } from '@react-pdf/fns';
 import runDropLast from '../run/dropLast';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Drop last glyph
  *
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string with new glyph
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string with new glyph
  */
-const dropLast = (attributedString) => {
+export default function dropLast(attributedString) {
   const string = arrayDropLast(attributedString.string);
   const runs = adjust(-1, runDropLast, attributedString.runs);
 
   return Object.assign({}, attributedString, { string, runs });
-};
-
-export default dropLast;
+}

--- a/packages/textkit/src/attributedString/dropLast.js
+++ b/packages/textkit/src/attributedString/dropLast.js
@@ -12,9 +12,11 @@ import runDropLast from '../run/dropLast';
  * @param {AttributedString} attributedString attributed string
  * @returns {AttributedString} attributed string with new glyph
  */
-export default function dropLast(attributedString) {
+const dropLast = (attributedString) => {
   const string = arrayDropLast(attributedString.string);
   const runs = adjust(-1, runDropLast, attributedString.runs);
 
   return Object.assign({}, attributedString, { string, runs });
-}
+};
+
+export default dropLast;

--- a/packages/textkit/src/attributedString/end.js
+++ b/packages/textkit/src/attributedString/end.js
@@ -10,7 +10,9 @@ import { last } from '@react-pdf/fns';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} end
  */
-export default function end(attributedString) {
+const end = (attributedString) => {
   const { runs } = attributedString;
   return runs.length === 0 ? 0 : last(runs).end;
-}
+};
+
+export default end;

--- a/packages/textkit/src/attributedString/end.js
+++ b/packages/textkit/src/attributedString/end.js
@@ -1,14 +1,16 @@
 import { last } from '@react-pdf/fns';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get attributed string end value
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} end
  */
-const end = (attributedString) => {
+export default function end(attributedString) {
   const { runs } = attributedString;
   return runs.length === 0 ? 0 : last(runs).end;
-};
-
-export default end;
+}

--- a/packages/textkit/src/attributedString/fromFragments.js
+++ b/packages/textkit/src/attributedString/fromFragments.js
@@ -9,7 +9,7 @@
  * @param {Fragment[]} fragments fragments
  * @returns {AttributedString} attributed string
  */
-function fromFragments(fragments) {
+const fromFragments = (fragments) => {
   let offset = 0;
   let string = '';
   const runs = [];
@@ -27,6 +27,6 @@ function fromFragments(fragments) {
   });
 
   return { string, runs };
-}
+};
 
 export default fromFragments;

--- a/packages/textkit/src/attributedString/fromFragments.js
+++ b/packages/textkit/src/attributedString/fromFragments.js
@@ -1,10 +1,15 @@
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Fragment} Fragment
+ */
+
+/**
  * Create attributed string from text fragments
  *
- * @param {Object[]} fragments fragments
- * @returns {Object} attributed string
+ * @param {Fragment[]} fragments fragments
+ * @returns {AttributedString} attributed string
  */
-const fromFragments = (fragments) => {
+function fromFragments(fragments) {
   let offset = 0;
   let string = '';
   const runs = [];
@@ -22,6 +27,6 @@ const fromFragments = (fragments) => {
   });
 
   return { string, runs };
-};
+}
 
 export default fromFragments;

--- a/packages/textkit/src/attributedString/glyphWidthAt.js
+++ b/packages/textkit/src/attributedString/glyphWidthAt.js
@@ -2,16 +2,18 @@ import runAt from './runAt';
 import glyphIndexAt from '../run/glyphIndexAt';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get glyph width at string index
  *
  * @param {number} index string index
- * @param {Object} string attributed string
+ * @param {AttributedString} string attributed string
  * @returns {number} glyph width
  */
-const glyphWidthAt = (index, string) => {
+export default function glyphWidthAt(index, string) {
   const run = runAt(index, string);
   const glyphIndex = glyphIndexAt(index, run);
   return run.positions[glyphIndex].xAdvance;
-};
-
-export default glyphWidthAt;
+}

--- a/packages/textkit/src/attributedString/glyphWidthAt.js
+++ b/packages/textkit/src/attributedString/glyphWidthAt.js
@@ -12,8 +12,10 @@ import glyphIndexAt from '../run/glyphIndexAt';
  * @param {AttributedString} string attributed string
  * @returns {number} glyph width
  */
-export default function glyphWidthAt(index, string) {
+const glyphWidthAt = (index, string) => {
   const run = runAt(index, string);
   const glyphIndex = glyphIndexAt(index, run);
   return run.positions[glyphIndex].xAdvance;
-}
+};
+
+export default glyphWidthAt;

--- a/packages/textkit/src/attributedString/height.js
+++ b/packages/textkit/src/attributedString/height.js
@@ -10,7 +10,9 @@ import runHeight from '../run/height';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} height
  */
-export default function height(attributedString) {
+const height = (attributedString) => {
   const reducer = (acc, run) => Math.max(acc, runHeight(run));
   return attributedString.runs.reduce(reducer, 0);
-}
+};
+
+export default height;

--- a/packages/textkit/src/attributedString/height.js
+++ b/packages/textkit/src/attributedString/height.js
@@ -1,14 +1,16 @@
 import runHeight from '../run/height';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Returns attributed string height
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} height
  */
-const height = (attributedString) => {
+export default function height(attributedString) {
   const reducer = (acc, run) => Math.max(acc, runHeight(run));
   return attributedString.runs.reduce(reducer, 0);
-};
-
-export default height;
+}

--- a/packages/textkit/src/attributedString/indexAtOffset.js
+++ b/packages/textkit/src/attributedString/indexAtOffset.js
@@ -3,13 +3,17 @@ import runAdvanceWidth from '../run/advanceWidth';
 import runIndexAtOffset from '../run/indexAtOffset';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get string index at offset
  *
  * @param {number} offset offset
- * @param {Object} string attributed string
+ * @param {AttributedString} string attributed string
  * @returns {number} string index at offset N
  */
-const indexAtOffset = (offset, string) => {
+export default function indexAtOffset(offset, string) {
   let index = 0;
   let counter = 0;
 
@@ -28,6 +32,4 @@ const indexAtOffset = (offset, string) => {
   }
 
   return index;
-};
-
-export default indexAtOffset;
+}

--- a/packages/textkit/src/attributedString/indexAtOffset.js
+++ b/packages/textkit/src/attributedString/indexAtOffset.js
@@ -13,7 +13,7 @@ import runIndexAtOffset from '../run/indexAtOffset';
  * @param {AttributedString} string attributed string
  * @returns {number} string index at offset N
  */
-export default function indexAtOffset(offset, string) {
+const indexAtOffset = (offset, string) => {
   let index = 0;
   let counter = 0;
 
@@ -32,4 +32,6 @@ export default function indexAtOffset(offset, string) {
   }
 
   return index;
-}
+};
+
+export default indexAtOffset;

--- a/packages/textkit/src/attributedString/insertGlyph.js
+++ b/packages/textkit/src/attributedString/insertGlyph.js
@@ -5,14 +5,19 @@ import runIndexAt from './runIndexAt';
 import stringFromCodePoints from '../utils/stringFromCodePoints';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
+/**
  * Insert glyph into attributed string
  *
- * @param {number} index
- * @param {Object} glyph
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string with new glyph
+ * @param {number} index index
+ * @param {Glyph} glyph glyph
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string with new glyph
  */
-const insertGlyph = (index, glyph, attributedString) => {
+function insertGlyph(index, glyph, attributedString) {
   const runIndex = runIndexAt(index, attributedString);
 
   // Add glyph to the end if run index invalid
@@ -34,6 +39,6 @@ const insertGlyph = (index, glyph, attributedString) => {
   });
 
   return Object.assign({}, attributedString, { string, runs });
-};
+}
 
 export default insertGlyph;

--- a/packages/textkit/src/attributedString/insertGlyph.js
+++ b/packages/textkit/src/attributedString/insertGlyph.js
@@ -17,7 +17,7 @@ import stringFromCodePoints from '../utils/stringFromCodePoints';
  * @param {AttributedString} attributedString attributed string
  * @returns {AttributedString} attributed string with new glyph
  */
-function insertGlyph(index, glyph, attributedString) {
+const insertGlyph = (index, glyph, attributedString) => {
   const runIndex = runIndexAt(index, attributedString);
 
   // Add glyph to the end if run index invalid
@@ -39,6 +39,6 @@ function insertGlyph(index, glyph, attributedString) {
   });
 
   return Object.assign({}, attributedString, { string, runs });
-}
+};
 
 export default insertGlyph;

--- a/packages/textkit/src/attributedString/leadingOffset.js
+++ b/packages/textkit/src/attributedString/leadingOffset.js
@@ -10,8 +10,10 @@ import runLeadingOffset from '../run/leadingOffset';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} leading white space offset
  */
-export default function leadingOffset(attributedString) {
+const leadingOffset = (attributedString) => {
   const runs = attributedString.runs || [];
 
   return runLeadingOffset(runs[0]);
-}
+};
+
+export default leadingOffset;

--- a/packages/textkit/src/attributedString/leadingOffset.js
+++ b/packages/textkit/src/attributedString/leadingOffset.js
@@ -1,15 +1,17 @@
 import runLeadingOffset from '../run/leadingOffset';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get attributed string leading white space offset
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} leading white space offset
  */
-const leadingOffset = (attributedString) => {
+export default function leadingOffset(attributedString) {
   const runs = attributedString.runs || [];
 
   return runLeadingOffset(runs[0]);
-};
-
-export default leadingOffset;
+}

--- a/packages/textkit/src/attributedString/length.js
+++ b/packages/textkit/src/attributedString/length.js
@@ -11,6 +11,8 @@ import end from './end';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} end
  */
-export default function length(attributedString) {
+const length = (attributedString) => {
   return end(attributedString) - start(attributedString);
-}
+};
+
+export default length;

--- a/packages/textkit/src/attributedString/length.js
+++ b/packages/textkit/src/attributedString/length.js
@@ -2,13 +2,15 @@ import start from './start';
 import end from './end';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get attributed string length
  *
- * @param {Object} attributedString glyph string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} end
  */
-const length = (attributedString) => {
+export default function length(attributedString) {
   return end(attributedString) - start(attributedString);
-};
-
-export default length;
+}

--- a/packages/textkit/src/attributedString/prepend.js
+++ b/packages/textkit/src/attributedString/prepend.js
@@ -15,7 +15,7 @@ import stringFromCodePoints from '../utils/stringFromCodePoints';
  * @param {AttributedString} attributedString attributed string
  * @returns {AttributedString} attributed string with new glyph
  */
-export default function prepend(glyph, attributedString) {
+const prepend = (glyph, attributedString) => {
   const codePoints = glyph?.codePoints || [];
   const string = stringFromCodePoints(codePoints) + attributedString.string;
 
@@ -27,4 +27,6 @@ export default function prepend(glyph, attributedString) {
   const runs = [prependToRun(glyph, firstRun)].concat(lastRuns);
 
   return Object.assign({}, attributedString, { runs, string });
-}
+};
+
+export default prepend;

--- a/packages/textkit/src/attributedString/prepend.js
+++ b/packages/textkit/src/attributedString/prepend.js
@@ -4,13 +4,18 @@ import prependToRun from '../run/prepend';
 import stringFromCodePoints from '../utils/stringFromCodePoints';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
+/**
  * prepend glyph into last run of attributed string
  *
- * @param {Object} glyph
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string with new glyph
+ * @param {Glyph} glyph
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string with new glyph
  */
-const prepend = (glyph, attributedString) => {
+export default function prepend(glyph, attributedString) {
   const codePoints = glyph?.codePoints || [];
   const string = stringFromCodePoints(codePoints) + attributedString.string;
 
@@ -22,6 +27,4 @@ const prepend = (glyph, attributedString) => {
   const runs = [prependToRun(glyph, firstRun)].concat(lastRuns);
 
   return Object.assign({}, attributedString, { runs, string });
-};
-
-export default prepend;
+}

--- a/packages/textkit/src/attributedString/runAt.js
+++ b/packages/textkit/src/attributedString/runAt.js
@@ -1,15 +1,18 @@
 import runIndexAt from './runIndexAt';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run at char index
  *
  * @param {number} n char index
- * @param {Object} attributedString attributed string
- * @returns {Object} run
+ * @param {AttributedString} attributedString attributed string
+ * @returns {Run} run
  */
-const runAt = (n, attributedString) => {
+export default function runAt(n, attributedString) {
   const runIndex = runIndexAt(n, attributedString);
   return attributedString.runs[runIndex];
-};
-
-export default runAt;
+}

--- a/packages/textkit/src/attributedString/runAt.js
+++ b/packages/textkit/src/attributedString/runAt.js
@@ -12,7 +12,9 @@ import runIndexAt from './runIndexAt';
  * @param {AttributedString} attributedString attributed string
  * @returns {Run} run
  */
-export default function runAt(n, attributedString) {
+const runAt = (n, attributedString) => {
   const runIndex = runIndexAt(n, attributedString);
   return attributedString.runs[runIndex];
-}
+};
+
+export default runAt;

--- a/packages/textkit/src/attributedString/runIndexAt.js
+++ b/packages/textkit/src/attributedString/runIndexAt.js
@@ -1,14 +1,16 @@
 import runIndexAtInternal from '../run/runIndexAt';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get run index at char index
  *
  * @param {number} n char index
- * @param {Object} string attributed string
+ * @param {AttributedString} string attributed string
  * @returns {number} run index
  */
-const runIndexAt = (n, string) => {
+export default function runIndexAt(n, string) {
   return runIndexAtInternal(n, string.runs);
-};
-
-export default runIndexAt;
+}

--- a/packages/textkit/src/attributedString/runIndexAt.js
+++ b/packages/textkit/src/attributedString/runIndexAt.js
@@ -11,6 +11,8 @@ import runIndexAtInternal from '../run/runIndexAt';
  * @param {AttributedString} string attributed string
  * @returns {number} run index
  */
-export default function runIndexAt(n, string) {
+const runIndexAt = (n, string) => {
   return runIndexAtInternal(n, string.runs);
-}
+};
+
+export default runIndexAt;

--- a/packages/textkit/src/attributedString/slice.js
+++ b/packages/textkit/src/attributedString/slice.js
@@ -40,7 +40,7 @@ const sliceRuns = (start, end, runs) => {
  * @param {AttributedString} attributedString attributed string
  * @returns {AttributedString} attributed string
  */
-export default function slice(start, end, attributedString) {
+const slice = (start, end, attributedString) => {
   if (attributedString.string.length === 0) return attributedString;
 
   const string = attributedString.string.slice(start, end);
@@ -48,4 +48,6 @@ export default function slice(start, end, attributedString) {
   const slicedRuns = sliceRuns(start, end, filteredRuns);
 
   return Object.assign({}, attributedString, { string, runs: slicedRuns });
-}
+};
+
+export default slice;

--- a/packages/textkit/src/attributedString/slice.js
+++ b/packages/textkit/src/attributedString/slice.js
@@ -3,12 +3,17 @@ import filterRuns from '../run/filter';
 import subtractRun from '../run/subtract';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Slice array of runs
  *
  * @param {number} start offset
  * @param {number} end offset
- * @param {Object[]} runs
- * @returns {Object[]} sliced runs
+ * @param {Run[]} runs
+ * @returns {Run[]} sliced runs
  */
 const sliceRuns = (start, end, runs) => {
   const sliceFirstRun = (a) => sliceRun(start - a.start, end - a.start, a);
@@ -32,10 +37,10 @@ const sliceRuns = (start, end, runs) => {
  *
  * @param {number} start offset
  * @param {number} end offset
- * @param {Object} attributedString attributed string
- * @returns {Object} attributedString
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string
  */
-const slice = (start, end, attributedString) => {
+export default function slice(start, end, attributedString) {
   if (attributedString.string.length === 0) return attributedString;
 
   const string = attributedString.string.slice(start, end);
@@ -43,6 +48,4 @@ const slice = (start, end, attributedString) => {
   const slicedRuns = sliceRuns(start, end, filteredRuns);
 
   return Object.assign({}, attributedString, { string, runs: slicedRuns });
-};
-
-export default slice;
+}

--- a/packages/textkit/src/attributedString/sliceAtOffset.js
+++ b/packages/textkit/src/attributedString/sliceAtOffset.js
@@ -12,7 +12,9 @@ import indexAtOffset from './indexAtOffset';
  * @param {AttributedString} string attributed string
  * @returns {AttributedString} attributed string
  */
-export default function sliceAtOffset(offset, string) {
+const sliceAtOffset = (offset, string) => {
   const index = indexAtOffset(offset, string);
   return slice(0, index, string);
-}
+};
+
+export default sliceAtOffset;

--- a/packages/textkit/src/attributedString/sliceAtOffset.js
+++ b/packages/textkit/src/attributedString/sliceAtOffset.js
@@ -2,15 +2,17 @@ import slice from './slice';
 import indexAtOffset from './indexAtOffset';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Slice attributed string at given offset
  *
  * @param {number} offset offset
- * @param {Object} string attributedString
- * @returns {Object} attributedString
+ * @param {AttributedString} string attributed string
+ * @returns {AttributedString} attributed string
  */
-const sliceAtOffset = (offset, string) => {
+export default function sliceAtOffset(offset, string) {
   const index = indexAtOffset(offset, string);
   return slice(0, index, string);
-};
-
-export default sliceAtOffset;
+}

--- a/packages/textkit/src/attributedString/start.js
+++ b/packages/textkit/src/attributedString/start.js
@@ -1,12 +1,14 @@
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get attributed string start value
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} start
  */
-const start = (attributedString) => {
+export default function start(attributedString) {
   const { runs } = attributedString;
   return runs.length === 0 ? 0 : runs[0].start;
-};
-
-export default start;
+}

--- a/packages/textkit/src/attributedString/start.js
+++ b/packages/textkit/src/attributedString/start.js
@@ -8,7 +8,9 @@
  * @param {AttributedString} attributedString attributed string
  * @returns {number} start
  */
-export default function start(attributedString) {
+const start = (attributedString) => {
   const { runs } = attributedString;
   return runs.length === 0 ? 0 : runs[0].start;
-}
+};
+
+export default start;

--- a/packages/textkit/src/attributedString/trailingOffset.js
+++ b/packages/textkit/src/attributedString/trailingOffset.js
@@ -12,8 +12,10 @@ import runTrailingOffset from '../run/trailingOffset';
  * @param {AttributedString} attributedString attributed string
  * @returns {number} trailing white space offset
  */
-export default function trailingOffset(attributedString) {
+const trailingOffset = (attributedString) => {
   const runs = attributedString.runs || [];
 
   return runTrailingOffset(last(runs));
-}
+};
+
+export default trailingOffset;

--- a/packages/textkit/src/attributedString/trailingOffset.js
+++ b/packages/textkit/src/attributedString/trailingOffset.js
@@ -3,15 +3,17 @@ import { last } from '@react-pdf/fns';
 import runTrailingOffset from '../run/trailingOffset';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Get attributed string trailing white space offset
  *
- * @param {Object} attributedString attributed string
+ * @param {AttributedString} attributedString attributed string
  * @returns {number} trailing white space offset
  */
-const trailingOffset = (attributedString) => {
+export default function trailingOffset(attributedString) {
   const runs = attributedString.runs || [];
 
   return runTrailingOffset(last(runs));
-};
-
-export default trailingOffset;
+}

--- a/packages/textkit/src/attributedString/trim.js
+++ b/packages/textkit/src/attributedString/trim.js
@@ -8,18 +8,18 @@ import slice from './slice';
  * @param {string} string
  * @returns {number} index
  */
-function findCharIndex(string) {
+const findCharIndex = (string) => {
   return string.search(/\S/g);
-}
+};
 
 /**
  * @param {string} string
  * @returns {number} index
  */
-function findLastCharIndex(string) {
+const findLastCharIndex = (string) => {
   const match = string.match(/\S/g);
   return match ? string.lastIndexOf(match[match.length - 1]) : -1;
-}
+};
 
 /**
  * Removes (strips) whitespace from both ends of the attributted string.
@@ -27,10 +27,12 @@ function findLastCharIndex(string) {
  * @param {AttributedString} attributedString attributed string
  * @returns {AttributedString} attributed string
  */
-export default function trim(attributedString) {
+const trim = (attributedString) => {
   const start = findCharIndex(attributedString.string);
 
   const end = findLastCharIndex(attributedString.string);
 
   return slice(start, end + 1, attributedString);
-}
+};
+
+export default trim;

--- a/packages/textkit/src/attributedString/trim.js
+++ b/packages/textkit/src/attributedString/trim.js
@@ -1,24 +1,36 @@
 import slice from './slice';
 
-const findCharIndex = (string) => string.search(/\S/g);
+/**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
 
-const findLastCharIndex = (string) => {
+/**
+ * @param {string} string
+ * @returns {number} index
+ */
+function findCharIndex(string) {
+  return string.search(/\S/g);
+}
+
+/**
+ * @param {string} string
+ * @returns {number} index
+ */
+function findLastCharIndex(string) {
   const match = string.match(/\S/g);
   return match ? string.lastIndexOf(match[match.length - 1]) : -1;
-};
+}
 
 /**
  * Removes (strips) whitespace from both ends of the attributted string.
  *
- * @param {Object}  attributedString
- * @returns {Object} attributedString
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string
  */
-const trim = (attributedString) => {
+export default function trim(attributedString) {
   const start = findCharIndex(attributedString.string);
 
   const end = findLastCharIndex(attributedString.string);
 
   return slice(start, end + 1, attributedString);
-};
-
-export default trim;
+}

--- a/packages/textkit/src/engines/fontSubstitution/index.js
+++ b/packages/textkit/src/engines/fontSubstitution/index.js
@@ -4,76 +4,83 @@ import { last } from '@react-pdf/fns';
 
 import empty from '../../attributedString/empty';
 
-const getFontSize = (value) => value.attributes.fontSize || 12;
+/**
+ * @typedef {import('../../types.js').AttributedString} AttributedString
+ * @typedef {import('../../types.js').Run} Run
+ */
 
 /**
- * @typedef {Function} FontSubstitution
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string
+ * @param {Run} run run
+ * @returns {number}
  */
+function getFontSize(run) {
+  return run.attributes.fontSize || 12;
+}
 
 /**
  * Resolve font runs in an AttributedString, grouping equal
  * runs and performing font substitution where necessary.
- *
- * @returns {FontSubstitution} font substitution
  */
-const fontSubstitution = () => (attributedString) => {
-  const { string, runs } = attributedString;
+export default function fontSubstitution() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string
+   */
+  return (attributedString) => {
+    const { string, runs } = attributedString;
 
-  let lastFont = null;
-  let lastIndex = 0;
-  let index = 0;
-  const res = [];
+    let lastFont = null;
+    let lastIndex = 0;
+    let index = 0;
+    const res = [];
 
-  if (!string) return empty();
+    if (!string) return empty();
 
-  for (const run of runs) {
-    const fontSize = getFontSize(run);
-    const defaultFont = run.attributes.font;
+    for (const run of runs) {
+      const fontSize = getFontSize(run);
+      const defaultFont = run.attributes.font;
 
-    if (string.length === 0) {
-      res.push({ start: 0, end: 0, attributes: { font: defaultFont } });
-      break;
-    }
-
-    for (const char of string.slice(run.start, run.end)) {
-      const font = defaultFont;
-
-      if (font !== lastFont) {
-        if (lastFont) {
-          res.push({
-            start: lastIndex,
-            end: index,
-            attributes: {
-              font: lastFont,
-              scale: lastFont ? fontSize / lastFont.unitsPerEm : 0,
-            },
-          });
-        }
-
-        lastFont = font;
-        lastIndex = index;
+      if (string.length === 0) {
+        res.push({ start: 0, end: 0, attributes: { font: defaultFont } });
+        break;
       }
 
-      index += char.length;
+      for (const char of string.slice(run.start, run.end)) {
+        const font = defaultFont;
+
+        if (font !== lastFont) {
+          if (lastFont) {
+            res.push({
+              start: lastIndex,
+              end: index,
+              attributes: {
+                font: lastFont,
+                scale: lastFont ? fontSize / lastFont.unitsPerEm : 0,
+              },
+            });
+          }
+
+          lastFont = font;
+          lastIndex = index;
+        }
+
+        index += char.length;
+      }
     }
-  }
 
-  if (lastIndex < string.length) {
-    const fontSize = getFontSize(last(runs));
+    if (lastIndex < string.length) {
+      const fontSize = getFontSize(last(runs));
 
-    res.push({
-      start: lastIndex,
-      end: string.length,
-      attributes: {
-        font: lastFont,
-        scale: lastFont ? fontSize / lastFont.unitsPerEm : 0,
-      },
-    });
-  }
+      res.push({
+        start: lastIndex,
+        end: string.length,
+        attributes: {
+          font: lastFont,
+          scale: lastFont ? fontSize / lastFont.unitsPerEm : 0,
+        },
+      });
+    }
 
-  return { string, runs: res };
-};
-
-export default fontSubstitution;
+    return { string, runs: res };
+  };
+}

--- a/packages/textkit/src/engines/fontSubstitution/index.js
+++ b/packages/textkit/src/engines/fontSubstitution/index.js
@@ -13,15 +13,15 @@ import empty from '../../attributedString/empty';
  * @param {Run} run run
  * @returns {number}
  */
-function getFontSize(run) {
+const getFontSize = (run) => {
   return run.attributes.fontSize || 12;
-}
+};
 
 /**
  * Resolve font runs in an AttributedString, grouping equal
  * runs and performing font substitution where necessary.
  */
-export default function fontSubstitution() {
+const fontSubstitution = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string
@@ -83,4 +83,6 @@ export default function fontSubstitution() {
 
     return { string, runs: res };
   };
-}
+};
+
+export default fontSubstitution;

--- a/packages/textkit/src/engines/justification/index.js
+++ b/packages/textkit/src/engines/justification/index.js
@@ -25,12 +25,6 @@ const justifyLine = (distances, line) => {
 };
 
 /**
- * @typedef {Function} Justification
- * @param {Object} line
- * @returns {Object} line
- */
-
-/**
  * A JustificationEngine is used by a Typesetter to perform line fragment
  * justification. This implementation is based on a description of Apple's
  * justification algorithm from a PDF in the Apple Font Tools package.
@@ -38,17 +32,22 @@ const justifyLine = (distances, line) => {
  * // TODO: Make it immutable
  *
  * @param {Object} options layout options
- * @returns {Justification} justification engine
  */
-const justification = (options) => (line) => {
-  const gap = line.box.width - advanceWidth(line);
+function justification(options) {
+  /**
+   * @param {Object} line
+   * @returns {Object} line
+   */
+  return (line) => {
+    const gap = line.box.width - advanceWidth(line);
 
-  if (gap === 0) return; // Exact fit
+    if (gap === 0) return; // Exact fit
 
-  const factors = getFactors(gap, line, options);
-  const distances = getDistances(gap, factors);
+    const factors = getFactors(gap, line, options);
+    const distances = getDistances(gap, factors);
 
-  return justifyLine(distances, line);
-};
+    return justifyLine(distances, line);
+  };
+}
 
 export default justification;

--- a/packages/textkit/src/engines/justification/index.js
+++ b/packages/textkit/src/engines/justification/index.js
@@ -33,7 +33,7 @@ const justifyLine = (distances, line) => {
  *
  * @param {Object} options layout options
  */
-function justification(options) {
+const justification = (options) => {
   /**
    * @param {Object} line
    * @returns {Object} line
@@ -48,6 +48,6 @@ function justification(options) {
 
     return justifyLine(distances, line);
   };
-}
+};
 
 export default justification;

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -1,7 +1,13 @@
 /* eslint-disable no-plusplus */
 const INFINITY = 10000;
 
-const getNextBreakpoint = (subnodes, widths, lineNumber) => {
+/**
+ * @param {Object[]} subnodes
+ * @param {number[]} widths
+ * @param {number} lineNumber
+ * @returns {number}
+ */
+function getNextBreakpoint(subnodes, widths, lineNumber) {
   let position = null;
   let minimumBadness = Infinity;
 
@@ -64,9 +70,13 @@ const getNextBreakpoint = (subnodes, widths, lineNumber) => {
   }
 
   return sum.width - sum.shrink > lineLength ? position : null;
-};
+}
 
-const applyBestFit = (nodes, widths) => {
+/**
+ * @param {Object[]} nodes
+ * @param {number[]} widths
+ */
+export default function applyBestFit(nodes, widths) {
   let count = 0;
   let lineNumber = 0;
   let subnodes = nodes;
@@ -87,6 +97,4 @@ const applyBestFit = (nodes, widths) => {
   }
 
   return breakpoints;
-};
-
-export default applyBestFit;
+}

--- a/packages/textkit/src/engines/linebreaker/bestFit.js
+++ b/packages/textkit/src/engines/linebreaker/bestFit.js
@@ -7,7 +7,7 @@ const INFINITY = 10000;
  * @param {number} lineNumber
  * @returns {number}
  */
-function getNextBreakpoint(subnodes, widths, lineNumber) {
+const getNextBreakpoint = (subnodes, widths, lineNumber) => {
   let position = null;
   let minimumBadness = Infinity;
 
@@ -70,13 +70,13 @@ function getNextBreakpoint(subnodes, widths, lineNumber) {
   }
 
   return sum.width - sum.shrink > lineLength ? position : null;
-}
+};
 
 /**
  * @param {Object[]} nodes
  * @param {number[]} widths
  */
-export default function applyBestFit(nodes, widths) {
+const applyBestFit = (nodes, widths) => {
   let count = 0;
   let lineNumber = 0;
   let subnodes = nodes;
@@ -97,4 +97,6 @@ export default function applyBestFit(nodes, widths) {
   }
 
   return breakpoints;
-}
+};
+
+export default applyBestFit;

--- a/packages/textkit/src/engines/linebreaker/index.js
+++ b/packages/textkit/src/engines/linebreaker/index.js
@@ -27,7 +27,7 @@ const opts = {
  * @param {Object[]} breaks
  * @returns {AttributedString[]} attributed strings
  */
-function breakLines(string, nodes, breaks) {
+const breakLines = (string, nodes, breaks) => {
   let start = 0;
   let end = null;
 
@@ -57,7 +57,7 @@ function breakLines(string, nodes, breaks) {
   lines.push(slice(start, string.string.length, string));
 
   return lines;
-}
+};
 
 /**
  * Return Knuth & Plass nodes based on line and previously calculated syllables
@@ -67,7 +67,7 @@ function breakLines(string, nodes, breaks) {
  * @param {Object} options layout options
  * @returns {Object[]} attributed strings
  */
-function getNodes(attributedString, { align }, options) {
+const getNodes = (attributedString, { align }, options) => {
   let start = 0;
 
   const hyphenWidth = 5;
@@ -108,15 +108,15 @@ function getNodes(attributedString, { align }, options) {
   result.push(linebreak.penalty(0, -linebreak.infinity, 1));
 
   return result;
-}
+};
 
 /**
  * @param {AttributedString} attributedString attributed string
  * @returns {Attributes} styles
  */
-function getStyles(attributedString) {
+const getStyles = (attributedString) => {
   return attributedString.runs?.[0]?.attributes || {};
-}
+};
 
 /**
  * Performs Knuth & Plass line breaking algorithm
@@ -124,7 +124,7 @@ function getStyles(attributedString) {
  *
  * @param {Object} options layout options
  */
-export default function linebreaker(options) {
+const linebreaker = (options) => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @param {number[]} availableWidths available widths
@@ -154,4 +154,6 @@ export default function linebreaker(options) {
 
     return breakLines(attributedString, nodes, breaks.slice(1));
   };
-}
+};
+
+export default linebreaker;

--- a/packages/textkit/src/engines/linebreaker/linebreak.js
+++ b/packages/textkit/src/engines/linebreaker/linebreak.js
@@ -2,13 +2,16 @@
 import LinkedList from './linkedList';
 
 /**
+ * @param {Object[]} nodes
+ * @param {number[]} lines
+ * @param {Object} settings
  * @preserve Knuth and Plass line breaking algorithm in JavaScript
  *
  * Licensed under the new BSD License.
  * Copyright 2009-2010, Bram Stein
  * All rights reserved.
  */
-const linebreak = (nodes, lines, settings) => {
+function linebreak(nodes, lines, settings) {
   const options = {
     demerits: {
       line: (settings && settings.demerits && settings.demerits.line) || 10,
@@ -336,7 +339,7 @@ const linebreak = (nodes, lines, settings) => {
     return breaks.reverse();
   }
   return [];
-};
+}
 
 linebreak.infinity = 10000;
 

--- a/packages/textkit/src/engines/linebreaker/linebreak.js
+++ b/packages/textkit/src/engines/linebreaker/linebreak.js
@@ -11,7 +11,7 @@ import LinkedList from './linkedList';
  * Copyright 2009-2010, Bram Stein
  * All rights reserved.
  */
-function linebreak(nodes, lines, settings) {
+const linebreak = (nodes, lines, settings) => {
   const options = {
     demerits: {
       line: (settings && settings.demerits && settings.demerits.line) || 10,
@@ -339,7 +339,7 @@ function linebreak(nodes, lines, settings) {
     return breaks.reverse();
   }
   return [];
-}
+};
 
 linebreak.infinity = 10000;
 

--- a/packages/textkit/src/engines/scriptItemizer/index.js
+++ b/packages/textkit/src/engines/scriptItemizer/index.js
@@ -11,7 +11,7 @@ const ignoredScripts = ['Common', 'Inherited', 'Unknown'];
 /**
  * Resolves unicode script in runs, grouping equal runs together
  */
-export default function scriptItemizer() {
+const scriptItemizer = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string
@@ -58,4 +58,6 @@ export default function scriptItemizer() {
 
     return { string, runs: res };
   };
-}
+};
+
+export default scriptItemizer;

--- a/packages/textkit/src/engines/scriptItemizer/index.js
+++ b/packages/textkit/src/engines/scriptItemizer/index.js
@@ -5,57 +5,57 @@ import empty from '../../attributedString/empty';
 const ignoredScripts = ['Common', 'Inherited', 'Unknown'];
 
 /**
- * @typedef {Function} ScriptItemizer
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string
+ * @typedef {import('../../types.js').AttributedString} AttributedString
  */
 
 /**
  * Resolves unicode script in runs, grouping equal runs together
- *
- * @returns {ScriptItemizer} script itemizer
  */
-const scriptItemizer = () => (attributedString) => {
-  const { string } = attributedString;
+export default function scriptItemizer() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string
+   */
+  return (attributedString) => {
+    const { string } = attributedString;
 
-  let lastScript = 'Unknown';
-  let lastIndex = 0;
-  let index = 0;
-  const res = [];
+    let lastScript = 'Unknown';
+    let lastIndex = 0;
+    let index = 0;
+    const res = [];
 
-  if (!string) return empty();
+    if (!string) return empty();
 
-  for (let i = 0; i < string.length; i += 1) {
-    const char = string[i];
+    for (let i = 0; i < string.length; i += 1) {
+      const char = string[i];
 
-    const codePoint = char.codePointAt();
-    const script = unicode.getScript(codePoint);
+      const codePoint = char.codePointAt();
+      const script = unicode.getScript(codePoint);
 
-    if (script !== lastScript && !ignoredScripts.includes(script)) {
-      if (lastScript !== 'Unknown') {
-        res.push({
-          start: lastIndex,
-          end: index,
-          attributes: { script: lastScript },
-        });
+      if (script !== lastScript && !ignoredScripts.includes(script)) {
+        if (lastScript !== 'Unknown') {
+          res.push({
+            start: lastIndex,
+            end: index,
+            attributes: { script: lastScript },
+          });
+        }
+
+        lastIndex = index;
+        lastScript = script;
       }
 
-      lastIndex = index;
-      lastScript = script;
+      index += char.length;
     }
 
-    index += char.length;
-  }
+    if (lastIndex < string.length) {
+      res.push({
+        start: lastIndex,
+        end: string.length,
+        attributes: { script: lastScript },
+      });
+    }
 
-  if (lastIndex < string.length) {
-    res.push({
-      start: lastIndex,
-      end: string.length,
-      attributes: { script: lastScript },
-    });
-  }
-
-  return { string, runs: res };
-};
-
-export default scriptItemizer;
+    return { string, runs: res };
+  };
+}

--- a/packages/textkit/src/engines/wordHyphenation/index.js
+++ b/packages/textkit/src/engines/wordHyphenation/index.js
@@ -6,24 +6,39 @@ import { isNil } from '@react-pdf/fns';
 
 const SOFT_HYPHEN = '\u00ad';
 const hyphenator = hyphen(pattern);
-const splitHyphen = (word) => word.split(SOFT_HYPHEN);
+
+/**
+ * @param {string} word
+ * @returns {string[]} word parts
+ */
+function splitHyphen(word) {
+  return word.split(SOFT_HYPHEN);
+}
 
 const cache = {};
 
-const getParts = (word) => {
+/**
+ * @param {string} word
+ * @returns {string[]} word parts
+ */
+function getParts(word) {
   const base = word.includes(SOFT_HYPHEN) ? word : hyphenator(word);
   return splitHyphen(base);
-};
+}
 
-const wordHyphenation = () => (word) => {
-  const cacheKey = `_${word}`;
+export default function wordHyphenation() {
+  /**
+   * @param {string} word word
+   * @returns {string[]} word parts
+   */
+  return (word) => {
+    const cacheKey = `_${word}`;
 
-  if (isNil(word)) return [];
-  if (cache[cacheKey]) return cache[cacheKey];
+    if (isNil(word)) return [];
+    if (cache[cacheKey]) return cache[cacheKey];
 
-  cache[cacheKey] = getParts(word);
+    cache[cacheKey] = getParts(word);
 
-  return cache[cacheKey];
-};
-
-export default wordHyphenation;
+    return cache[cacheKey];
+  };
+}

--- a/packages/textkit/src/engines/wordHyphenation/index.js
+++ b/packages/textkit/src/engines/wordHyphenation/index.js
@@ -11,9 +11,9 @@ const hyphenator = hyphen(pattern);
  * @param {string} word
  * @returns {string[]} word parts
  */
-function splitHyphen(word) {
+const splitHyphen = (word) => {
   return word.split(SOFT_HYPHEN);
-}
+};
 
 const cache = {};
 
@@ -21,12 +21,12 @@ const cache = {};
  * @param {string} word
  * @returns {string[]} word parts
  */
-function getParts(word) {
+const getParts = (word) => {
   const base = word.includes(SOFT_HYPHEN) ? word : hyphenator(word);
   return splitHyphen(base);
-}
+};
 
-export default function wordHyphenation() {
+const wordHyphenation = () => {
   /**
    * @param {string} word word
    * @returns {string[]} word parts
@@ -41,4 +41,6 @@ export default function wordHyphenation() {
 
     return cache[cacheKey];
   };
-}
+};
+
+export default wordHyphenation;

--- a/packages/textkit/src/glyph/fromCodePoint.js
+++ b/packages/textkit/src/glyph/fromCodePoint.js
@@ -10,6 +10,8 @@
  * @param {Font} [font] font
  * @returns {Glyph} glyph
  * */
-export default function fromCodePoint(value, font) {
+const fromCodePoint = (value, font) => {
   return font && value ? font.glyphForCodePoint(value) : null;
-}
+};
+
+export default fromCodePoint;

--- a/packages/textkit/src/glyph/fromCodePoint.js
+++ b/packages/textkit/src/glyph/fromCodePoint.js
@@ -1,11 +1,15 @@
 /**
+ * @typedef {import('../types.js').Font} Font
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
+/**
  * Get glyph for a given code point
  *
  * @param {number} [value] codePoint
- * @param {Object} [font] font
- * @returns {Object} glyph
+ * @param {Font} [font] font
+ * @returns {Glyph} glyph
  * */
-const fromCodePoint = (value, font) =>
-  font && value ? font.glyphForCodePoint(value) : null;
-
-export default fromCodePoint;
+export default function fromCodePoint(value, font) {
+  return font && value ? font.glyphForCodePoint(value) : null;
+}

--- a/packages/textkit/src/glyph/isWhiteSpace.js
+++ b/packages/textkit/src/glyph/isWhiteSpace.js
@@ -1,14 +1,16 @@
+/**
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
 const WHITE_SPACES_CODE = 32;
 
 /**
  * Check if glyph is white space
  *
- * @param {Object} glyph
- * @returns {boolean}  is white space
+ * @param {Glyph} [glyph] glyph
+ * @returns {boolean} whether glyph is white space
  * */
-const isWhiteSpace = (glyph) => {
+export default function isWhiteSpace(glyph) {
   const codePoints = glyph?.codePoints || [];
   return codePoints.includes(WHITE_SPACES_CODE);
-};
-
-export default isWhiteSpace;
+}

--- a/packages/textkit/src/glyph/isWhiteSpace.js
+++ b/packages/textkit/src/glyph/isWhiteSpace.js
@@ -10,7 +10,9 @@ const WHITE_SPACES_CODE = 32;
  * @param {Glyph} [glyph] glyph
  * @returns {boolean} whether glyph is white space
  * */
-export default function isWhiteSpace(glyph) {
+const isWhiteSpace = (glyph) => {
   const codePoints = glyph?.codePoints || [];
   return codePoints.includes(WHITE_SPACES_CODE);
-}
+};
+
+export default isWhiteSpace;

--- a/packages/textkit/src/glyph/slice.js
+++ b/packages/textkit/src/glyph/slice.js
@@ -1,14 +1,19 @@
 /**
+ * @typedef {import('../types.js').Font} Font
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
+/**
  * Slice glyph between codePoints range
  * Util for breaking ligatures
  *
- * @param {number} start code point index
- * @param {number} end code point index
- * @param {Object} font to generate new glyph
- * @param {Object} glyph to be sliced
- * @returns {Object[]} sliced glyph parts
+ * @param {number} start start code point index
+ * @param {number} end end code point index
+ * @param {Font} font font to generate new glyph
+ * @param {Glyph} glyph glyph to be sliced
+ * @returns {Glyph[]} sliced glyph parts
  */
-const slice = (start, end, font, glyph) => {
+export default function slice(start, end, font, glyph) {
   if (!glyph) return [];
   if (start === end) return [];
   if (start === 0 && end === glyph.codePoints.length) return [glyph];
@@ -16,6 +21,4 @@ const slice = (start, end, font, glyph) => {
   const codePoints = glyph.codePoints.slice(start, end);
   const string = String.fromCodePoint(...codePoints);
   return font ? font.layout(string).glyphs : [glyph];
-};
-
-export default slice;
+}

--- a/packages/textkit/src/glyph/slice.js
+++ b/packages/textkit/src/glyph/slice.js
@@ -13,7 +13,7 @@
  * @param {Glyph} glyph glyph to be sliced
  * @returns {Glyph[]} sliced glyph parts
  */
-export default function slice(start, end, font, glyph) {
+const slice = (start, end, font, glyph) => {
   if (!glyph) return [];
   if (start === end) return [];
   if (start === 0 && end === glyph.codePoints.length) return [glyph];
@@ -21,4 +21,6 @@ export default function slice(start, end, font, glyph) {
   const codePoints = glyph.codePoints.slice(start, end);
   const string = String.fromCodePoint(...codePoints);
   return font ? font.layout(string).glyphs : [glyph];
-}
+};
+
+export default slice;

--- a/packages/textkit/src/indices/append.js
+++ b/packages/textkit/src/indices/append.js
@@ -9,10 +9,12 @@ import { isNil, last } from '@react-pdf/fns';
  * @param {number[]} indices glyph indices
  * @returns {number[]} extended glyph indices
  */
-export default function appendIndices(length, indices) {
+const appendIndices = (length, indices) => {
   const lastIndex = last(indices);
   const value = isNil(lastIndex) ? 0 : lastIndex + 1;
   const newIndices = Array(length).fill(value);
 
   return indices.concat(newIndices);
-}
+};
+
+export default appendIndices;

--- a/packages/textkit/src/indices/append.js
+++ b/packages/textkit/src/indices/append.js
@@ -9,12 +9,10 @@ import { isNil, last } from '@react-pdf/fns';
  * @param {number[]} indices glyph indices
  * @returns {number[]} extended glyph indices
  */
-const appendIndices = (length, indices) => {
+export default function appendIndices(length, indices) {
   const lastIndex = last(indices);
   const value = isNil(lastIndex) ? 0 : lastIndex + 1;
   const newIndices = Array(length).fill(value);
 
   return indices.concat(newIndices);
-};
-
-export default appendIndices;
+}

--- a/packages/textkit/src/indices/normalize.js
+++ b/packages/textkit/src/indices/normalize.js
@@ -4,7 +4,9 @@
  * @param {number[]} array list
  * @returns {number[]} normalized array
  */
-export default function normalize(array) {
+const normalize = (array) => {
   const head = array[0];
   return array.map((value) => value - head);
-}
+};
+
+export default normalize;

--- a/packages/textkit/src/indices/normalize.js
+++ b/packages/textkit/src/indices/normalize.js
@@ -4,9 +4,7 @@
  * @param {number[]} array list
  * @returns {number[]} normalized array
  */
-const normalize = (array) => {
+export default function normalize(array) {
   const head = array[0];
   return array.map((value) => value - head);
-};
-
-export default normalize;
+}

--- a/packages/textkit/src/indices/prepend.js
+++ b/packages/textkit/src/indices/prepend.js
@@ -7,11 +7,13 @@
  * @param {number[]} indices glyph indices
  * @returns {number[]}  extended glyph indices
  */
-export default function prepend(length, indices) {
+const prepend = (length, indices) => {
   if (length === 0) return indices;
 
   const newIndices = Array(length).fill(0);
   const lastIndices = indices.map((value) => value + 1);
 
   return newIndices.concat(lastIndices);
-}
+};
+
+export default prepend;

--- a/packages/textkit/src/indices/prepend.js
+++ b/packages/textkit/src/indices/prepend.js
@@ -7,13 +7,11 @@
  * @param {number[]} indices glyph indices
  * @returns {number[]}  extended glyph indices
  */
-const prepend = (length, indices) => {
+export default function prepend(length, indices) {
   if (length === 0) return indices;
 
   const newIndices = Array(length).fill(0);
   const lastIndices = indices.map((value) => value + 1);
 
   return newIndices.concat(lastIndices);
-};
-
-export default prepend;
+}

--- a/packages/textkit/src/indices/resolve.js
+++ b/packages/textkit/src/indices/resolve.js
@@ -10,7 +10,7 @@ const DUMMY_CODEPOINT = 123;
  * @param {Glyph[]} glyphs
  * @returns {number[]} glyph indices
  */
-export default function resolve(glyphs = []) {
+const resolve = (glyphs = []) => {
   return glyphs.reduce((acc, glyph) => {
     const codePoints = glyph?.codePoints || [DUMMY_CODEPOINT];
 
@@ -21,4 +21,6 @@ export default function resolve(glyphs = []) {
 
     return [...acc, ...next];
   }, []);
-}
+};
+
+export default resolve;

--- a/packages/textkit/src/indices/resolve.js
+++ b/packages/textkit/src/indices/resolve.js
@@ -1,12 +1,16 @@
+/**
+ * @typedef {import('../types.js').Glyph} Glyph
+ */
+
 const DUMMY_CODEPOINT = 123;
 
 /**
  * Resolve string indices based on glyphs code points
  *
- * @param {Object[]} glyphs
+ * @param {Glyph[]} glyphs
  * @returns {number[]} glyph indices
  */
-const resolve = (glyphs = []) => {
+export default function resolve(glyphs = []) {
   return glyphs.reduce((acc, glyph) => {
     const codePoints = glyph?.codePoints || [DUMMY_CODEPOINT];
 
@@ -17,6 +21,4 @@ const resolve = (glyphs = []) => {
 
     return [...acc, ...next];
   }, []);
-};
-
-export default resolve;
+}

--- a/packages/textkit/src/layout/applyDefaultStyles.js
+++ b/packages/textkit/src/layout/applyDefaultStyles.js
@@ -1,74 +1,78 @@
 /**
- * @param {Object} a attributes
- * @returns {Object} attributes with defaults
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Attributes} Attributes
+ * @typedef {import('../types.js').Run} Run
  */
-const applyAttributes = (a) => ({
-  align: a.align || 'left',
-  alignLastLine:
-    a.alignLastLine || (a.align === 'justify' ? 'left' : a.align || 'left'),
-  attachment: a.attachment || null,
-  backgroundColor: a.backgroundColor || null,
-  bidiLevel: a.bidiLevel || null,
-  bullet: a.bullet || null,
-  characterSpacing: a.characterSpacing || 0,
-  color: a.color || 'black',
-  features: a.features || [],
-  fill: a.fill !== false,
-  font: a.font || null,
-  fontSize: a.fontSize || 12,
-  hangingPunctuation: a.hangingPunctuation || false,
-  hyphenationFactor: a.hyphenationFactor || 0,
-  indent: a.indent || 0,
-  justificationFactor: a.justificationFactor || 1,
-  lineHeight: a.lineHeight || null,
-  lineSpacing: a.lineSpacing || 0,
-  link: a.link || null,
-  marginLeft: a.marginLeft || a.margin || 0,
-  marginRight: a.marginRight || a.margin || 0,
-  opacity: a.opacity,
-  paddingTop: a.paddingTop || a.padding || 0,
-  paragraphSpacing: a.paragraphSpacing || 0,
-  underline: a.underline || false,
-  underlineColor: a.underlineColor || a.color || 'black',
-  underlineStyle: a.underlineStyle || 'solid',
-  script: a.script || null,
-  shrinkFactor: a.shrinkFactor || 0,
-  strike: a.strike || false,
-  strikeColor: a.strikeColor || a.color || 'black',
-  strikeStyle: a.strikeStyle || 'solid',
-  stroke: a.stroke || false,
-  verticalAlign: a.verticalAlign || null,
-  wordSpacing: a.wordSpacing || 0,
-  yOffset: a.yOffset || 0,
-});
+
+/**
+ * @param {Attributes} a attributes
+ * @returns {Attributes} attributes with defaults
+ */
+function applyAttributes(a) {
+  return {
+    align: a.align || 'left',
+    alignLastLine:
+      a.alignLastLine || (a.align === 'justify' ? 'left' : a.align || 'left'),
+    attachment: a.attachment || null,
+    backgroundColor: a.backgroundColor || null,
+    bidiLevel: a.bidiLevel || null,
+    bullet: a.bullet || null,
+    characterSpacing: a.characterSpacing || 0,
+    color: a.color || 'black',
+    features: a.features || [],
+    fill: a.fill !== false,
+    font: a.font || null,
+    fontSize: a.fontSize || 12,
+    hangingPunctuation: a.hangingPunctuation || false,
+    hyphenationFactor: a.hyphenationFactor || 0,
+    indent: a.indent || 0,
+    justificationFactor: a.justificationFactor || 1,
+    lineHeight: a.lineHeight || null,
+    lineSpacing: a.lineSpacing || 0,
+    link: a.link || null,
+    marginLeft: a.marginLeft || a.margin || 0,
+    marginRight: a.marginRight || a.margin || 0,
+    opacity: a.opacity,
+    paddingTop: a.paddingTop || a.padding || 0,
+    paragraphSpacing: a.paragraphSpacing || 0,
+    script: a.script || null,
+    shrinkFactor: a.shrinkFactor || 0,
+    strike: a.strike || false,
+    strikeColor: a.strikeColor || a.color || 'black',
+    strikeStyle: a.strikeStyle || 'solid',
+    stroke: a.stroke || false,
+    underline: a.underline || false,
+    underlineColor: a.underlineColor || a.color || 'black',
+    underlineStyle: a.underlineStyle || 'solid',
+    verticalAlign: a.verticalAlign || null,
+    wordSpacing: a.wordSpacing || 0,
+    yOffset: a.yOffset || 0,
+  };
+}
 
 /**
  * Apply default style to run
  *
- * @param {Object} run run
- * @returns {Object} run with styles
+ * @param {Run} run run
+ * @returns {Run} run with styles
  */
-const applyRunStyles = (run) => {
+function applyRunStyles(run) {
   const attributes = applyAttributes(run.attributes);
   return Object.assign({}, run, { attributes });
-};
-
-/**
- * @typedef {Function} ApplyDefaultStyles
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string
- */
+}
 
 /**
  * Apply default attributes for an attributed string
- *
- * @returns {ApplyDefaultStyles} applyDefaultStyles
  */
-const applyDefaultStyles = () => (attributedString) => {
-  const string = attributedString.string || '';
-  const runs = (attributedString.runs || []).map(applyRunStyles);
+export default function applyDefaultStyles() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string
+   */
+  return (attributedString) => {
+    const string = attributedString.string || '';
+    const runs = (attributedString.runs || []).map(applyRunStyles);
 
-  return { string, runs };
-};
-
-export default applyDefaultStyles;
+    return { string, runs };
+  };
+}

--- a/packages/textkit/src/layout/applyDefaultStyles.js
+++ b/packages/textkit/src/layout/applyDefaultStyles.js
@@ -8,7 +8,7 @@
  * @param {Attributes} a attributes
  * @returns {Attributes} attributes with defaults
  */
-function applyAttributes(a) {
+const applyAttributes = (a) => {
   return {
     align: a.align || 'left',
     alignLastLine:
@@ -48,7 +48,7 @@ function applyAttributes(a) {
     wordSpacing: a.wordSpacing || 0,
     yOffset: a.yOffset || 0,
   };
-}
+};
 
 /**
  * Apply default style to run
@@ -56,15 +56,15 @@ function applyAttributes(a) {
  * @param {Run} run run
  * @returns {Run} run with styles
  */
-function applyRunStyles(run) {
+const applyRunStyles = (run) => {
   const attributes = applyAttributes(run.attributes);
   return Object.assign({}, run, { attributes });
-}
+};
 
 /**
  * Apply default attributes for an attributed string
  */
-export default function applyDefaultStyles() {
+const applyDefaultStyles = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string
@@ -75,4 +75,6 @@ export default function applyDefaultStyles() {
 
     return { string, runs };
   };
-}
+};
+
+export default applyDefaultStyles;

--- a/packages/textkit/src/layout/finalizeFragments.js
+++ b/packages/textkit/src/layout/finalizeFragments.js
@@ -47,33 +47,32 @@ const adjustOverflow = (line) => {
 };
 
 /**
- * @typedef {Function} JustifyLine
- * @param {Object} line
- * @returns {Object} line
- */
-
-/**
  * Performs line justification by calling appropiate engine
  *
  * @param {Object} engines engines
  * @param {Object} options layout options
  * @param {string} align text align
- * @returns {JustifyLine} justifyLine
  */
-const justifyLine = (engines, options, align) => (line) => {
-  const lineWidth = advanceWidth(line);
-  const alignFactor = ALIGNMENT_FACTORS[align] || 0;
-  const remainingWidth = Math.max(0, line.box.width - lineWidth);
-  const shouldJustify = align === 'justify' || lineWidth > line.box.width;
+function justifyLine(engines, options, align) {
+  /**
+   * @param {Object} line lint
+   * @returns {Object} line
+   */
+  return (line) => {
+    const lineWidth = advanceWidth(line);
+    const alignFactor = ALIGNMENT_FACTORS[align] || 0;
+    const remainingWidth = Math.max(0, line.box.width - lineWidth);
+    const shouldJustify = align === 'justify' || lineWidth > line.box.width;
 
-  const x = line.box.x + remainingWidth * alignFactor;
-  const box = Object.assign({}, line.box, { x });
-  const newLine = Object.assign({}, line, { box });
+    const x = line.box.x + remainingWidth * alignFactor;
+    const box = Object.assign({}, line.box, { x });
+    const newLine = Object.assign({}, line, { box });
 
-  return shouldJustify ? engines.justification(options)(newLine) : newLine;
-};
+    return shouldJustify ? engines.justification(options)(newLine) : newLine;
+  };
+}
 
-const finalizeLine = (line) => {
+function finalizeLine(line) {
   let lineAscent = 0;
   let lineDescent = 0;
   let lineHeight = 0;
@@ -100,15 +99,7 @@ const finalizeLine = (line) => {
     descent: lineDescent,
     xAdvance: lineXAdvance,
   });
-};
-
-/**
- * @typedef {Function} FinalizeBlock
- * @param {Object} line
- * @param {number} i line index
- * @param {Object[]} lines total lines
- * @returns {Object} line
- */
+}
 
 /**
  * Finalize line by performing line justification
@@ -116,11 +107,15 @@ const finalizeLine = (line) => {
  *
  * @param {Object} engines engines
  * @param {Object} options layout options
- * @returns {FinalizeBlock} finalize block
  */
-const finalizeBlock =
-  (engines = {}, options) =>
-  (line, i, lines) => {
+function finalizeBlock(engines = {}, options) {
+  /**
+   * @param {Object} line lint
+   * @param {number} i line index
+   * @param {Object[]} lines total lines
+   * @returns {Object} line
+   */
+  return (line, i, lines) => {
     const isLastFragment = i === lines.length - 1;
     const style = line.runs?.[0]?.attributes || {};
     const align = isLastFragment ? style.alignLastLine : style.align;
@@ -133,12 +128,7 @@ const finalizeBlock =
       removeNewLine,
     )(line);
   };
-
-/**
- * @typedef {Function} FinalizeFragments
- * @param {Object[]} blocks line blocks
- * @returns {Object[]} blocks
- */
+}
 
 /**
  * Finalize line block by performing line justification
@@ -146,11 +136,14 @@ const finalizeBlock =
  *
  * @param {Object} engines engines
  * @param {Object} options layout options
- * @returns {FinalizeFragments} finalizeFragments
  */
-const finalizeFragments = (engines, options) => (blocks) => {
-  const blockFinalizer = finalizeBlock(engines, options);
-  return blocks.map((block) => block.map(blockFinalizer));
-};
-
-export default finalizeFragments;
+export default function finalizeFragments(engines, options) {
+  /**
+   * @param {Object[]} blocks line blocks
+   * @returns {Object[]} blocks
+   */
+  return (blocks) => {
+    const blockFinalizer = finalizeBlock(engines, options);
+    return blocks.map((block) => block.map(blockFinalizer));
+  };
+}

--- a/packages/textkit/src/layout/finalizeFragments.js
+++ b/packages/textkit/src/layout/finalizeFragments.js
@@ -53,7 +53,7 @@ const adjustOverflow = (line) => {
  * @param {Object} options layout options
  * @param {string} align text align
  */
-function justifyLine(engines, options, align) {
+const justifyLine = (engines, options, align) => {
   /**
    * @param {Object} line lint
    * @returns {Object} line
@@ -70,9 +70,9 @@ function justifyLine(engines, options, align) {
 
     return shouldJustify ? engines.justification(options)(newLine) : newLine;
   };
-}
+};
 
-function finalizeLine(line) {
+const finalizeLine = (line) => {
   let lineAscent = 0;
   let lineDescent = 0;
   let lineHeight = 0;
@@ -99,7 +99,7 @@ function finalizeLine(line) {
     descent: lineDescent,
     xAdvance: lineXAdvance,
   });
-}
+};
 
 /**
  * Finalize line by performing line justification
@@ -108,7 +108,7 @@ function finalizeLine(line) {
  * @param {Object} engines engines
  * @param {Object} options layout options
  */
-function finalizeBlock(engines = {}, options) {
+const finalizeBlock = (engines = {}, options) => {
   /**
    * @param {Object} line lint
    * @param {number} i line index
@@ -128,7 +128,7 @@ function finalizeBlock(engines = {}, options) {
       removeNewLine,
     )(line);
   };
-}
+};
 
 /**
  * Finalize line block by performing line justification
@@ -137,7 +137,7 @@ function finalizeBlock(engines = {}, options) {
  * @param {Object} engines engines
  * @param {Object} options layout options
  */
-export default function finalizeFragments(engines, options) {
+const finalizeFragments = (engines, options) => {
   /**
    * @param {Object[]} blocks line blocks
    * @returns {Object[]} blocks
@@ -146,4 +146,6 @@ export default function finalizeFragments(engines, options) {
     const blockFinalizer = finalizeBlock(engines, options);
     return blocks.map((block) => block.map(blockFinalizer));
   };
-}
+};
+
+export default finalizeFragments;

--- a/packages/textkit/src/layout/generateGlyphs.js
+++ b/packages/textkit/src/layout/generateGlyphs.js
@@ -1,14 +1,26 @@
 import scale from '../run/scale';
 import resolveGlyphIndices from '../indices/resolve';
 
-const getCharacterSpacing = (run) => run.attributes?.characterSpacing || 0;
+/**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Position} Position
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
+ * @param {Run} run
+ * @returns {number}
+ */
+function getCharacterSpacing(run) {
+  return run.attributes?.characterSpacing || 0;
+}
 
 /**
  * Scale run positions
  *
- * @param {Object} run
- * @param {Object[]} positions
- * @returns {Object[]} scaled positions
+ * @param {Run} run
+ * @param {Position[]} positions
+ * @returns {Position[]} scaled positions
  */
 const scalePositions = (run, positions) => {
   const runScale = scale(run);
@@ -28,50 +40,45 @@ const scalePositions = (run, positions) => {
 };
 
 /**
- * @typedef {Function} LayoutRun
- * @param {Object} run run
- * @returns {Object} glyph run
- */
-
-/**
  * Create glyph run
  *
  * @param {string} string string
- * @returns {LayoutRun} layout run
  */
-const layoutRun = (string) => (run) => {
-  const { start, end, attributes = {} } = run;
-  const { font } = attributes;
+function layoutRun(string) {
+  /**
+   * @param {Run} run run
+   * @returns {Run} glyph run
+   */
+  return (run) => {
+    const { start, end, attributes = {} } = run;
+    const { font } = attributes;
 
-  if (!font) return { ...run, glyphs: [], glyphIndices: [], positions: [] };
+    if (!font) return { ...run, glyphs: [], glyphIndices: [], positions: [] };
 
-  const runString = string.slice(start, end);
-  const glyphRun = font.layout(runString);
-  const positions = scalePositions(run, glyphRun.positions);
-  const glyphIndices = resolveGlyphIndices(glyphRun.glyphs);
+    const runString = string.slice(start, end);
+    const glyphRun = font.layout(runString);
+    const positions = scalePositions(run, glyphRun.positions);
+    const glyphIndices = resolveGlyphIndices(glyphRun.glyphs);
 
-  return {
-    ...run,
-    positions,
-    glyphIndices,
-    glyphs: glyphRun.glyphs,
+    return {
+      ...run,
+      positions,
+      glyphIndices,
+      glyphs: glyphRun.glyphs,
+    };
   };
-};
-
-/**
- * @typedef {Function} GenerateGlyphs
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string with glyphs
- */
+}
 
 /**
  * Generate glyphs for single attributed string
- *
- * @returns {GenerateGlyphs} generate glyphs
  */
-const generateGlyphs = () => (attributedString) => {
-  const runs = attributedString.runs.map(layoutRun(attributedString.string));
-  return Object.assign({}, attributedString, { runs });
-};
-
-export default generateGlyphs;
+export default function generateGlyphs() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string with glyphs
+   */
+  return (attributedString) => {
+    const runs = attributedString.runs.map(layoutRun(attributedString.string));
+    return Object.assign({}, attributedString, { runs });
+  };
+}

--- a/packages/textkit/src/layout/generateGlyphs.js
+++ b/packages/textkit/src/layout/generateGlyphs.js
@@ -11,9 +11,9 @@ import resolveGlyphIndices from '../indices/resolve';
  * @param {Run} run
  * @returns {number}
  */
-function getCharacterSpacing(run) {
+const getCharacterSpacing = (run) => {
   return run.attributes?.characterSpacing || 0;
-}
+};
 
 /**
  * Scale run positions
@@ -44,7 +44,7 @@ const scalePositions = (run, positions) => {
  *
  * @param {string} string string
  */
-function layoutRun(string) {
+const layoutRun = (string) => {
   /**
    * @param {Run} run run
    * @returns {Run} glyph run
@@ -67,12 +67,12 @@ function layoutRun(string) {
       glyphs: glyphRun.glyphs,
     };
   };
-}
+};
 
 /**
  * Generate glyphs for single attributed string
  */
-export default function generateGlyphs() {
+const generateGlyphs = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string with glyphs
@@ -81,4 +81,6 @@ export default function generateGlyphs() {
     const runs = attributedString.runs.map(layoutRun(attributedString.string));
     return Object.assign({}, attributedString, { runs });
   };
-}
+};
+
+export default generateGlyphs;

--- a/packages/textkit/src/layout/index.js
+++ b/packages/textkit/src/layout/index.js
@@ -12,11 +12,8 @@ import applyDefaultStyles from './applyDefaultStyles';
 import verticalAlignment from './verticalAlign';
 
 /**
- * @typedef {Function} LayoutEngine
- * @param {Object} attributedString attributed string
- * @param {Object} container container rect
- * @param {Object} options layout options
- * @returns {Object[]} paragraph blocks
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Rect} Rect
  */
 
 /**
@@ -27,11 +24,15 @@ import verticalAlignment from './verticalAlign';
  * layout behavior.
  *
  * @param {Object} engines engines
- * @returns {LayoutEngine} layout engine
  */
-const layoutEngine =
-  (engines) =>
-  (attributedString, container, options = {}) => {
+export default function layoutEngine(engines) {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @param {Rect} container container rect
+   * @param {Object} options layout options
+   * @returns {Object[]} paragraph blocks
+   */
+  return (attributedString, container, options = {}) => {
     const processParagraph = compose(
       resolveYOffset(),
       resolveAttachments(),
@@ -51,5 +52,4 @@ const layoutEngine =
       applyDefaultStyles(),
     )(attributedString);
   };
-
-export default layoutEngine;
+}

--- a/packages/textkit/src/layout/index.js
+++ b/packages/textkit/src/layout/index.js
@@ -25,7 +25,7 @@ import verticalAlignment from './verticalAlign';
  *
  * @param {Object} engines engines
  */
-export default function layoutEngine(engines) {
+const layoutEngine = (engines) => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @param {Rect} container container rect
@@ -52,4 +52,6 @@ export default function layoutEngine(engines) {
       applyDefaultStyles(),
     )(attributedString);
   };
-}
+};
+
+export default layoutEngine;

--- a/packages/textkit/src/layout/layoutParagraph.js
+++ b/packages/textkit/src/layout/layoutParagraph.js
@@ -70,7 +70,7 @@ const layoutLines = (rects, lines, indent) => {
  * @param {Object} engines engines
  * @param {Object} options layout options
  */
-export default function layoutParagraph(engines, options) {
+const layoutParagraph = (engines, options) => {
   /**
    * @param {Rect} container rect
    * @param {Object} paragraph attributed string
@@ -88,4 +88,6 @@ export default function layoutParagraph(engines, options) {
 
     return layoutLines(rects, lines, indent);
   };
-}
+};
+
+export default layoutParagraph;

--- a/packages/textkit/src/layout/layoutParagraph.js
+++ b/packages/textkit/src/layout/layoutParagraph.js
@@ -5,10 +5,15 @@ import generateLineRects from './generateLineRects';
 const ATTACHMENT_CODE = '\ufffc'; // 65532
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Remove attachment attribute if no char present
  *
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string
+ * @param {AttributedString} attributedString attributed string
+ * @returns {AttributedString} attributed string
  */
 const purgeAttachments = (attributedString) => {
   const shouldPurge = !attributedString.string.includes(ATTACHMENT_CODE);
@@ -60,30 +65,27 @@ const layoutLines = (rects, lines, indent) => {
 };
 
 /**
- * @typedef {Function} LayoutParagraph
- * @param {Object} container rect
- * @param {Object} paragraph attributed string
- * @returns {Object} layout block
- */
-
-/**
  * Performs line breaking and layout
  *
  * @param {Object} engines engines
  * @param {Object} options layout options
- * @returns {LayoutParagraph} layout paragraph
  */
-const layoutParagraph = (engines, options) => (container, paragraph) => {
-  const height = stringHeight(paragraph);
-  const indent = paragraph.runs?.[0]?.attributes?.indent || 0;
-  const rects = generateLineRects(container, height);
+export default function layoutParagraph(engines, options) {
+  /**
+   * @param {Rect} container rect
+   * @param {Object} paragraph attributed string
+   * @returns {Object} layout block
+   */
+  return (container, paragraph) => {
+    const height = stringHeight(paragraph);
+    const indent = paragraph.runs?.[0]?.attributes?.indent || 0;
+    const rects = generateLineRects(container, height);
 
-  const availableWidths = rects.map((r) => r.width);
-  availableWidths[0] -= indent;
+    const availableWidths = rects.map((r) => r.width);
+    availableWidths[0] -= indent;
 
-  const lines = engines.linebreaker(options)(paragraph, availableWidths);
+    const lines = engines.linebreaker(options)(paragraph, availableWidths);
 
-  return layoutLines(rects, lines, indent);
-};
-
-export default layoutParagraph;
+    return layoutLines(rects, lines, indent);
+  };
+}

--- a/packages/textkit/src/layout/preprocessRuns.js
+++ b/packages/textkit/src/layout/preprocessRuns.js
@@ -13,10 +13,10 @@ import empty from '../attributedString/empty';
  * @param {AttributedString} attributedString
  * @returns {AttributedString} attributed string without font
  */
-function omitFont(attributedString) {
+const omitFont = (attributedString) => {
   const runs = attributedString.runs.map((run) => omit('font', run));
   return Object.assign({}, attributedString, { runs });
-}
+};
 
 /**
  * Performs font substitution and script itemization on attributed string
@@ -24,7 +24,7 @@ function omitFont(attributedString) {
  * @param {Object} engines engines
  * @param {Object} options layout options
  */
-export default function preprocessRuns(engines, options) {
+const preprocessRuns = (engines, options) => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} processed attributed string
@@ -46,4 +46,6 @@ export default function preprocessRuns(engines, options) {
 
     return { string, runs: flatten(runs) };
   };
-}
+};
+
+export default preprocessRuns;

--- a/packages/textkit/src/layout/preprocessRuns.js
+++ b/packages/textkit/src/layout/preprocessRuns.js
@@ -4,37 +4,46 @@ import omit from '../run/omit';
 import flatten from '../run/flatten';
 import empty from '../attributedString/empty';
 
-const omitFont = (attributedString) => {
-  const runs = attributedString.runs.map((run) => omit('font', run));
-  return Object.assign({}, attributedString, { runs });
-};
+/**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
 
 /**
- * @typedef {Function} PreprocessRuns
- * @param {Object} attributedString attributed string
- * @returns {Object} processed attributed string
+ *
+ * @param {AttributedString} attributedString
+ * @returns {AttributedString} attributed string without font
  */
+function omitFont(attributedString) {
+  const runs = attributedString.runs.map((run) => omit('font', run));
+  return Object.assign({}, attributedString, { runs });
+}
 
 /**
  * Performs font substitution and script itemization on attributed string
  *
  * @param {Object} engines engines
  * @param {Object} options layout options
- * @returns {PreprocessRuns} preprocess runs
  */
-const preprocessRuns = (engines, options) => (attributedString) => {
-  if (isNil(attributedString)) return empty();
+export default function preprocessRuns(engines, options) {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} processed attributed string
+   */
+  return (attributedString) => {
+    if (isNil(attributedString)) return empty();
 
-  const { string } = attributedString;
-  const { fontSubstitution, scriptItemizer } = engines;
+    const { string } = attributedString;
+    const { fontSubstitution, scriptItemizer } = engines;
 
-  const { runs: omittedFontRuns } = omitFont(attributedString);
-  const { runs: substitutedRuns } = fontSubstitution(options)(attributedString);
-  const { runs: itemizationRuns } = scriptItemizer(options)(attributedString);
+    const { runs: omittedFontRuns } = omitFont(attributedString);
+    const { runs: substitutedRuns } =
+      fontSubstitution(options)(attributedString);
+    const { runs: itemizationRuns } = scriptItemizer(options)(attributedString);
 
-  const runs = substitutedRuns.concat(itemizationRuns).concat(omittedFontRuns);
+    const runs = substitutedRuns
+      .concat(itemizationRuns)
+      .concat(omittedFontRuns);
 
-  return { string, runs: flatten(runs) };
-};
-
-export default preprocessRuns;
+    return { string, runs: flatten(runs) };
+  };
+}

--- a/packages/textkit/src/layout/resolveAttachments.js
+++ b/packages/textkit/src/layout/resolveAttachments.js
@@ -1,3 +1,7 @@
+/**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
 const ATTACHMENT_CODE = 0xfffc; // 65532
 
 const isReplaceGlyph = (glyph) => glyph.codePoints.includes(ATTACHMENT_CODE);
@@ -28,19 +32,15 @@ const resolveRunAttachments = (run) => {
 };
 
 /**
- * @typedef {Function} AttachmentResolver
- * @param {string} attributedString attributed string
- * @returns {string} attributed string
- */
-
-/**
  * Resolve attachments for multiple paragraphs
- *
- * @returns {AttachmentResolver} attachmentResolver
  */
-const resolveAttachments = () => (attributedString) => {
-  const runs = attributedString.runs.map(resolveRunAttachments);
-  return Object.assign({}, attributedString, { runs });
-};
-
-export default resolveAttachments;
+export default function resolveAttachments() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string
+   */
+  return (attributedString) => {
+    const runs = attributedString.runs.map(resolveRunAttachments);
+    return Object.assign({}, attributedString, { runs });
+  };
+}

--- a/packages/textkit/src/layout/resolveAttachments.js
+++ b/packages/textkit/src/layout/resolveAttachments.js
@@ -34,7 +34,7 @@ const resolveRunAttachments = (run) => {
 /**
  * Resolve attachments for multiple paragraphs
  */
-export default function resolveAttachments() {
+const resolveAttachments = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string
@@ -43,4 +43,6 @@ export default function resolveAttachments() {
     const runs = attributedString.runs.map(resolveRunAttachments);
     return Object.assign({}, attributedString, { runs });
   };
-}
+};
+
+export default resolveAttachments;

--- a/packages/textkit/src/layout/resolveYOffset.js
+++ b/packages/textkit/src/layout/resolveYOffset.js
@@ -9,7 +9,7 @@
  * @param {Run} run run
  * @returns {Run} run
  */
-function resolveRunYOffset(run) {
+const resolveRunYOffset = (run) => {
   if (!run.positions) return run;
 
   const unitsPerEm = run.attributes?.font?.unitsPerEm || 0;
@@ -17,12 +17,12 @@ function resolveRunYOffset(run) {
   const positions = run.positions.map((p) => Object.assign({}, p, { yOffset }));
 
   return Object.assign({}, run, { positions });
-}
+};
 
 /**
  * Resolves yOffset for multiple paragraphs
  */
-export default function resolveYOffset() {
+const resolveYOffset = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string
@@ -31,4 +31,6 @@ export default function resolveYOffset() {
     const runs = attributedString.runs.map(resolveRunYOffset);
     return Object.assign({}, attributedString, { runs });
   };
-}
+};
+
+export default resolveYOffset;

--- a/packages/textkit/src/layout/resolveYOffset.js
+++ b/packages/textkit/src/layout/resolveYOffset.js
@@ -1,10 +1,15 @@
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Resolves yOffset for run
  *
- * @param {Object}  run
- * @returns {Object} run
+ * @param {Run} run run
+ * @returns {Run} run
  */
-const resolveRunYOffset = (run) => {
+function resolveRunYOffset(run) {
   if (!run.positions) return run;
 
   const unitsPerEm = run.attributes?.font?.unitsPerEm || 0;
@@ -12,22 +17,18 @@ const resolveRunYOffset = (run) => {
   const positions = run.positions.map((p) => Object.assign({}, p, { yOffset }));
 
   return Object.assign({}, run, { positions });
-};
-
-/**
- * @typedef {Function} YOffsetResolver
- * @param {string} attributedString attributed string
- * @returns {string} attributed string
- */
+}
 
 /**
  * Resolves yOffset for multiple paragraphs
- *
- * @returns {YOffsetResolver} yOffsetResolver
  */
-const resolveYOffset = () => (attributedString) => {
-  const runs = attributedString.runs.map(resolveRunYOffset);
-  return Object.assign({}, attributedString, { runs });
-};
-
-export default resolveYOffset;
+export default function resolveYOffset() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string
+   */
+  return (attributedString) => {
+    const runs = attributedString.runs.map(resolveRunYOffset);
+    return Object.assign({}, attributedString, { runs });
+  };
+}

--- a/packages/textkit/src/layout/splitParagraphs.js
+++ b/packages/textkit/src/layout/splitParagraphs.js
@@ -2,35 +2,37 @@ import length from '../attributedString/length';
 import slice from '../attributedString/slice';
 
 /**
- * @typedef {Function} SplitParagraphs
- * @param {Object} attributedString attributed string
- * @returns {Object[]} attributed string array
+ * @typedef {import('../types.js').AttributedString} AttributedString
  */
 
 /**
  * Breaks attributed string into paragraphs
- *
- * @returns {SplitParagraphs} split paragraphs
  */
-const splitParagraphs = () => (attributedString) => {
-  const res = [];
+function splitParagraphs() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString[]} attributed string array
+   */
+  return (attributedString) => {
+    const res = [];
 
-  let start = 0;
-  let breakPoint = attributedString.string.indexOf('\n') + 1;
+    let start = 0;
+    let breakPoint = attributedString.string.indexOf('\n') + 1;
 
-  while (breakPoint > 0) {
-    res.push(slice(start, breakPoint, attributedString));
-    start = breakPoint;
-    breakPoint = attributedString.string.indexOf('\n', breakPoint) + 1;
-  }
+    while (breakPoint > 0) {
+      res.push(slice(start, breakPoint, attributedString));
+      start = breakPoint;
+      breakPoint = attributedString.string.indexOf('\n', breakPoint) + 1;
+    }
 
-  if (start === 0) {
-    res.push(attributedString);
-  } else if (start < attributedString.string.length) {
-    res.push(slice(start, length(attributedString), attributedString));
-  }
+    if (start === 0) {
+      res.push(attributedString);
+    } else if (start < attributedString.string.length) {
+      res.push(slice(start, length(attributedString), attributedString));
+    }
 
-  return res;
-};
+    return res;
+  };
+}
 
 export default splitParagraphs;

--- a/packages/textkit/src/layout/splitParagraphs.js
+++ b/packages/textkit/src/layout/splitParagraphs.js
@@ -8,7 +8,7 @@ import slice from '../attributedString/slice';
 /**
  * Breaks attributed string into paragraphs
  */
-function splitParagraphs() {
+const splitParagraphs = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString[]} attributed string array
@@ -33,6 +33,6 @@ function splitParagraphs() {
 
     return res;
   };
-}
+};
 
 export default splitParagraphs;

--- a/packages/textkit/src/layout/typesetter.js
+++ b/packages/textkit/src/layout/typesetter.js
@@ -20,7 +20,7 @@ import sliceBlockAtHeight from '../block/sliceAtHeight';
  * @param {Object} options layout options
  * @param {Rect} container container rect
  */
-export default function typesetter(engines, options, container) {
+const typesetter = (engines, options, container) => {
   /**
    * @param {AttributedString} attributedStrings attributed strings (paragraphs)
    * @returns {Object[]} paragraph blocks
@@ -60,4 +60,6 @@ export default function typesetter(engines, options, container) {
 
     return blocks;
   };
-}
+};
+
+export default typesetter;

--- a/packages/textkit/src/layout/typesetter.js
+++ b/packages/textkit/src/layout/typesetter.js
@@ -8,9 +8,8 @@ import layoutParagraph from './layoutParagraph';
 import sliceBlockAtHeight from '../block/sliceAtHeight';
 
 /**
- * @typedef {Function} TypeSetter
- * @param {Object} attributedStrings attributed strings (paragraphs)
- * @returns {Object[]} paragraph blocks
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ * @typedef {import('../types.js').Rect} Rect
  */
 
 /**
@@ -19,43 +18,46 @@ import sliceBlockAtHeight from '../block/sliceAtHeight';
  *
  * @param {Object} engines engines
  * @param {Object} options layout options
- * @param {Object} container container rect
- * @returns {TypeSetter} type setter
+ * @param {Rect} container container rect
  */
-const typesetter = (engines, options, container) => (attributedStrings) => {
-  const blocks = [];
-  const paragraphs = [...attributedStrings];
-  const layoutBlock = layoutParagraph(engines, options);
-  const maxLines = isNil(container.maxLines) ? Infinity : container.maxLines;
-  const truncateEllipsis = container.truncateMode === 'ellipsis';
+export default function typesetter(engines, options, container) {
+  /**
+   * @param {AttributedString} attributedStrings attributed strings (paragraphs)
+   * @returns {Object[]} paragraph blocks
+   */
+  return (attributedStrings) => {
+    const blocks = [];
+    const paragraphs = [...attributedStrings];
+    const layoutBlock = layoutParagraph(engines, options);
+    const maxLines = isNil(container.maxLines) ? Infinity : container.maxLines;
+    const truncateEllipsis = container.truncateMode === 'ellipsis';
 
-  let linesCount = maxLines;
-  let paragraphRect = copyRect(container);
-  let nextParagraph = paragraphs.shift();
+    let linesCount = maxLines;
+    let paragraphRect = copyRect(container);
+    let nextParagraph = paragraphs.shift();
 
-  while (linesCount > 0 && nextParagraph) {
-    const block = layoutBlock(paragraphRect, nextParagraph);
-    const slicedBlock = block.slice(0, linesCount);
-    const linesHeight = blockHeight(slicedBlock);
+    while (linesCount > 0 && nextParagraph) {
+      const block = layoutBlock(paragraphRect, nextParagraph);
+      const slicedBlock = block.slice(0, linesCount);
+      const linesHeight = blockHeight(slicedBlock);
 
-    const shouldTruncate =
-      truncateEllipsis && block.length !== slicedBlock.length;
+      const shouldTruncate =
+        truncateEllipsis && block.length !== slicedBlock.length;
 
-    linesCount -= slicedBlock.length;
+      linesCount -= slicedBlock.length;
 
-    if (paragraphRect.height >= linesHeight) {
-      blocks.push(shouldTruncate ? truncateBlock(slicedBlock) : slicedBlock);
-      paragraphRect = cropRect(linesHeight, paragraphRect);
-      nextParagraph = paragraphs.shift();
-    } else {
-      blocks.push(
-        truncateBlock(sliceBlockAtHeight(paragraphRect.height, slicedBlock)),
-      );
-      break;
+      if (paragraphRect.height >= linesHeight) {
+        blocks.push(shouldTruncate ? truncateBlock(slicedBlock) : slicedBlock);
+        paragraphRect = cropRect(linesHeight, paragraphRect);
+        nextParagraph = paragraphs.shift();
+      } else {
+        blocks.push(
+          truncateBlock(sliceBlockAtHeight(paragraphRect.height, slicedBlock)),
+        );
+        break;
+      }
     }
-  }
 
-  return blocks;
-};
-
-export default typesetter;
+    return blocks;
+  };
+}

--- a/packages/textkit/src/layout/verticalAlign.js
+++ b/packages/textkit/src/layout/verticalAlign.js
@@ -1,28 +1,28 @@
 /* eslint-disable no-restricted-syntax */
 
 /**
- * @typedef {Function} VerticalAlignment
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string
+ * @typedef {import('../types.js').AttributedString} AttributedString
  */
 
 /**
  * Apply scaling and yOffset for verticalAlign 'sub' and 'super'.
- *
- * @returns {VerticalAlignment} verticalAlignment
  */
-const verticalAlignment = () => (attributedString) => {
-  attributedString.runs.forEach((run) => {
-    const { attributes } = run;
-    const { verticalAlign } = attributes;
+export default function verticalAlignment() {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string
+   */
+  return (attributedString) => {
+    attributedString.runs.forEach((run) => {
+      const { attributes } = run;
+      const { verticalAlign } = attributes;
 
-    if (verticalAlign === 'sub') {
-      attributes.yOffset = -0.2;
-    } else if (verticalAlign === 'super') {
-      attributes.yOffset = 0.4;
-    }
-  });
-  return attributedString;
-};
-
-export default verticalAlignment;
+      if (verticalAlign === 'sub') {
+        attributes.yOffset = -0.2;
+      } else if (verticalAlign === 'super') {
+        attributes.yOffset = 0.4;
+      }
+    });
+    return attributedString;
+  };
+}

--- a/packages/textkit/src/layout/verticalAlign.js
+++ b/packages/textkit/src/layout/verticalAlign.js
@@ -7,7 +7,7 @@
 /**
  * Apply scaling and yOffset for verticalAlign 'sub' and 'super'.
  */
-export default function verticalAlignment() {
+const verticalAlignment = () => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string
@@ -25,4 +25,6 @@ export default function verticalAlignment() {
     });
     return attributedString;
   };
-}
+};
+
+export default verticalAlignment;

--- a/packages/textkit/src/layout/wrapWords.js
+++ b/packages/textkit/src/layout/wrapWords.js
@@ -1,6 +1,10 @@
 import fromFragments from '../attributedString/fromFragments';
 
 /**
+ * @typedef {import('../types.js').AttributedString} AttributedString
+ */
+
+/**
  * Default word hyphenation engine used when no one provided.
  * Does not perform word hyphenation at all
  *
@@ -10,21 +14,17 @@ import fromFragments from '../attributedString/fromFragments';
 const defaultHyphenationEngine = (word) => [word];
 
 /**
- * @typedef {Function} HyphenationCallback
- * @param {Object} attributedString attributed string
- * @returns {Object} attributed string including syllables
- */
-
-/**
  * Wrap words of attribute string
  *
  * @param {Object} engines layout engines
  * @param {Object} options layout options
- * @returns {HyphenationCallback} hyphenation callback
  */
-const wrapWords =
-  (engines = {}, options = {}) =>
-  (attributedString) => {
+export default function wrapWords(engines = {}, options = {}) {
+  /**
+   * @param {AttributedString} attributedString attributed string
+   * @returns {AttributedString} attributed string including syllables
+   */
+  return (attributedString) => {
     const syllables = [];
     const fragments = [];
 
@@ -54,5 +54,4 @@ const wrapWords =
 
     return { ...fromFragments(fragments), syllables };
   };
-
-export default wrapWords;
+}

--- a/packages/textkit/src/layout/wrapWords.js
+++ b/packages/textkit/src/layout/wrapWords.js
@@ -19,7 +19,7 @@ const defaultHyphenationEngine = (word) => [word];
  * @param {Object} engines layout engines
  * @param {Object} options layout options
  */
-export default function wrapWords(engines = {}, options = {}) {
+const wrapWords = (engines = {}, options = {}) => {
   /**
    * @param {AttributedString} attributedString attributed string
    * @returns {AttributedString} attributed string including syllables
@@ -54,4 +54,6 @@ export default function wrapWords(engines = {}, options = {}) {
 
     return { ...fromFragments(fragments), syllables };
   };
-}
+};
+
+export default wrapWords;

--- a/packages/textkit/src/positions/advanceWidth.js
+++ b/packages/textkit/src/positions/advanceWidth.js
@@ -8,6 +8,8 @@
  * @param {Position[]} positions positions
  * @returns {number} advance width
  */
-export default function advanceWidth(positions) {
+const advanceWidth = (positions) => {
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);
-}
+};
+
+export default advanceWidth;

--- a/packages/textkit/src/positions/advanceWidth.js
+++ b/packages/textkit/src/positions/advanceWidth.js
@@ -1,11 +1,13 @@
 /**
+ * @typedef {import('../types.js').Position} Position
+ */
+
+/**
  * Return positions advance width
  *
- * @param {Object}  positions
+ * @param {Position[]} positions positions
  * @returns {number} advance width
  */
-const advanceWidth = (positions) => {
+export default function advanceWidth(positions) {
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);
-};
-
-export default advanceWidth;
+}

--- a/packages/textkit/src/rect/area.js
+++ b/packages/textkit/src/rect/area.js
@@ -8,6 +8,8 @@
  * @param {Rect} [rect] rect
  * @returns {number} rect area
  */
-export default function area(rect) {
+const area = (rect) => {
   return rect ? rect.height * rect.width : 0;
-}
+};
+
+export default area;

--- a/packages/textkit/src/rect/area.js
+++ b/packages/textkit/src/rect/area.js
@@ -1,11 +1,13 @@
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Returns rect area
  *
- * @param {Object}  rect
+ * @param {Rect} [rect] rect
  * @returns {number} rect area
  */
-const area = (rect) => {
+export default function area(rect) {
   return rect ? rect.height * rect.width : 0;
-};
-
-export default area;
+}

--- a/packages/textkit/src/rect/bottomLeft.js
+++ b/packages/textkit/src/rect/bottomLeft.js
@@ -12,6 +12,8 @@ const ZERO = { x: 0, y: 0 };
  * @param {Rect} [rect] rect
  * @returns {{ x: number, y: number }} bottom left point
  */
-export default function bottomLeft(rect) {
+const bottomLeft = (rect) => {
   return rect ? { x: rect.x || 0, y: maxY(rect) } : ZERO;
-}
+};
+
+export default bottomLeft;

--- a/packages/textkit/src/rect/bottomLeft.js
+++ b/packages/textkit/src/rect/bottomLeft.js
@@ -1,15 +1,17 @@
 import maxY from './maxY';
 
+/**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
 const ZERO = { x: 0, y: 0 };
 
 /**
  * Returns rect bottom left point
  *
- * @param {Object} rect rect
+ * @param {Rect} [rect] rect
  * @returns {{ x: number, y: number }} bottom left point
  */
-const bottomLeft = (rect) => {
+export default function bottomLeft(rect) {
   return rect ? { x: rect.x || 0, y: maxY(rect) } : ZERO;
-};
-
-export default bottomLeft;
+}

--- a/packages/textkit/src/rect/bottomRight.js
+++ b/packages/textkit/src/rect/bottomRight.js
@@ -2,9 +2,13 @@ import maxX from './maxX';
 import maxY from './maxY';
 
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Returns rect bottom right point
  *
- * @param {Object} rect rect
+ * @param {Rect} rect rect
  * @returns {{ x:number, y:number }} bottom right point
  */
 const bottomRight = (rect) => ({ x: maxX(rect), y: maxY(rect) });

--- a/packages/textkit/src/rect/copy.js
+++ b/packages/textkit/src/rect/copy.js
@@ -8,6 +8,8 @@
  * @param {Rect} rect rect
  * @returns {Rect} cloned rect
  */
-export default function copy(rect) {
+const copy = (rect) => {
   return Object.assign({}, rect);
-}
+};
+
+export default copy;

--- a/packages/textkit/src/rect/copy.js
+++ b/packages/textkit/src/rect/copy.js
@@ -1,9 +1,13 @@
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Clone rect
  *
- * @param {Object}  rect
- * @returns {Object} cloned rect
+ * @param {Rect} rect rect
+ * @returns {Rect} cloned rect
  */
-const copy = (rect) => Object.assign({}, rect);
-
-export default copy;
+export default function copy(rect) {
+  return Object.assign({}, rect);
+}

--- a/packages/textkit/src/rect/crop.js
+++ b/packages/textkit/src/rect/crop.js
@@ -11,7 +11,9 @@ import partition from './partition';
  * @param {Rect} rect rect
  * @returns {Rect} cropped rect
  */
-export default function crop(height, rect) {
+const crop = (height, rect) => {
   const [, result] = partition(rect, height);
   return result;
-}
+};
+
+export default crop;

--- a/packages/textkit/src/rect/crop.js
+++ b/packages/textkit/src/rect/crop.js
@@ -1,14 +1,17 @@
 import partition from './partition';
 
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Crop upper section of rect
  *
- * @param {Object}  rect
- * @returns {Object} cropped rect
+ * @param {number} height height
+ * @param {Rect} rect rect
+ * @returns {Rect} cropped rect
  */
-const crop = (height, rect) => {
+export default function crop(height, rect) {
   const [, result] = partition(rect, height);
   return result;
-};
-
-export default crop;
+}

--- a/packages/textkit/src/rect/empty.js
+++ b/packages/textkit/src/rect/empty.js
@@ -1,13 +1,17 @@
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Returns empty rect
  *
- * @returns {Object} empty rect
+ * @returns {Rect} empty rect
  */
-const empty = () => ({
-  x: 0,
-  y: 0,
-  width: 0,
-  height: 0,
-});
-
-export default empty;
+export default function empty() {
+  return {
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+  };
+}

--- a/packages/textkit/src/rect/empty.js
+++ b/packages/textkit/src/rect/empty.js
@@ -7,11 +7,13 @@
  *
  * @returns {Rect} empty rect
  */
-export default function empty() {
+const empty = () => {
   return {
     x: 0,
     y: 0,
     width: 0,
     height: 0,
   };
-}
+};
+
+export default empty;

--- a/packages/textkit/src/rect/equals.js
+++ b/packages/textkit/src/rect/equals.js
@@ -1,15 +1,17 @@
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Check if two rect are equal
  *
  * @param {Object} a rect A
  * @param {Object} b rect B
- * @returns {boolean} rects are equal
+ * @returns {boolean} whether rects are equal
  *
  */
-const equals = (a, b) => {
+export default function equals(a, b) {
   return (
     a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
   );
-};
-
-export default equals;
+}

--- a/packages/textkit/src/rect/equals.js
+++ b/packages/textkit/src/rect/equals.js
@@ -10,8 +10,10 @@
  * @returns {boolean} whether rects are equal
  *
  */
-export default function equals(a, b) {
+const equals = (a, b) => {
   return (
     a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
   );
-}
+};
+
+export default equals;

--- a/packages/textkit/src/rect/intersects.js
+++ b/packages/textkit/src/rect/intersects.js
@@ -1,25 +1,19 @@
 /**
- * @typedef {Object} Rect
- * @property {number} x
- * @property {number} y
- * @property {number} width
- * @property {number} height
+ * @typedef {import('../types.js').Rect} Rect
  */
 
 /**
  * Checks if two rects intersect each other
  *
- * @param {Rect} a
- * @param {Rect} b
- * @returns {boolean} rects intersects
+ * @param {Rect} a rect A
+ * @param {Rect} b rect B
+ * @returns {boolean} whether rects intersect
  */
-const intersects = (a, b) => {
+export default function intersects(a, b) {
   const x = Math.max(a.x, b.x);
   const num1 = Math.min(a.x + a.width, b.x + b.width);
   const y = Math.max(a.y, b.y);
   const num2 = Math.min(a.y + a.height, b.y + b.height);
 
   return num1 >= x && num2 >= y;
-};
-
-export default intersects;
+}

--- a/packages/textkit/src/rect/intersects.js
+++ b/packages/textkit/src/rect/intersects.js
@@ -9,11 +9,13 @@
  * @param {Rect} b rect B
  * @returns {boolean} whether rects intersect
  */
-export default function intersects(a, b) {
+const intersects = (a, b) => {
   const x = Math.max(a.x, b.x);
   const num1 = Math.min(a.x + a.width, b.x + b.width);
   const y = Math.max(a.y, b.y);
   const num2 = Math.min(a.y + a.height, b.y + b.height);
 
   return num1 >= x && num2 >= y;
-}
+};
+
+export default intersects;

--- a/packages/textkit/src/rect/maxX.js
+++ b/packages/textkit/src/rect/maxX.js
@@ -8,6 +8,8 @@
  * @param {Rect} [rect] rect
  * @returns {number} x coordinate
  */
-export default function maxX(rect) {
+const maxX = (rect) => {
   return rect ? rect.x + rect.width : 0;
-}
+};
+
+export default maxX;

--- a/packages/textkit/src/rect/maxX.js
+++ b/packages/textkit/src/rect/maxX.js
@@ -1,11 +1,13 @@
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Returns max rect X coordinate
  *
- * @param {Object}  rect
+ * @param {Rect} [rect] rect
  * @returns {number} x coordinate
  */
-const maxX = (rect) => {
+export default function maxX(rect) {
   return rect ? rect.x + rect.width : 0;
-};
-
-export default maxX;
+}

--- a/packages/textkit/src/rect/maxY.js
+++ b/packages/textkit/src/rect/maxY.js
@@ -1,11 +1,13 @@
 /**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
  * Returns max rect Y coordinate
  *
- * @param {Object}  rect
+ * @param {Rect} [rect] rect
  * @returns {number} y coordinate
  */
-const maxY = (rect) => {
+export default function maxY(rect) {
   return rect ? rect.y + rect.height : 0;
-};
-
-export default maxY;
+}

--- a/packages/textkit/src/rect/maxY.js
+++ b/packages/textkit/src/rect/maxY.js
@@ -8,6 +8,8 @@
  * @param {Rect} [rect] rect
  * @returns {number} y coordinate
  */
-export default function maxY(rect) {
+const maxY = (rect) => {
   return rect ? rect.y + rect.height : 0;
-}
+};
+
+export default maxY;

--- a/packages/textkit/src/rect/partition.js
+++ b/packages/textkit/src/rect/partition.js
@@ -8,7 +8,7 @@
  * @param {number} height height
  * @returns {[Rect, Rect]} partitioned rects
  */
-export default function partition(rect, height) {
+const partition = (rect, height) => {
   const a = Object.assign({}, rect, { height });
 
   const b = Object.assign({}, rect, {
@@ -17,4 +17,6 @@ export default function partition(rect, height) {
   });
 
   return [a, b];
-}
+};
+
+export default partition;

--- a/packages/textkit/src/rect/partition.js
+++ b/packages/textkit/src/rect/partition.js
@@ -1,4 +1,14 @@
-const partition = (rect, height) => {
+/**
+ * @typedef {import('../types.js').Rect} Rect
+ */
+
+/**
+ *
+ * @param {Rect} rect rect
+ * @param {number} height height
+ * @returns {[Rect, Rect]} partitioned rects
+ */
+export default function partition(rect, height) {
   const a = Object.assign({}, rect, { height });
 
   const b = Object.assign({}, rect, {
@@ -7,6 +17,4 @@ const partition = (rect, height) => {
   });
 
   return [a, b];
-};
-
-export default partition;
+}

--- a/packages/textkit/src/run/add.js
+++ b/packages/textkit/src/run/add.js
@@ -1,15 +1,17 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Add scalar to run
  *
  * @param {number} n scalar
- * @param {Object} run run
- * @returns {Object} added run
+ * @param {Run} run run
+ * @returns {Run} added run
  */
-const add = (n, run) => {
+export default function add(n, run) {
   const start = run.start + n;
   const end = run.end + n;
 
   return Object.assign({}, run, { start, end });
-};
-
-export default add;
+}

--- a/packages/textkit/src/run/add.js
+++ b/packages/textkit/src/run/add.js
@@ -9,9 +9,11 @@
  * @param {Run} run run
  * @returns {Run} added run
  */
-export default function add(n, run) {
+const add = (n, run) => {
   const start = run.start + n;
   const end = run.end + n;
 
   return Object.assign({}, run, { start, end });
-}
+};
+
+export default add;

--- a/packages/textkit/src/run/advanceWidth.js
+++ b/packages/textkit/src/run/advanceWidth.js
@@ -1,13 +1,15 @@
 import positionsAdvanceWidth from '../positions/advanceWidth';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Return run advance width
  *
- * @param {Object}  run
+ * @param {Run} run run
  * @returns {number} advance width
  */
-const advanceWidth = (run) => {
+export default function advanceWidth(run) {
   return positionsAdvanceWidth(run.positions || []);
-};
-
-export default advanceWidth;
+}

--- a/packages/textkit/src/run/advanceWidth.js
+++ b/packages/textkit/src/run/advanceWidth.js
@@ -10,6 +10,8 @@ import positionsAdvanceWidth from '../positions/advanceWidth';
  * @param {Run} run run
  * @returns {number} advance width
  */
-export default function advanceWidth(run) {
+const advanceWidth = (run) => {
   return positionsAdvanceWidth(run.positions || []);
-}
+};
+
+export default advanceWidth;

--- a/packages/textkit/src/run/advanceWidthBetween.js
+++ b/packages/textkit/src/run/advanceWidthBetween.js
@@ -13,11 +13,13 @@ import positionsAdvanceWidth from '../positions/advanceWidth';
  * @param {Run} run run
  * @returns {number} advanced width run
  */
-export default function advanceWidthBetween(start, end, run) {
+const advanceWidthBetween = (start, end, run) => {
   const runStart = run.start || 0;
   const glyphStartIndex = Math.max(0, glyphIndexAt(start - runStart, run));
   const glyphEndIndex = Math.max(0, glyphIndexAt(end - runStart, run));
   const positions = (run.positions || []).slice(glyphStartIndex, glyphEndIndex);
 
   return positionsAdvanceWidth(positions);
-}
+};
+
+export default advanceWidthBetween;

--- a/packages/textkit/src/run/advanceWidthBetween.js
+++ b/packages/textkit/src/run/advanceWidthBetween.js
@@ -2,20 +2,22 @@ import glyphIndexAt from './glyphIndexAt';
 import positionsAdvanceWidth from '../positions/advanceWidth';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Advance width between two string indices
  *
- * @param {number}  start glyph index
- * @param {number}  end glyph index
- * @param {Object}  run
- * @returns {Object} advanced width run
+ * @param {number} start glyph index
+ * @param {number} end glyph index
+ * @param {Run} run run
+ * @returns {number} advanced width run
  */
-const advanceWidthBetween = (start, end, run) => {
+export default function advanceWidthBetween(start, end, run) {
   const runStart = run.start || 0;
   const glyphStartIndex = Math.max(0, glyphIndexAt(start - runStart, run));
   const glyphEndIndex = Math.max(0, glyphIndexAt(end - runStart, run));
   const positions = (run.positions || []).slice(glyphStartIndex, glyphEndIndex);
 
   return positionsAdvanceWidth(positions);
-};
-
-export default advanceWidthBetween;
+}

--- a/packages/textkit/src/run/append.js
+++ b/packages/textkit/src/run/append.js
@@ -5,13 +5,18 @@ import appendIndices from '../indices/append';
 import glyphFromCodePoint from '../glyph/fromCodePoint';
 
 /**
+ * @typedef {import('../types.js').Glyph} Glyph
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Append glyph to run
  *
- * @param {Object}  glyph
- * @param {Object}  run
- * @returns {Object} run with glyph
+ * @param {Glyph} glyph glyph
+ * @param {Run} run run
+ * @returns {Run} run with glyph
  */
-const appendGlyph = (glyph, run) => {
+function appendGlyph(glyph, run) {
   const glyphLength = glyph.codePoints?.length || 0;
   const end = run.end + glyphLength;
   const glyphs = run.glyphs.concat(glyph);
@@ -25,22 +30,20 @@ const appendGlyph = (glyph, run) => {
   });
 
   return Object.assign({}, run, { end, glyphs, glyphIndices, positions });
-};
+}
 
 /**
  * Append glyph or code point to run
  *
- * @param {Object | number} value glyph | codePoint
- * @param {Object} run
- * @returns {Object} run with glyph
+ * @param {Glyph | number | undefined} value glyph or codePoint
+ * @param {Run} run run
+ * @returns {Run} run with glyph
  */
-const append = (value, run) => {
+export default function append(value, run) {
   if (!value) return run;
 
   const font = getFont(run);
   const glyph = isNumber(value) ? glyphFromCodePoint(value, font) : value;
 
   return appendGlyph(glyph, run);
-};
-
-export default append;
+}

--- a/packages/textkit/src/run/append.js
+++ b/packages/textkit/src/run/append.js
@@ -16,7 +16,7 @@ import glyphFromCodePoint from '../glyph/fromCodePoint';
  * @param {Run} run run
  * @returns {Run} run with glyph
  */
-function appendGlyph(glyph, run) {
+const appendGlyph = (glyph, run) => {
   const glyphLength = glyph.codePoints?.length || 0;
   const end = run.end + glyphLength;
   const glyphs = run.glyphs.concat(glyph);
@@ -30,7 +30,7 @@ function appendGlyph(glyph, run) {
   });
 
   return Object.assign({}, run, { end, glyphs, glyphIndices, positions });
-}
+};
 
 /**
  * Append glyph or code point to run
@@ -39,11 +39,13 @@ function appendGlyph(glyph, run) {
  * @param {Run} run run
  * @returns {Run} run with glyph
  */
-export default function append(value, run) {
+const append = (value, run) => {
   if (!value) return run;
 
   const font = getFont(run);
   const glyph = isNumber(value) ? glyphFromCodePoint(value, font) : value;
 
   return appendGlyph(glyph, run);
-}
+};
+
+export default append;

--- a/packages/textkit/src/run/ascent.js
+++ b/packages/textkit/src/run/ascent.js
@@ -1,16 +1,18 @@
 import scale from './scale';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run ascent
  *
- * @param {Object} run
+ * @param {Run} run run
  * @returns {number} ascent
  */
-const ascent = (run) => {
+export default function ascent(run) {
   const attachmentHeight = run.attributes?.attachment?.height || 0;
   const fontAscent = run.attributes?.font?.ascent || 0;
 
   return Math.max(attachmentHeight, fontAscent * scale(run));
-};
-
-export default ascent;
+}

--- a/packages/textkit/src/run/ascent.js
+++ b/packages/textkit/src/run/ascent.js
@@ -10,9 +10,11 @@ import scale from './scale';
  * @param {Run} run run
  * @returns {number} ascent
  */
-export default function ascent(run) {
+const ascent = (run) => {
   const attachmentHeight = run.attributes?.attachment?.height || 0;
   const fontAscent = run.attributes?.font?.ascent || 0;
 
   return Math.max(attachmentHeight, fontAscent * scale(run));
-}
+};
+
+export default ascent;

--- a/packages/textkit/src/run/concat.js
+++ b/packages/textkit/src/run/concat.js
@@ -14,7 +14,7 @@ import normalizeIndices from '../indices/normalize';
  * @param {Run} runB second run
  * @returns {Run} concatenated run
  */
-export default function concat(runA, runB) {
+const concat = (runA, runB) => {
   const end = runA.end + length(runB);
 
   const glyphs = (runA.glyphs || []).concat(runB.glyphs || []);
@@ -35,4 +35,6 @@ export default function concat(runA, runB) {
     attributes,
     glyphIndices,
   });
-}
+};
+
+export default concat;

--- a/packages/textkit/src/run/concat.js
+++ b/packages/textkit/src/run/concat.js
@@ -4,13 +4,17 @@ import length from './length';
 import normalizeIndices from '../indices/normalize';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Concats two runs into one
  *
- * @param {Object} runA first run
- * @param {Object} runB second run
- * @returns {Object} concatenated run
+ * @param {Run} runA first run
+ * @param {Run} runB second run
+ * @returns {Run} concatenated run
  */
-const concat = (runA, runB) => {
+export default function concat(runA, runB) {
   const end = runA.end + length(runB);
 
   const glyphs = (runA.glyphs || []).concat(runB.glyphs || []);
@@ -31,6 +35,4 @@ const concat = (runA, runB) => {
     attributes,
     glyphIndices,
   });
-};
-
-export default concat;
+}

--- a/packages/textkit/src/run/descent.js
+++ b/packages/textkit/src/run/descent.js
@@ -10,8 +10,10 @@ import scale from './scale';
  * @param {Run} run run
  * @returns {number} descent
  */
-export default function descent(run) {
+const descent = (run) => {
   const fontDescent = run.attributes?.font?.descent || 0;
 
   return scale(run) * fontDescent;
-}
+};
+
+export default descent;

--- a/packages/textkit/src/run/descent.js
+++ b/packages/textkit/src/run/descent.js
@@ -1,15 +1,17 @@
 import scale from './scale';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run descent
  *
- * @param {Object}  run
+ * @param {Run} run run
  * @returns {number} descent
  */
-const descent = (run) => {
+export default function descent(run) {
   const fontDescent = run.attributes?.font?.descent || 0;
 
   return scale(run) * fontDescent;
-};
-
-export default descent;
+}

--- a/packages/textkit/src/run/dropLast.js
+++ b/packages/textkit/src/run/dropLast.js
@@ -10,6 +10,8 @@ import slice from './slice';
  * @param {Run} run run
  * @returns {Run} run without last char
  */
-export default function dropLast(run) {
+const dropLast = (run) => {
   return slice(0, run.end - run.start - 1, run);
-}
+};
+
+export default dropLast;

--- a/packages/textkit/src/run/dropLast.js
+++ b/packages/textkit/src/run/dropLast.js
@@ -1,11 +1,15 @@
 import slice from './slice';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Drop last char of run
  *
- * @param {Object} run
- * @returns {Object} run without last char
+ * @param {Run} run run
+ * @returns {Run} run without last char
  */
-const dropLast = (run) => slice(0, run.end - run.start - 1, run);
-
-export default dropLast;
+export default function dropLast(run) {
+  return slice(0, run.end - run.start - 1, run);
+}

--- a/packages/textkit/src/run/empty.js
+++ b/packages/textkit/src/run/empty.js
@@ -1,15 +1,19 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Returns empty run
  *
- * @returns {Object} empty run
+ * @returns {Run} empty run
  */
-const empty = () => ({
-  start: 0,
-  end: 0,
-  glyphIndices: [],
-  glyphs: [],
-  positions: [],
-  attributes: {},
-});
-
-export default empty;
+export default function empty() {
+  return {
+    start: 0,
+    end: 0,
+    glyphIndices: [],
+    glyphs: [],
+    positions: [],
+    attributes: {},
+  };
+}

--- a/packages/textkit/src/run/empty.js
+++ b/packages/textkit/src/run/empty.js
@@ -7,7 +7,7 @@
  *
  * @returns {Run} empty run
  */
-export default function empty() {
+const empty = () => {
   return {
     start: 0,
     end: 0,
@@ -16,4 +16,6 @@ export default function empty() {
     positions: [],
     attributes: {},
   };
-}
+};
+
+export default empty;

--- a/packages/textkit/src/run/filter.js
+++ b/packages/textkit/src/run/filter.js
@@ -1,18 +1,20 @@
 import runIndexAt from './runIndexAt';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Filter runs contained between start and end
  *
- * @param {number}  start
- * @param {number}  end
- * @param {Object[]}   runs
- * @returns {Object} filtered runs
+ * @param {number} start
+ * @param {number} end
+ * @param {Run[]} runs
+ * @returns {Run[]} filtered runs
  */
-const filter = (start, end, runs) => {
+export default function filter(start, end, runs) {
   const startIndex = runIndexAt(start, runs);
   const endIndex = Math.max(runIndexAt(end - 1, runs), startIndex);
 
   return runs.slice(startIndex, endIndex + 1);
-};
-
-export default filter;
+}

--- a/packages/textkit/src/run/filter.js
+++ b/packages/textkit/src/run/filter.js
@@ -12,9 +12,11 @@ import runIndexAt from './runIndexAt';
  * @param {Run[]} runs
  * @returns {Run[]} filtered runs
  */
-export default function filter(start, end, runs) {
+const filter = (start, end, runs) => {
   const startIndex = runIndexAt(start, runs);
   const endIndex = Math.max(runIndexAt(end - 1, runs), startIndex);
 
   return runs.slice(startIndex, endIndex + 1);
-}
+};
+
+export default filter;

--- a/packages/textkit/src/run/flatten.js
+++ b/packages/textkit/src/run/flatten.js
@@ -12,15 +12,15 @@ import isEmpty from './isEmpty';
  * @param {Point} b second point
  * @returns {number} sort order
  */
-function sortPoints(a, b) {
+const sortPoints = (a, b) => {
   return a[1] - b[1] || a[3] - b[3];
-}
+};
 
 /**
  * @param {Run[]} runs
  * @returns {Point[]} points
  */
-function generatePoints(runs) {
+const generatePoints = (runs) => {
   const result = runs.reduce((acc, run, i) => {
     return acc.concat([
       ['start', run.start, run.attributes, i],
@@ -29,24 +29,24 @@ function generatePoints(runs) {
   }, []);
 
   return result.sort(sortPoints);
-}
+};
 
 /**
  * @param {Run[]} runs
  * @returns {Run} merged runs
  */
-function mergeRuns(runs) {
+const mergeRuns = (runs) => {
   return runs.reduce((acc, run) => {
     const attributes = Object.assign({}, acc.attributes, run.attributes);
     return Object.assign({}, run, { attributes });
   }, {});
-}
+};
 
 /**
  * @param {Run[]} runs
  * @returns {Run[][]} grouped runs
  */
-function groupEmptyRuns(runs) {
+const groupEmptyRuns = (runs) => {
   const groups = runs.reduce((acc, run) => {
     if (!acc[run.start]) acc[run.start] = [];
     acc[run.start].push(run);
@@ -54,21 +54,21 @@ function groupEmptyRuns(runs) {
   }, []);
 
   return Object.values(groups);
-}
+};
 
 /**
  * @param {Run[]} runs
  * @returns {Run[]} flattened runs
  */
-function flattenEmptyRuns(runs) {
+const flattenEmptyRuns = (runs) => {
   return groupEmptyRuns(runs).map(mergeRuns);
-}
+};
 
 /**
  * @param {Run[]} runs
  * @returns {Run[]} flattened runs
  */
-function flattenRegularRuns(runs) {
+const flattenRegularRuns = (runs) => {
   const res = [];
   const points = generatePoints(runs);
 
@@ -103,7 +103,7 @@ function flattenRegularRuns(runs) {
   }
 
   return res;
-}
+};
 
 /**
  * Flatten many runs
@@ -111,9 +111,11 @@ function flattenRegularRuns(runs) {
  * @param {Run[]} runs
  * @returns {Run[]} flattened runs
  */
-export default function flatten(runs = []) {
+const flatten = (runs = []) => {
   const emptyRuns = flattenEmptyRuns(runs.filter((run) => isEmpty(run)));
   const regularRuns = flattenRegularRuns(runs.filter((run) => !isEmpty(run)));
 
   return sort(emptyRuns.concat(regularRuns));
-}
+};
+
+export default flatten;

--- a/packages/textkit/src/run/flatten.js
+++ b/packages/textkit/src/run/flatten.js
@@ -1,9 +1,26 @@
 import sort from './sort';
 import isEmpty from './isEmpty';
 
-const sortPoints = (a, b) => a[1] - b[1] || a[3] - b[3];
+/**
+ * @typedef {import('../types.js').Point} Point
+ * @typedef {import('../types.js').Run} Run
+ */
 
-const generatePoints = (runs) => {
+/**
+ * Sort points in ascending order
+ * @param {Point} a first point
+ * @param {Point} b second point
+ * @returns {number} sort order
+ */
+function sortPoints(a, b) {
+  return a[1] - b[1] || a[3] - b[3];
+}
+
+/**
+ * @param {Run[]} runs
+ * @returns {Point[]} points
+ */
+function generatePoints(runs) {
   const result = runs.reduce((acc, run, i) => {
     return acc.concat([
       ['start', run.start, run.attributes, i],
@@ -12,29 +29,46 @@ const generatePoints = (runs) => {
   }, []);
 
   return result.sort(sortPoints);
-};
+}
 
-const mergeRuns = (runs) =>
-  runs.reduce((acc, run) => {
+/**
+ * @param {Run[]} runs
+ * @returns {Run} merged runs
+ */
+function mergeRuns(runs) {
+  return runs.reduce((acc, run) => {
     const attributes = Object.assign({}, acc.attributes, run.attributes);
     return Object.assign({}, run, { attributes });
   }, {});
+}
 
-const groupEmptyRuns = (runs) => {
+/**
+ * @param {Run[]} runs
+ * @returns {Run[][]} grouped runs
+ */
+function groupEmptyRuns(runs) {
   const groups = runs.reduce((acc, run) => {
     if (!acc[run.start]) acc[run.start] = [];
     acc[run.start].push(run);
     return acc;
-  }, {});
+  }, []);
 
   return Object.values(groups);
-};
+}
 
-const flattenEmptyRuns = (runs) => {
+/**
+ * @param {Run[]} runs
+ * @returns {Run[]} flattened runs
+ */
+function flattenEmptyRuns(runs) {
   return groupEmptyRuns(runs).map(mergeRuns);
-};
+}
 
-const flattenRegularRuns = (runs) => {
+/**
+ * @param {Run[]} runs
+ * @returns {Run[]} flattened runs
+ */
+function flattenRegularRuns(runs) {
   const res = [];
   const points = generatePoints(runs);
 
@@ -69,19 +103,17 @@ const flattenRegularRuns = (runs) => {
   }
 
   return res;
-};
+}
 
 /**
  * Flatten many runs
  *
- * @param {Object[]} runs
- * @returns {Object[]} flatten runs
+ * @param {Run[]} runs
+ * @returns {Run[]} flattened runs
  */
-const flatten = (runs = []) => {
+export default function flatten(runs = []) {
   const emptyRuns = flattenEmptyRuns(runs.filter((run) => isEmpty(run)));
   const regularRuns = flattenRegularRuns(runs.filter((run) => !isEmpty(run)));
 
   return sort(emptyRuns.concat(regularRuns));
-};
-
-export default flatten;
+}

--- a/packages/textkit/src/run/getFont.js
+++ b/packages/textkit/src/run/getFont.js
@@ -9,6 +9,8 @@
  * @param {Run} run run
  * @returns {Font | null} font
  */
-export default function getFont(run) {
+const getFont = (run) => {
   return run.attributes?.font || null;
-}
+};
+
+export default getFont;

--- a/packages/textkit/src/run/getFont.js
+++ b/packages/textkit/src/run/getFont.js
@@ -1,9 +1,14 @@
 /**
+ * @typedef {import('../types.js').Font} Font
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run font
  *
- * @param {Object}  run
- * @returns {Object} font
+ * @param {Run} run run
+ * @returns {Font | null} font
  */
-const getFont = (run) => run.attributes?.font || null;
-
-export default getFont;
+export default function getFont(run) {
+  return run.attributes?.font || null;
+}

--- a/packages/textkit/src/run/glyphIndexAt.js
+++ b/packages/textkit/src/run/glyphIndexAt.js
@@ -12,7 +12,9 @@ import { isNil } from '@react-pdf/fns';
  * @param {Run} run run
  * @returns {number} glyph index
  */
-export default function glyphIndexAt(index, run) {
+const glyphIndexAt = (index, run) => {
   const result = run?.glyphIndices?.[index];
   return isNil(result) ? index : result;
-}
+};
+
+export default glyphIndexAt;

--- a/packages/textkit/src/run/glyphIndexAt.js
+++ b/packages/textkit/src/run/glyphIndexAt.js
@@ -1,16 +1,18 @@
 import { isNil } from '@react-pdf/fns';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Return glyph index at string index, if glyph indices present.
  * Otherwise return string index
  *
- * @param {number}  index index
- * @param {Object}  run
- * @returns {number}  glyph index
+ * @param {number} index index
+ * @param {Run} run run
+ * @returns {number} glyph index
  */
-const glyphIndexAt = (index, run) => {
+export default function glyphIndexAt(index, run) {
   const result = run?.glyphIndices?.[index];
   return isNil(result) ? index : result;
-};
-
-export default glyphIndexAt;
+}

--- a/packages/textkit/src/run/height.js
+++ b/packages/textkit/src/run/height.js
@@ -3,14 +3,16 @@ import descent from './descent';
 import lineGap from './lineGap';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run height
  *
- * @param {Object} run
+ * @param {Run} run run
  * @returns {number} height
  */
-const height = (run) => {
+export default function height(run) {
   const lineHeight = run.attributes?.lineHeight;
   return lineHeight || lineGap(run) + ascent(run) - descent(run);
-};
-
-export default height;
+}

--- a/packages/textkit/src/run/height.js
+++ b/packages/textkit/src/run/height.js
@@ -12,7 +12,9 @@ import lineGap from './lineGap';
  * @param {Run} run run
  * @returns {number} height
  */
-export default function height(run) {
+const height = (run) => {
   const lineHeight = run.attributes?.lineHeight;
   return lineHeight || lineGap(run) + ascent(run) - descent(run);
-}
+};
+
+export default height;

--- a/packages/textkit/src/run/indexAtOffset.js
+++ b/packages/textkit/src/run/indexAtOffset.js
@@ -9,7 +9,7 @@
  * @param {Run} run run
  * @returns {number} string index at offset N
  */
-export default function indexAtOffset(offset, run) {
+const indexAtOffset = (offset, run) => {
   let counter = 0;
   let index = 0;
 
@@ -26,4 +26,6 @@ export default function indexAtOffset(offset, run) {
   }
 
   return index;
-}
+};
+
+export default indexAtOffset;

--- a/packages/textkit/src/run/indexAtOffset.js
+++ b/packages/textkit/src/run/indexAtOffset.js
@@ -1,11 +1,15 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get string index at offset
  *
- * @param {number} offset
- * @param {Object} run
+ * @param {number} offset offset
+ * @param {Run} run run
  * @returns {number} string index at offset N
  */
-const indexAtOffset = (offset, run) => {
+export default function indexAtOffset(offset, run) {
   let counter = 0;
   let index = 0;
 
@@ -22,6 +26,4 @@ const indexAtOffset = (offset, run) => {
   }
 
   return index;
-};
-
-export default indexAtOffset;
+}

--- a/packages/textkit/src/run/insert.js
+++ b/packages/textkit/src/run/insert.js
@@ -18,7 +18,7 @@ import glyphFromCodePoint from '../glyph/fromCodePoint';
  * @param {Run} run run
  * @returns {Run} run with glyph
  */
-function insertGlyph(index, glyph, run) {
+const insertGlyph = (index, glyph, run) => {
   if (!glyph) return run;
 
   // Split resolves ligature splitting in case new glyph breaks some
@@ -26,7 +26,7 @@ function insertGlyph(index, glyph, run) {
   const trailingRun = slice(index, Infinity, run);
 
   return concat(append(glyph, leadingRun), trailingRun);
-}
+};
 
 /**
  * Insert either glyph or code point to run in the given index
@@ -36,8 +36,10 @@ function insertGlyph(index, glyph, run) {
  * @param {Run} run run
  * @returns {Run} run with glyph
  */
-export default function insert(index, value, run) {
+const insert = (index, value, run) => {
   const font = getFont(run);
   const glyph = isNumber(value) ? glyphFromCodePoint(value, font) : value;
   return insertGlyph(index, glyph, run);
-}
+};
+
+export default insert;

--- a/packages/textkit/src/run/insert.js
+++ b/packages/textkit/src/run/insert.js
@@ -6,14 +6,19 @@ import isNumber from '../utils/isNumber';
 import glyphFromCodePoint from '../glyph/fromCodePoint';
 
 /**
+ * @typedef {import('../types.js').Glyph} Glyph
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Insert glyph to run in the given index
  *
  * @param {number} index index
- * @param {Object} glyph
- * @param {Object} run
- * @returns {Object} run with glyph
+ * @param {Glyph} glyph glyph
+ * @param {Run} run run
+ * @returns {Run} run with glyph
  */
-const insertGlyph = (index, glyph, run) => {
+function insertGlyph(index, glyph, run) {
   if (!glyph) return run;
 
   // Split resolves ligature splitting in case new glyph breaks some
@@ -21,20 +26,18 @@ const insertGlyph = (index, glyph, run) => {
   const trailingRun = slice(index, Infinity, run);
 
   return concat(append(glyph, leadingRun), trailingRun);
-};
+}
 
 /**
  * Insert either glyph or code point to run in the given index
  *
  * @param {number} index index
- * @param {Object | number} value glyph | codePoint
- * @param {Object} run
- * @returns {Object} run with glyph
+ * @param {Glyph | number} value glyph or codePoint
+ * @param {Run} run run
+ * @returns {Run} run with glyph
  */
-const insert = (index, value, run) => {
+export default function insert(index, value, run) {
   const font = getFont(run);
   const glyph = isNumber(value) ? glyphFromCodePoint(value, font) : value;
   return insertGlyph(index, glyph, run);
-};
-
-export default insert;
+}

--- a/packages/textkit/src/run/isEmpty.js
+++ b/packages/textkit/src/run/isEmpty.js
@@ -1,11 +1,13 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Is run empty (start === end)
  *
- * @param {Object}  run
- * @returns {Object} is run empty
+ * @param {Run} run run
+ * @returns {boolean} is run empty
  */
-const isEmpty = (run) => {
+export default function isEmpty(run) {
   return run.start === run.end;
-};
-
-export default isEmpty;
+}

--- a/packages/textkit/src/run/isEmpty.js
+++ b/packages/textkit/src/run/isEmpty.js
@@ -8,6 +8,8 @@
  * @param {Run} run run
  * @returns {boolean} is run empty
  */
-export default function isEmpty(run) {
+const isEmpty = (run) => {
   return run.start === run.end;
-}
+};
+
+export default isEmpty;

--- a/packages/textkit/src/run/leadingOffset.js
+++ b/packages/textkit/src/run/leadingOffset.js
@@ -1,29 +1,32 @@
 import isWhiteSpace from '../glyph/isWhiteSpace';
 
 /**
+ * @typedef {import('../types.js').Position} Position
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get white space leading positions
  *
- * @param {Object} run
- * @returns {Object[]} white space leading positions
+ * @param {Run} run run
+ * @returns {Position[]} white space leading positions
  */
-const leadingPositions = (run) => {
+function leadingPositions(run) {
   const glyphs = run.glyphs || [];
   const positions = run.positions || [];
   const leadingWhitespaces = glyphs.findIndex((g) => !isWhiteSpace(g));
 
   return positions.slice(0, leadingWhitespaces);
-};
+}
 
 /**
  * Get run leading white space offset
  *
- * @param {Object}  run
+ * @param {Run} run run
  * @returns {number} leading white space offset
  */
-const leadingOffset = (run) => {
+export default function leadingOffset(run) {
   const positions = leadingPositions(run);
 
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);
-};
-
-export default leadingOffset;
+}

--- a/packages/textkit/src/run/leadingOffset.js
+++ b/packages/textkit/src/run/leadingOffset.js
@@ -11,13 +11,13 @@ import isWhiteSpace from '../glyph/isWhiteSpace';
  * @param {Run} run run
  * @returns {Position[]} white space leading positions
  */
-function leadingPositions(run) {
+const leadingPositions = (run) => {
   const glyphs = run.glyphs || [];
   const positions = run.positions || [];
   const leadingWhitespaces = glyphs.findIndex((g) => !isWhiteSpace(g));
 
   return positions.slice(0, leadingWhitespaces);
-}
+};
 
 /**
  * Get run leading white space offset
@@ -25,8 +25,10 @@ function leadingPositions(run) {
  * @param {Run} run run
  * @returns {number} leading white space offset
  */
-export default function leadingOffset(run) {
+const leadingOffset = (run) => {
   const positions = leadingPositions(run);
 
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);
-}
+};
+
+export default leadingOffset;

--- a/packages/textkit/src/run/length.js
+++ b/packages/textkit/src/run/length.js
@@ -8,6 +8,8 @@
  * @param {Run} run run
  * @returns {number} length
  */
-export default function length(run) {
+const length = (run) => {
   return run.end - run.start;
-}
+};
+
+export default length;

--- a/packages/textkit/src/run/length.js
+++ b/packages/textkit/src/run/length.js
@@ -1,11 +1,13 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run length
  *
- * @param {Object}  run
+ * @param {Run} run run
  * @returns {number} length
  */
-const length = (run) => {
+export default function length(run) {
   return run.end - run.start;
-};
-
-export default length;
+}

--- a/packages/textkit/src/run/lineGap.js
+++ b/packages/textkit/src/run/lineGap.js
@@ -10,6 +10,8 @@ import scale from './scale';
  * @param {Object} run run
  * @returns {number} lineGap
  */
-export default function lineGap(run) {
+const lineGap = (run) => {
   return (run.attributes?.font?.lineGap || 0) * scale(run);
-}
+};
+
+export default lineGap;

--- a/packages/textkit/src/run/lineGap.js
+++ b/packages/textkit/src/run/lineGap.js
@@ -1,13 +1,15 @@
 import scale from './scale';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run lineGap
  *
- * @param {Object}  run
+ * @param {Object} run run
  * @returns {number} lineGap
  */
-const lineGap = (run) => {
+export default function lineGap(run) {
   return (run.attributes?.font?.lineGap || 0) * scale(run);
-};
-
-export default lineGap;
+}

--- a/packages/textkit/src/run/offset.js
+++ b/packages/textkit/src/run/offset.js
@@ -1,4 +1,8 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get ligature offset by index
  *
  * Ex. ffi ligature
@@ -7,17 +11,15 @@
  *   glyphIndices:   0  1  2  2  2  3
  *   offset:         0  0  0  1  2  0
  *
- * @param {number}  index
- * @param {Object}  run
+ * @param {number} index
+ * @param {Run} run run
  * @returns {number} ligature offset
  */
-const offset = (index, run) => {
+export default function offset(index, run) {
   if (!run) return 0;
 
   const glyphIndices = run.glyphIndices || [];
   const value = glyphIndices[index];
 
   return glyphIndices.slice(0, index).filter((i) => i === value).length;
-};
-
-export default offset;
+}

--- a/packages/textkit/src/run/offset.js
+++ b/packages/textkit/src/run/offset.js
@@ -15,11 +15,13 @@
  * @param {Run} run run
  * @returns {number} ligature offset
  */
-export default function offset(index, run) {
+const offset = (index, run) => {
   if (!run) return 0;
 
   const glyphIndices = run.glyphIndices || [];
   const value = glyphIndices[index];
 
   return glyphIndices.slice(0, index).filter((i) => i === value).length;
-}
+};
+
+export default offset;

--- a/packages/textkit/src/run/omit.js
+++ b/packages/textkit/src/run/omit.js
@@ -1,15 +1,19 @@
 /**
+ * @typedef {import('../types.js').Attributes} Attributes
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Omit attribute from run
  *
- * @param {Object}  run
- * @returns {Object} run without ommited attribute
+ * @param {keyof Attributes} value attribute value
+ * @param {Run} run run
+ * @returns {Run} run without ommited attribute
  */
-const omit = (value, run) => {
+export default function omit(value, run) {
   const attributes = Object.assign({}, run.attributes);
 
   delete attributes[value];
 
   return Object.assign({}, run, { attributes });
-};
-
-export default omit;
+}

--- a/packages/textkit/src/run/omit.js
+++ b/packages/textkit/src/run/omit.js
@@ -10,10 +10,12 @@
  * @param {Run} run run
  * @returns {Run} run without ommited attribute
  */
-export default function omit(value, run) {
+const omit = (value, run) => {
   const attributes = Object.assign({}, run.attributes);
 
   delete attributes[value];
 
   return Object.assign({}, run, { attributes });
-}
+};
+
+export default omit;

--- a/packages/textkit/src/run/prepend.js
+++ b/packages/textkit/src/run/prepend.js
@@ -17,7 +17,7 @@ import glyphFromCodePoint from '../glyph/fromCodePoint';
  * @param {Run} run run
  * @returns {Run} run with glyph
  */
-function prependGlyph(glyph, run) {
+const prependGlyph = (glyph, run) => {
   const runScale = scale(run);
   const glyphLength = glyph.codePoints.length;
 
@@ -30,7 +30,7 @@ function prependGlyph(glyph, run) {
   ]).concat(run.positions);
 
   return Object.assign({}, run, { end, glyphs, glyphIndices, positions });
-}
+};
 
 /**
  * Prepend glyph or code point on run
@@ -39,11 +39,13 @@ function prependGlyph(glyph, run) {
  * @param {Run} run run
  * @returns {Run} run with glyph
  */
-export default function prepend(value, run) {
+const prepend = (value, run) => {
   if (!value) return run;
 
   const font = getFont(run);
   const glyph = isNumber(value) ? glyphFromCodePoint(value, font) : value;
 
   return prependGlyph(glyph, run);
-}
+};
+
+export default prepend;

--- a/packages/textkit/src/run/prepend.js
+++ b/packages/textkit/src/run/prepend.js
@@ -5,40 +5,45 @@ import prependIndices from '../indices/prepend';
 import glyphFromCodePoint from '../glyph/fromCodePoint';
 
 /**
+ * @typedef {import('../types.js').Glyph} Glyph
+ * @typedef {import('../types.js').Position} Position
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Prepend glyph to run
  *
- * @param {Object} glyph
- * @param {Object} run
- * @returns {Object} run with glyph
+ * @param {Glyph} glyph glyph
+ * @param {Run} run run
+ * @returns {Run} run with glyph
  */
-const prependGlyph = (glyph, run) => {
+function prependGlyph(glyph, run) {
   const runScale = scale(run);
   const glyphLength = glyph.codePoints.length;
 
   const end = run.end + glyphLength;
   const glyphIndices = prependIndices(glyphLength, run.glyphIndices);
   const glyphs = [glyph].concat(run.glyphs);
-  const positions = [{ xAdvance: glyph.advanceWidth * runScale }].concat(
-    run.positions,
-  );
+
+  const positions = /** @type {Position[]} */ ([
+    { xAdvance: glyph.advanceWidth * runScale },
+  ]).concat(run.positions);
 
   return Object.assign({}, run, { end, glyphs, glyphIndices, positions });
-};
+}
 
 /**
  * Prepend glyph or code point on run
  *
- * @param {Object | number} value glyph or codePoint
- * @param {Object} run
- * @returns {Object} run with glyph
+ * @param {Glyph | number} value glyph or codePoint
+ * @param {Run} run run
+ * @returns {Run} run with glyph
  */
-const prepend = (value, run) => {
+export default function prepend(value, run) {
   if (!value) return run;
 
   const font = getFont(run);
   const glyph = isNumber(value) ? glyphFromCodePoint(value, font) : value;
 
   return prependGlyph(glyph, run);
-};
-
-export default prepend;
+}

--- a/packages/textkit/src/run/runIndexAt.js
+++ b/packages/textkit/src/run/runIndexAt.js
@@ -1,8 +1,12 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Get run index that contains passed index
  *
  * @param {number} n index
- * @param {{ start: number, end: number }[]} runs array
+ * @param {Run[]} runs runs
  * @returns {number} run index
  */
 const runIndexAt = (n, runs) => {

--- a/packages/textkit/src/run/scale.js
+++ b/packages/textkit/src/run/scale.js
@@ -8,13 +8,13 @@
  * @param {Run} run run
  * @returns {number} scale
  */
-function calculateScale(run) {
+const calculateScale = (run) => {
   const attributes = run.attributes || {};
   const fontSize = attributes.fontSize || 12;
   const unitsPerEm = attributes.font?.unitsPerEm;
 
   return unitsPerEm ? fontSize / unitsPerEm : 0;
-}
+};
 
 /**
  * Get run scale
@@ -22,6 +22,8 @@ function calculateScale(run) {
  * @param {Object}  run
  * @returns {number} scale
  */
-export default function scale(run) {
+const scale = (run) => {
   return run.attributes?.scale || calculateScale(run);
-}
+};
+
+export default scale;

--- a/packages/textkit/src/run/scale.js
+++ b/packages/textkit/src/run/scale.js
@@ -1,16 +1,20 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Calculate run scale
  *
- * @param {Object}  run
+ * @param {Run} run run
  * @returns {number} scale
  */
-const calculateScale = (run) => {
+function calculateScale(run) {
   const attributes = run.attributes || {};
   const fontSize = attributes.fontSize || 12;
   const unitsPerEm = attributes.font?.unitsPerEm;
 
   return unitsPerEm ? fontSize / unitsPerEm : 0;
-};
+}
 
 /**
  * Get run scale
@@ -18,8 +22,6 @@ const calculateScale = (run) => {
  * @param {Object}  run
  * @returns {number} scale
  */
-const scale = (run) => {
+export default function scale(run) {
   return run.attributes?.scale || calculateScale(run);
-};
-
-export default scale;
+}

--- a/packages/textkit/src/run/slice.js
+++ b/packages/textkit/src/run/slice.js
@@ -6,14 +6,18 @@ import glyphIndexAt from './glyphIndexAt';
 import normalizeIndices from '../indices/normalize';
 
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Slice run between glyph indices range
  *
  * @param {number} start glyph index
  * @param {number} end glyph index
- * @param {Object} run
- * @returns {Object} sliced run
+ * @param {Run} run run
+ * @returns {Run} sliced run
  */
-const slice = (start, end, run) => {
+export default function slice(start, end, run) {
   const runScale = scale(run);
   const font = getFont(run);
 
@@ -51,6 +55,4 @@ const slice = (start, end, run) => {
     glyphs: [startGlyphs, glyphs, endGlyphs].flat(),
     positions: [startPositions, positions, endPositions].flat(),
   });
-};
-
-export default slice;
+}

--- a/packages/textkit/src/run/slice.js
+++ b/packages/textkit/src/run/slice.js
@@ -17,7 +17,7 @@ import normalizeIndices from '../indices/normalize';
  * @param {Run} run run
  * @returns {Run} sliced run
  */
-export default function slice(start, end, run) {
+const slice = (start, end, run) => {
   const runScale = scale(run);
   const font = getFont(run);
 
@@ -55,4 +55,6 @@ export default function slice(start, end, run) {
     glyphs: [startGlyphs, glyphs, endGlyphs].flat(),
     positions: [startPositions, positions, endPositions].flat(),
   });
-}
+};
+
+export default slice;

--- a/packages/textkit/src/run/sort.js
+++ b/packages/textkit/src/run/sort.js
@@ -1,10 +1,13 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Sort runs in ascending order
  *
- * @template {{ start: number, end: number }} T
- * @param {T[]} runs
- * @returns {T[]} sorted runs
+ * @param {Run[]} runs
+ * @returns {Run[]} sorted runs
  */
-const sort = (runs) => runs.sort((a, b) => a.start - b.start || a.end - b.end);
-
-export default sort;
+export default function sort(runs) {
+  return runs.sort((a, b) => a.start - b.start || a.end - b.end);
+}

--- a/packages/textkit/src/run/sort.js
+++ b/packages/textkit/src/run/sort.js
@@ -8,6 +8,8 @@
  * @param {Run[]} runs
  * @returns {Run[]} sorted runs
  */
-export default function sort(runs) {
+const sort = (runs) => {
   return runs.sort((a, b) => a.start - b.start || a.end - b.end);
-}
+};
+
+export default sort;

--- a/packages/textkit/src/run/subtract.js
+++ b/packages/textkit/src/run/subtract.js
@@ -1,15 +1,17 @@
 /**
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * Subtract scalar to run
  *
  * @param {number} n scalar
- * @param {Object} run
+ * @param {Run} run run
  * @returns {Object} subtracted run
  */
-const subtract = (n, run) => {
+export default function subtract(n, run) {
   const start = run.start - n;
   const end = run.end - n;
 
   return Object.assign({}, run, { start, end });
-};
-
-export default subtract;
+}

--- a/packages/textkit/src/run/subtract.js
+++ b/packages/textkit/src/run/subtract.js
@@ -9,9 +9,11 @@
  * @param {Run} run run
  * @returns {Object} subtracted run
  */
-export default function subtract(n, run) {
+const subtract = (n, run) => {
   const start = run.start - n;
   const end = run.end - n;
 
   return Object.assign({}, run, { start, end });
-}
+};
+
+export default subtract;

--- a/packages/textkit/src/run/trailingOffset.js
+++ b/packages/textkit/src/run/trailingOffset.js
@@ -10,9 +10,9 @@ import isWhiteSpace from '../glyph/isWhiteSpace';
  * @param {T[]} array
  * @returns {T[]} reversed array
  */
-function reverse(array) {
+const reverse = (array) => {
   return [...array].reverse();
-}
+};
 
 /**
  * Get white space trailing positions
@@ -20,13 +20,13 @@ function reverse(array) {
  * @param {Run} run run
  * @returns {Position[]} white space trailing positions
  */
-function trailingPositions(run) {
+const trailingPositions = (run) => {
   const glyphs = reverse(run.glyphs || []);
   const positions = reverse(run.positions || []);
   const leadingWhitespaces = glyphs.findIndex((g) => !isWhiteSpace(g));
 
   return positions.slice(0, leadingWhitespaces);
-}
+};
 
 /**
  * Get run trailing white space offset
@@ -34,8 +34,10 @@ function trailingPositions(run) {
  * @param {Run} run run
  * @returns {number} trailing white space offset
  */
-export default function trailingOffset(run) {
+const trailingOffset = (run) => {
   const positions = trailingPositions(run);
 
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);
-}
+};
+
+export default trailingOffset;

--- a/packages/textkit/src/run/trailingOffset.js
+++ b/packages/textkit/src/run/trailingOffset.js
@@ -1,36 +1,41 @@
 import isWhiteSpace from '../glyph/isWhiteSpace';
 
 /**
+ * @typedef {import('../types.js').Position} Position
+ * @typedef {import('../types.js').Run} Run
+ */
+
+/**
  * @template T
  * @param {T[]} array
  * @returns {T[]} reversed array
  */
-const reverse = (array) => [...array].reverse();
+function reverse(array) {
+  return [...array].reverse();
+}
 
 /**
  * Get white space trailing positions
  *
- * @param {Object} run
- * @returns {Object[]} white space trailing positions
+ * @param {Run} run run
+ * @returns {Position[]} white space trailing positions
  */
-const trailingPositions = (run) => {
+function trailingPositions(run) {
   const glyphs = reverse(run.glyphs || []);
   const positions = reverse(run.positions || []);
   const leadingWhitespaces = glyphs.findIndex((g) => !isWhiteSpace(g));
 
   return positions.slice(0, leadingWhitespaces);
-};
+}
 
 /**
  * Get run trailing white space offset
  *
- * @param {Object}  run
+ * @param {Run} run run
  * @returns {number} trailing white space offset
  */
-const trailingOffset = (run) => {
+export default function trailingOffset(run) {
   const positions = trailingPositions(run);
 
   return positions.reduce((acc, pos) => acc + (pos.xAdvance || 0), 0);
-};
-
-export default trailingOffset;
+}

--- a/packages/textkit/src/types.js
+++ b/packages/textkit/src/types.js
@@ -1,0 +1,113 @@
+/**
+ * @typedef {Object} AttributedString
+ * @property {string} [string]
+ * @property {string[]} [syllables]
+ * @property {Run[]} [runs]
+ */
+
+/**
+ * @typedef {Object} Attachment
+ * @property {number} [x]
+ * @property {number} [y]
+ * @property {number} [width]
+ * @property {number} [height]
+ */
+
+/**
+ * @typedef {Object} Attributes
+ * @property {string} [align]
+ * @property {string} [alignLastLine]
+ * @property {Attachment} [attachment]
+ * @property {string} [backgroundColor]
+ * @property {unknown} [bidiLevel]
+ * @property {unknown} [bullet]
+ * @property {number} [characterSpacing]
+ * @property {string} [color]
+ * @property {unknown[]} [features]
+ * @property {boolean} [fill]
+ * @property {Font | string} [font]
+ * @property {number} [fontSize]
+ * @property {boolean} [hangingPunctuation]
+ * @property {number} [hyphenationFactor]
+ * @property {number} [indent]
+ * @property {number} [justificationFactor]
+ * @property {number} [lineHeight]
+ * @property {number} [lineSpacing]
+ * @property {unknown} [link]
+ * @property {number} [margin]
+ * @property {number} [marginLeft]
+ * @property {number} [marginRight]
+ * @property {number} [opacity]
+ * @property {number} [padding]
+ * @property {number} [paddingTop]
+ * @property {number} [paragraphSpacing]
+ * @property {number} [scale]
+ * @property {unknown} [script]
+ * @property {number} [shrinkFactor]
+ * @property {boolean} [strike]
+ * @property {string} [strikeColor]
+ * @property {string} [strikeStyle]
+ * @property {boolean} [stroke]
+ * @property {boolean} [underline]
+ * @property {string} [underlineColor]
+ * @property {string} [underlineStyle]
+ * @property {string} [verticalAlign]
+ * @property {number} [wordSpacing]
+ * @property {number} [yOffset]
+ */
+
+/**
+ * @typedef {Object} Fragment
+ * @property {string} string
+ * @property {Attributes} [attributes]
+ */
+
+/**
+ * @typedef {Object} Glyph
+ * @property {number} [id]
+ * @property {number} [advanceWidth]
+ * @property {number[]} [codePoints]
+ */
+
+/**
+ * @typedef {Object} Font
+ * @property {number} [ascent]
+ * @property {number} [descent]
+ * @property {number} [height]
+ * @property {number} [unitsPerEm]
+ * @property {Function} [glyphForCodePoint]
+ * @property {Function} [layout]
+ */
+
+/**
+ * @typedef {['start' | 'end', number, Attributes, number]} Point
+ */
+
+/**
+ * @typedef {Object} Position
+ * @property {number} [xAdvance]
+ * @property {number} [yAdvance]
+ * @property {number} [xOffset]
+ * @property {number} [yOffset]
+ * @property {number} [advanceWidth]
+ */
+
+/**
+ * @typedef {Object} Rect
+ * @property {number} x
+ * @property {number} y
+ * @property {number} width
+ * @property {number} height
+ */
+
+/**
+ * @typedef {Object} Run
+ * @property {number} [start]
+ * @property {number} [end]
+ * @property {number[]} [glyphIndices]
+ * @property {Glyph[]} [glyphs]
+ * @property {Position[]} [positions]
+ * @property {Attributes} [attributes]
+ */
+
+module.exports = {};

--- a/packages/textkit/src/utils/isNumber.js
+++ b/packages/textkit/src/utils/isNumber.js
@@ -1,3 +1,10 @@
-const isNumber = (value) => typeof value === 'number';
-
-export default isNumber;
+/**
+ * Check if value is a number
+ *
+ * @template {unknown} T
+ * @param {T} value Value to check
+ * @returns {value is number} Whether value is a number
+ */
+export default function isNumber(value) {
+  return typeof value === 'number';
+}

--- a/packages/textkit/src/utils/isNumber.js
+++ b/packages/textkit/src/utils/isNumber.js
@@ -5,6 +5,8 @@
  * @param {T} value Value to check
  * @returns {value is number} Whether value is a number
  */
-export default function isNumber(value) {
+const isNumber = (value) => {
   return typeof value === 'number';
-}
+};
+
+export default isNumber;

--- a/packages/textkit/src/utils/stringFromCodePoints.js
+++ b/packages/textkit/src/utils/stringFromCodePoints.js
@@ -4,6 +4,8 @@
  * @param {number[]} codePoints points
  * @returns {string} string
  */
-export default function stringFromCodePoints(codePoints) {
+const stringFromCodePoints = (codePoints) => {
   return String.fromCodePoint(...(codePoints || []));
-}
+};
+
+export default stringFromCodePoints;

--- a/packages/textkit/src/utils/stringFromCodePoints.js
+++ b/packages/textkit/src/utils/stringFromCodePoints.js
@@ -4,7 +4,6 @@
  * @param {number[]} codePoints points
  * @returns {string} string
  */
-const stringFromCodePoints = (codePoints) =>
-  String.fromCodePoint(...(codePoints || []));
-
-export default stringFromCodePoints;
+export default function stringFromCodePoints(codePoints) {
+  return String.fromCodePoint(...(codePoints || []));
+}

--- a/packages/textkit/tests/attributedString/dropLast.test.js
+++ b/packages/textkit/tests/attributedString/dropLast.test.js
@@ -5,22 +5,22 @@ import dropLast from '../../src/attributedString/dropLast';
 
 describe('attributeString dropLast operator', () => {
   test('should dropLast with one run', () => {
-    const runs = [{ start: 0, end: 11, attributes: { attr: 1 } }];
+    const runs = [{ start: 0, end: 11, attributes: { font: {} } }];
     const string = { string: 'Lorem ipsum', runs };
     const result = dropLast(string);
 
     expect(result.string).toBe('Lorem ipsu');
     expect(result.runs[0]).toHaveProperty('start', 0);
     expect(result.runs[0]).toHaveProperty('end', 10);
-    expect(result.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(result.runs[0]).toHaveProperty('attributes', { font: {} });
   });
 
   test('should dropLast with two runs', () => {
     const string = {
       string: 'Lorem ipsum',
       runs: [
-        { start: 0, end: 6, attributes: { attr: 1 } },
-        { start: 6, end: 11, attributes: { attr: 2 } },
+        { start: 0, end: 6, attributes: { font: {} } },
+        { start: 6, end: 11, attributes: { fontSize: 16 } },
       ],
     };
     const splittedString = dropLast(string);
@@ -28,17 +28,19 @@ describe('attributeString dropLast operator', () => {
     expect(splittedString.string).toBe('Lorem ipsu');
     expect(splittedString.runs[0]).toHaveProperty('start', 0);
     expect(splittedString.runs[0]).toHaveProperty('end', 6);
-    expect(splittedString.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(splittedString.runs[0]).toHaveProperty('attributes', { font: {} });
     expect(splittedString.runs[1]).toHaveProperty('start', 6);
     expect(splittedString.runs[1]).toHaveProperty('end', 10);
-    expect(splittedString.runs[1]).toHaveProperty('attributes', { attr: 2 });
+    expect(splittedString.runs[1]).toHaveProperty('attributes', {
+      fontSize: 16,
+    });
   });
 
   test('should slice with several runs', () => {
     const runs = [
-      { start: 0, end: 3, attributes: { attr: 1 } },
-      { start: 3, end: 6, attributes: { attr: 2 } },
-      { start: 6, end: 11, attributes: { attr: 3 } },
+      { start: 0, end: 3, attributes: { font: {} } },
+      { start: 3, end: 6, attributes: { fontSize: 16 } },
+      { start: 6, end: 11, attributes: { fontSize: 20 } },
     ];
     const string = { string: 'Lorem ipsum', runs };
     const splittedString = dropLast(string);
@@ -46,13 +48,17 @@ describe('attributeString dropLast operator', () => {
     expect(splittedString.string).toBe('Lorem ipsu');
     expect(splittedString.runs[0]).toHaveProperty('start', 0);
     expect(splittedString.runs[0]).toHaveProperty('end', 3);
-    expect(splittedString.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(splittedString.runs[0]).toHaveProperty('attributes', { font: {} });
     expect(splittedString.runs[1]).toHaveProperty('start', 3);
     expect(splittedString.runs[1]).toHaveProperty('end', 6);
-    expect(splittedString.runs[1]).toHaveProperty('attributes', { attr: 2 });
+    expect(splittedString.runs[1]).toHaveProperty('attributes', {
+      fontSize: 16,
+    });
     expect(splittedString.runs[2]).toHaveProperty('start', 6);
     expect(splittedString.runs[2]).toHaveProperty('end', 10);
-    expect(splittedString.runs[2]).toHaveProperty('attributes', { attr: 3 });
+    expect(splittedString.runs[2]).toHaveProperty('attributes', {
+      fontSize: 20,
+    });
   });
 
   test('should dropLast glyphs with one run', () => {

--- a/packages/textkit/tests/attributedString/fromFragments.test.js
+++ b/packages/textkit/tests/attributedString/fromFragments.test.js
@@ -33,11 +33,13 @@ describe('attributeString fromFragments operator', () => {
 
   test('should preserve fragment attributes', () => {
     const attributedString = fromFragments([
-      { string: 'Hey', attributes: { attr: 1 } },
-      { string: ' ho', attributes: { attr: 2 } },
+      { string: 'Hey', attributes: { font: {} } },
+      { string: ' ho', attributes: { fontSize: 16 } },
     ]);
 
-    expect(attributedString.runs[0]).toHaveProperty('attributes', { attr: 1 });
-    expect(attributedString.runs[1]).toHaveProperty('attributes', { attr: 2 });
+    expect(attributedString.runs[0]).toHaveProperty('attributes', { font: {} });
+    expect(attributedString.runs[1]).toHaveProperty('attributes', {
+      fontSize: 16,
+    });
   });
 });

--- a/packages/textkit/tests/attributedString/slice.test.js
+++ b/packages/textkit/tests/attributedString/slice.test.js
@@ -6,20 +6,20 @@ import slice from '../../src/attributedString/slice';
 
 const testString = 'Lorem ipsum';
 const testRuns = [
-  { start: 0, end: 6, attributes: { attr: 1 } },
-  { start: 6, end: 11, attributes: { attr: 2 } },
+  { start: 0, end: 6, attributes: { font: {} } },
+  { start: 6, end: 11, attributes: { fontSize: 16 } },
 ];
 
 describe('attributeString slice operator', () => {
   test('should slice with one run', () => {
-    const runs = [{ start: 0, end: 11, attributes: { attr: 1 } }];
+    const runs = [{ start: 0, end: 11, attributes: { font: {} } }];
     const string = { string: testString, runs };
     const sliced = slice(2, 8, string);
 
     expect(sliced.string).toBe('rem ip');
     expect(sliced.runs[0]).toHaveProperty('start', 0);
     expect(sliced.runs[0]).toHaveProperty('end', 6);
-    expect(sliced.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(sliced.runs[0]).toHaveProperty('attributes', { font: {} });
   });
 
   test('should slice with two runs', () => {
@@ -29,17 +29,19 @@ describe('attributeString slice operator', () => {
     expect(splittedString.string).toBe('rem ip');
     expect(splittedString.runs[0]).toHaveProperty('start', 0);
     expect(splittedString.runs[0]).toHaveProperty('end', 4);
-    expect(splittedString.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(splittedString.runs[0]).toHaveProperty('attributes', { font: {} });
     expect(splittedString.runs[1]).toHaveProperty('start', 4);
     expect(splittedString.runs[1]).toHaveProperty('end', 6);
-    expect(splittedString.runs[1]).toHaveProperty('attributes', { attr: 2 });
+    expect(splittedString.runs[1]).toHaveProperty('attributes', {
+      fontSize: 16,
+    });
   });
 
   test('should slice with several runs', () => {
     const runs = [
-      { start: 0, end: 3, attributes: { attr: 1 } },
-      { start: 3, end: 6, attributes: { attr: 2 } },
-      { start: 6, end: 11, attributes: { attr: 3 } },
+      { start: 0, end: 3, attributes: { font: {} } },
+      { start: 3, end: 6, attributes: { fontSize: 16 } },
+      { start: 6, end: 11, attributes: { fontSize: 20 } },
     ];
     const string = { string: testString, runs };
     const splittedString = slice(2, 8, string);
@@ -47,13 +49,17 @@ describe('attributeString slice operator', () => {
     expect(splittedString.string).toBe('rem ip');
     expect(splittedString.runs[0]).toHaveProperty('start', 0);
     expect(splittedString.runs[0]).toHaveProperty('end', 1);
-    expect(splittedString.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(splittedString.runs[0]).toHaveProperty('attributes', { font: {} });
     expect(splittedString.runs[1]).toHaveProperty('start', 1);
     expect(splittedString.runs[1]).toHaveProperty('end', 4);
-    expect(splittedString.runs[1]).toHaveProperty('attributes', { attr: 2 });
+    expect(splittedString.runs[1]).toHaveProperty('attributes', {
+      fontSize: 16,
+    });
     expect(splittedString.runs[2]).toHaveProperty('start', 4);
     expect(splittedString.runs[2]).toHaveProperty('end', 6);
-    expect(splittedString.runs[2]).toHaveProperty('attributes', { attr: 3 });
+    expect(splittedString.runs[2]).toHaveProperty('attributes', {
+      fontSize: 20,
+    });
   });
 
   test('should ignore unnecesary leading runs when slice', () => {
@@ -64,7 +70,9 @@ describe('attributeString slice operator', () => {
     expect(splittedString.string).toBe('ipsum');
     expect(splittedString.runs[0]).toHaveProperty('start', 0);
     expect(splittedString.runs[0]).toHaveProperty('end', 5);
-    expect(splittedString.runs[0]).toHaveProperty('attributes', { attr: 2 });
+    expect(splittedString.runs[0]).toHaveProperty('attributes', {
+      fontSize: 16,
+    });
   });
 
   test('should ignore unnecesary trailing runs when slice', () => {
@@ -75,7 +83,7 @@ describe('attributeString slice operator', () => {
     expect(splittedString.string).toBe('orem ');
     expect(splittedString.runs[0]).toHaveProperty('start', 0);
     expect(splittedString.runs[0]).toHaveProperty('end', 5);
-    expect(splittedString.runs[0]).toHaveProperty('attributes', { attr: 1 });
+    expect(splittedString.runs[0]).toHaveProperty('attributes', { font: {} });
   });
 
   test('should slice glyphs when one run', () => {

--- a/packages/textkit/tests/indices/resolve.test.js
+++ b/packages/textkit/tests/indices/resolve.test.js
@@ -2,12 +2,12 @@ import { describe, expect, test } from 'vitest';
 
 import resolve from '../../src/indices/resolve';
 
-const singleGlyph = { codePoints: ['codePoint'] };
+const singleGlyph = { codePoints: [0] };
 
-const ligatureGlyph = { codePoints: ['codePoint', 'otherCodePoint'] };
+const ligatureGlyph = { codePoints: [0, 1] };
 
 const longerLigatureGlyph = {
-  codePoints: ['codePoint', 'otherCodePoint', 'anotherCodePoint'],
+  codePoints: [0, 1, 2],
 };
 
 describe('indices resolve operator', () => {

--- a/packages/textkit/tests/layout/resolveAttachments.test.js
+++ b/packages/textkit/tests/layout/resolveAttachments.test.js
@@ -59,7 +59,7 @@ describe('resolveAttachments', () => {
             { xAdvance: 4 }, // m
           ],
           glyphIndices: [0, 1, 2, 3, 4],
-          attributes: { something: 'blah' },
+          attributes: { font: {} },
         },
       ],
     };

--- a/packages/textkit/tests/layout/resolveYOffset.test.js
+++ b/packages/textkit/tests/layout/resolveYOffset.test.js
@@ -60,7 +60,7 @@ describe('resolveYOffset', () => {
             { xAdvance: 4, yOffset: 0 }, // m
           ],
           glyphIndices: [0, 1, 2, 3, 4],
-          attributes: { something: 'blah' },
+          attributes: { font: {} },
         },
       ],
     };

--- a/packages/textkit/tests/run/add.test.js
+++ b/packages/textkit/tests/run/add.test.js
@@ -4,7 +4,7 @@ import add from '../../src/run/add';
 
 describe('run add operator', () => {
   test('should return equal run if 0', () => {
-    const attributes = { something: 'blah' };
+    const attributes = { font: {} };
     const run = { start: 5, end: 15, attributes };
     const added = add(0, run);
 
@@ -15,7 +15,7 @@ describe('run add operator', () => {
   });
 
   test('should return added run', () => {
-    const attributes = { something: 'blah' };
+    const attributes = { font: {} };
     const run = { start: 5, end: 15, attributes };
     const added = add(5, run);
 

--- a/packages/textkit/tests/run/advanceWidth.test.js
+++ b/packages/textkit/tests/run/advanceWidth.test.js
@@ -31,6 +31,7 @@ describe('run advanceWidth operator', () => {
     ];
     const run = { start: 5, end: 15, attributes: {}, positions };
 
+    // @ts-expect-error - intentionally invalid argument
     expect(advanceWidth(run)).toBe(30);
   });
 });

--- a/packages/textkit/tests/run/concat.test.js
+++ b/packages/textkit/tests/run/concat.test.js
@@ -18,19 +18,19 @@ describe('run concat operator', () => {
     const runA = {
       start: 0,
       end: 3,
-      attributes: { hey: 'ho' },
+      attributes: { font: {} },
     };
     const runB = {
       start: 3,
       end: 5,
-      attributes: { lets: 'go' },
+      attributes: { fontSize: 16 },
     };
 
     const result = concat(runA, runB);
 
     expect(result).toHaveProperty('start', 0);
     expect(result).toHaveProperty('end', 5);
-    expect(result).toHaveProperty('attributes', { hey: 'ho', lets: 'go' });
+    expect(result).toHaveProperty('attributes', { font: {}, fontSize: 16 });
   });
 
   test('should concat runs glyphs', () => {

--- a/packages/textkit/tests/run/filter.test.js
+++ b/packages/textkit/tests/run/filter.test.js
@@ -10,7 +10,7 @@ describe('run filter operator', () => {
   });
 
   test('should filter only one run', () => {
-    const attributes = { something: 'blah' };
+    const attributes = { font: {} };
     const runs = [{ start: 0, end: 15, attributes }];
     const filtered = filter(2, 15, runs);
 

--- a/packages/textkit/tests/run/omit.test.js
+++ b/packages/textkit/tests/run/omit.test.js
@@ -4,34 +4,34 @@ import omit from '../../src/run/omit';
 
 describe('run omit operator', () => {
   test('should omit passed attribute', () => {
-    const run = { start: 5, end: 15, attributes: { something: 'blah' } };
-    const ommited = omit('something', run);
+    const run = { start: 5, end: 15, attributes: { font: {} } };
+    const ommited = omit('font', run);
 
     expect(ommited).toHaveProperty('start', 5);
     expect(ommited).toHaveProperty('end', 15);
-    expect(ommited.attributes.something).toBeFalsy();
+    expect(ommited.attributes).not.toHaveProperty('font');
   });
 
   test('should not omit other attribute', () => {
-    const run = { start: 5, end: 15, attributes: { something: 'blah' } };
-    const ommited = omit('somethingElse', run);
+    const run = { start: 5, end: 15, attributes: { font: {} } };
+    const ommited = omit('fontSize', run);
 
     expect(ommited).toHaveProperty('start', 5);
     expect(ommited).toHaveProperty('end', 15);
-    expect(ommited.attributes).toHaveProperty('something', 'blah');
+    expect(ommited.attributes).toHaveProperty('font', {});
   });
 
   test('should preserve other attributes', () => {
     const run = {
       start: 5,
       end: 15,
-      attributes: { something: 'blah', somethingElse: 'bloh' },
+      attributes: { font: {}, fontSize: 16 },
     };
-    const ommited = omit('something', run);
+    const ommited = omit('font', run);
 
     expect(ommited).toHaveProperty('start', 5);
     expect(ommited).toHaveProperty('end', 15);
-    expect(ommited.attributes.something).toBeFalsy();
-    expect(ommited.attributes).toHaveProperty('somethingElse', 'bloh');
+    expect(ommited.attributes).not.toHaveProperty('font');
+    expect(ommited.attributes).toHaveProperty('fontSize', 16);
   });
 });

--- a/packages/textkit/tests/run/slice.test.js
+++ b/packages/textkit/tests/run/slice.test.js
@@ -7,7 +7,7 @@ import slice from '../../src/run/slice';
 describe('run slice operator', () => {
   describe('slice start and end', () => {
     test('should slice containing range', () => {
-      const attributes = { something: 'blah' };
+      const attributes = { font: {} };
       const run = { start: 0, end: 10, attributes };
       const sliced = slice(2, 5, run);
 
@@ -17,7 +17,7 @@ describe('run slice operator', () => {
     });
 
     test('should slice exact range', () => {
-      const attributes = { something: 'blah' };
+      const attributes = { font: {} };
       const run = { start: 0, end: 10, attributes };
       const sliced = slice(0, 10, run);
 
@@ -27,7 +27,7 @@ describe('run slice operator', () => {
     });
 
     test('should slice exceeding range', () => {
-      const attributes = { something: 'blah' };
+      const attributes = { font: {} };
       const run = { start: 0, end: 10, attributes };
       const sliced = slice(2, 20, run);
 
@@ -37,7 +37,7 @@ describe('run slice operator', () => {
     });
 
     test('should slice containing range when start not zero', () => {
-      const attributes = { something: 'blah' };
+      const attributes = { font: {} };
       const run = { start: 5, end: 15, attributes };
       const sliced = slice(2, 5, run);
 
@@ -47,7 +47,7 @@ describe('run slice operator', () => {
     });
 
     test('should slice exact range when start not zero', () => {
-      const attributes = { something: 'blah' };
+      const attributes = { font: {} };
       const run = { start: 5, end: 15, attributes };
       const sliced = slice(0, 10, run);
 
@@ -57,7 +57,7 @@ describe('run slice operator', () => {
     });
 
     test('should slice exceeding range when start not zero', () => {
-      const attributes = { something: 'blah' };
+      const attributes = { font: {} };
       const run = { start: 5, end: 15, attributes };
       const sliced = slice(8, 13, run);
 

--- a/packages/textkit/tests/run/subtract.test.js
+++ b/packages/textkit/tests/run/subtract.test.js
@@ -4,7 +4,7 @@ import subtract from '../../src/run/subtract';
 
 describe('run subtract operator', () => {
   test('should return equal run if 0', () => {
-    const attributes = { something: 'blah' };
+    const attributes = { font: {} };
     const run = { start: 5, end: 15, attributes };
     const subtracted = subtract(0, run);
 
@@ -15,7 +15,7 @@ describe('run subtract operator', () => {
   });
 
   test('should return subtracted run', () => {
-    const attributes = { something: 'blah' };
+    const attributes = { font: {} };
     const run = { start: 5, end: 15, attributes };
     const subtracted = subtract(5, run);
 


### PR DESCRIPTION
This is a sample PR that improves type safety while keeping the code 100% in JavaScript. It's not fully functional (yet - unless #2588 gets merged), but gives an insight on how the codebase would look like with JS + JSDoc.

@diegomura, I would love to hear what you think. Should I continue? 