### PR TITLE
fix: replace jpeg-exif with jay-peg

### DIFF
--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -33,7 +33,7 @@
     "@babel/runtime": "^7.20.13",
     "@react-pdf/png-js": "^2.3.0",
     "cross-fetch": "^3.1.5",
-    "jpeg-exif": "^1.1.4"
+    "jay-peg": "^1.0.0"
   },
   "files": [
     "lib"

--- a/packages/image/src/jpeg.js
+++ b/packages/image/src/jpeg.js
@@ -1,9 +1,4 @@
-import exif from 'jpeg-exif';
-
-const MARKERS = [
-  0xffc0, 0xffc1, 0xffc2, 0xffc3, 0xffc5, 0xffc6, 0xffc7, 0xffc8, 0xffc9,
-  0xffca, 0xffcb, 0xffcc, 0xffcd, 0xffce, 0xffcf,
-];
+import _JPEG from 'jay-peg';
 
 class JPEG {
   data = null;
@@ -19,30 +14,20 @@ class JPEG {
       throw new Error('SOI not found in JPEG');
     }
 
-    let marker;
-    let pos = 2;
+    const markers = _JPEG.decode(this.data);
 
-    // Parse the EXIF orientation
-    this.orientation = exif.fromBuffer(this.data).Orientation || 1;
+    for (let i = 0; i < markers.length; i += 1) {
+      const marker = markers[i];
 
-    while (pos < data.length) {
-      marker = data.readUInt16BE(pos);
-      pos += 2;
-      if (MARKERS.includes(marker)) {
-        break;
+      if (marker.name === 'EXIF' && marker.entries.orientation) {
+        this.orientation = marker.entries.orientation;
       }
-      pos += data.readUInt16BE(pos);
+
+      if (marker.name === 'SOF') {
+        this.width ||= marker.width;
+        this.height ||= marker.height;
+      }
     }
-
-    if (!MARKERS.includes(marker)) {
-      throw new Error('Invalid JPEG.');
-    }
-
-    pos += 3;
-    this.height = data.readUInt16BE(pos);
-
-    pos += 2;
-    this.width = data.readUInt16BE(pos);
 
     if (this.orientation > 4) {
       [this.width, this.height] = [this.height, this.width];
@@ -50,28 +35,8 @@ class JPEG {
   }
 }
 
-JPEG.isValid = (data) => {
-  if (!data || !Buffer.isBuffer(data) || data.readUInt16BE(0) !== 0xffd8) {
-    return false;
-  }
-
-  let marker;
-  let pos = 2;
-
-  while (pos < data.length) {
-    marker = data.readUInt16BE(pos);
-    pos += 2;
-    if (MARKERS.includes(marker)) {
-      break;
-    }
-    pos += data.readUInt16BE(pos);
-  }
-
-  if (!MARKERS.includes(marker)) {
-    return false;
-  }
-
-  return true;
+JPEG.isValid = data => {
+  return data && Buffer.isBuffer(data) && data.readUInt16BE(0) === 0xffd8;
 };
 
 export default JPEG;

--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -42,7 +42,7 @@
     "browserify-zlib": "^0.2.0",
     "crypto-js": "^4.2.0",
     "fontkit": "^2.0.2",
-    "jpeg-exif": "^1.1.4",
+    "jay-peg": "^1.0.0",
     "vite-compatible-readable-stream": "^3.6.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5791,6 +5791,13 @@ jake@^10.8.5:
     filelist "^1.0.4"
     minimatch "^3.1.2"
 
+jay-peg@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/jay-peg/-/jay-peg-1.0.0.tgz#20c099750af38e6a53b03f9ccee6f611d16c282c"
+  integrity sha512-rCKRgTXsU/ZhKpmrKSXEodSoVG0EQjpBhxS+jYB8AnI31o0uKLsqR4LNR3seo1+vMARsa0ceXqWe8iq4GR6pIw==
+  dependencies:
+    restructure "^3.0.0"
+
 "jest-diff@>=29.4.3 < 30", jest-diff@^29.4.1:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
@@ -5837,11 +5844,6 @@ jest-worker@^27.4.5:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
-
-jpeg-exif@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/jpeg-exif/-/jpeg-exif-1.1.4.tgz#781a65b6cd74f62cb1c493511020f8d3577a1c2b"
-  integrity sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Fixes: https://github.com/diegomura/react-pdf/issues/2535
Fixes: https://github.com/diegomura/react-pdf/issues/2574

Wrote a JPEG decoder [here](https://github.com/diegomura/jay-peg) that's very performant and leverages restructure which is already used in the project, so it should not add much bundle size (maybe it will even reduce it). This does more than getting EXIF data, so maybe in the future can be used to embed extra info of the image in the document. This should fix the node dep errors people are getting out of `jpeg-exif`