### PR TITLE
Fix invalid JPEG image

### DIFF
--- a/packages/pdfkit/src/image/jpeg.js
+++ b/packages/pdfkit/src/image/jpeg.js
@@ -43,7 +43,7 @@ class JPEG {
     this.obj = document.ref({
       Type: 'XObject',
       Subtype: 'Image',
-      BitsPerComponent: this.bits,
+      BitsPerComponent: 8,
       Width: this.width,
       Height: this.height,
       ColorSpace: this.colorSpace,


### PR DESCRIPTION
Fix #2625 

# Before :
<img width="554" alt="image" src="https://github.com/diegomura/react-pdf/assets/3911114/bf00f4ff-5b77-4666-a349-65617946217a">

``` bash
$ pdfcpu validate ./Downloads/document.pdf
validating(mode=relaxed) ./Downloads/document.pdf ...
dereferenceAndLoad: problem dereferencing object 12: strconv.ParseFloat: parsing "undefined": invalid syntax
```

# After :
<img width="554" alt="image" src="https://github.com/diegomura/react-pdf/assets/3911114/b3836e92-aa20-4d72-a6f0-358d4b6ada5b">

``` bash
$ pdfcpu validate ./Downloads/document.pdf
validating(mode=relaxed) ./Downloads/document.pdf ...
validation ok
```
