### PR TITLE
fix: add key to pdf viewer iframe

### DIFF
--- a/.changeset/giant-tables-fry.md
+++ b/.changeset/giant-tables-fry.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/renderer": major
+---
+
+Add key to PDFViewer's iframe to fix the browser history issue

--- a/packages/renderer/src/dom/PDFViewer.js
+++ b/packages/renderer/src/dom/PDFViewer.js
@@ -29,6 +29,7 @@ export const PDFViewer = ({
       ref={innerRef}
       style={style}
       className={className}
+      key={crypto.randomUUID()}
       {...props}
     />
   );


### PR DESCRIPTION
## What
Fix the browser history issue
https://stackoverflow.com/questions/45277276/react-router-and-iframe-browser-history
## Why
With React Router, NextJS..., when the PDF data changes and the user clicks to browser's `Back` button, it doesn't go to the previous page
## How
Add a `key` parameter to the PDFViewer's iframe