### PR TITLE
chore: add TypeScript as a dependency

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -1,0 +1,28 @@
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      DOCUMENT: any;
+      PAGE: any;
+      TEXT: any;
+      VIEW: any;
+    }
+  }
+
+  interface Navigator {
+    readonly msSaveBlob: any;
+  }
+
+  const BROWSER: boolean;
+
+  interface Window {
+    BROWSER: boolean;
+  }
+
+  namespace jest {
+    interface Matchers<R> {
+      toMatchImageSnapshot(): R;
+    }
+  }
+}
+
+export {};

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,19 @@
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.ttf' {
+  const src: string;
+  export default src;
+}

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "rollup-plugin-ignore": "^1.0.10",
     "rollup-plugin-local-resolve": "^1.0.7",
     "rollup-plugin-polyfill-node": "^0.13.0",
+    "typescript": "^5.3.3",
     "vitest": "^1.2.0",
     "vitest-fetch-mock": "^0.2.2"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "target": "es2019"
+  },
+  "include": ["packages/**/src/**/*"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmit": true,
     "noUncheckedIndexedAccess": true,
@@ -14,5 +14,10 @@
     "strict": false,
     "target": "es2019"
   },
-  "include": ["packages/**/src/**/*"]
+  "include": [
+    "packages/**/src/**/*",
+    "packages/**/tests/**/*",
+    "custom.d.ts",
+    "global.d.ts"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9366,7 +9366,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-"typescript@>=3 < 6":
+"typescript@>=3 < 6", typescript@^5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.3.3.tgz#b3ce6ba258e72e6305ba66f5c9b452aaee3ffe37"
   integrity sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==


### PR DESCRIPTION
This PR does NOT migrate the codebase to TypeScript nor indicates intent to do so in the future. What it does is simply installs TypeScript, so that developer experience (when writing JavaScript!) can be improved.

On top of that, this makes `yarn tsc` command available. At the moment, it still produces a lot of errors, so it's pretty useless, but as #2587 (and the PRs that come after that) gets merged, slowly but surely we'll have increased type safety.

Eventually, we could consider having type checking as a CI step to ensure better quality. Still, writing JavaScript!