### PR TITLE
fix: CI workflow error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,7 @@ jobs:
         run: REACT_VERSION=${{ matrix.react_version }} yarn test
 
   e2e-node:
-    name: Run E2E tests (Node.js ${{ matrix.node_version }}; ${{ matrix.cjs_or_esm.toUpperCase() }})
+    name: Run E2E tests (Node.js ${{ matrix.node_version }}; ${{ matrix.cjs_or_esm == 'cjs' ? 'CJS' : 'ESM' }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Fixes an issue where .toUpperCase() was used in an expression that's not JS, causing an error.

Please kindly run this workflow against this branch - no other way to test it, and I can't trigger it myself.