### PR TITLE
fix: typo that breaks attempts of rendering non-visual elements like DEFS

### DIFF
--- a/packages/render/src/primitives/renderSvg.js
+++ b/packages/render/src/primitives/renderSvg.js
@@ -172,7 +172,7 @@ const renderFns = {
 const renderNode = (ctx, node) => {
   const renderFn = renderFns[node.type];
 
-  if (renderFns) {
+  if (renderFn) {
     renderFn(ctx, node);
   } else {
     console.warn(`SVG node of type ${node.type} is not currenty supported`);


### PR DESCRIPTION
Rendering content that contains `<defs>` fails because `renderFns[node.type];` is undefined for nodeType DEFS, and the check is clearly wrong, since the renderFns is a declared object. Seems a typo.