### PR TITLE
fix: rendering of \xc2\xa9 copyright symbol

### DIFF
--- a/packages/layout/src/text/emoji.js
+++ b/packages/layout/src/text/emoji.js
@@ -69,7 +69,12 @@ export const fetchEmojis = (string, source) => {
   return promises;
 };
 
-const specialCases = ['©️', '®', '™']; // Do not treat these as emojis if emoji not present
+/**
+ * Do not treat these as emojis if emoji not present.
+ * Note there are two different copyright symbols
+ *   (\xc2\xa9 and \xc2\xa9\xef\xb8\x8f)
+ */
+const specialCases = ['©', '©️', '®', '™'];
 
 export const embedEmojis = (fragments) => {
   const result = [];


### PR DESCRIPTION
The current `specialCases` in `packages/layout/src/text/emoji.js` only ignores the copyright symbol `\xc2\xa9\xef\xb8\x8f` and not the standard UTF-8 copyright symbol `\xc2\xa9`. The former has the VS-16 variation selector appended to the standard symbol, but the latter still appears to be treated as an emoji and doesn't render.

This PR simply adds the standard copyright symbol `\xc2\xa9` to the `specialCases` array along with some comments explaining why there appears to be two copyright symbols.

Before the fix:
<img width="792" alt="Before" src="https://github.com/diegomura/react-pdf/assets/6438781/5a66a878-7adc-42c2-b1bb-e800020e3545">

After the fix:
<img width="792" alt="After" src="https://github.com/diegomura/react-pdf/assets/6438781/9abc50d4-f7b0-493a-8346-953cdbaacf43">
