### PR TITLE
bump yoga layout

### DIFF
--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -37,7 +37,7 @@
     "cross-fetch": "^3.1.5",
     "emoji-regex": "^10.3.0",
     "queue": "^6.0.1",
-    "yoga-layout": "^2.0.1"
+    "yoga-layout": "^3.0.0"
   },
   "files": [
     "lib"


### PR DESCRIPTION
Attempts to fix #2589 

As shown in the comment [here](https://github.com/facebook/yoga/issues/1572#issuecomment-1996299039), Yoga 3.0 (released a couple of hours ago) caches the instance which _should_ fix this WASM memory issue.