### PR TITLE
fix: jpeg precision metadata

### DIFF
--- a/.changeset/wicked-jeans-switch.md
+++ b/.changeset/wicked-jeans-switch.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/pdfkit": patch
+---
+
+fix: jpeg precision metadata

--- a/packages/pdfkit/src/image/jpeg.js
+++ b/packages/pdfkit/src/image/jpeg.js
@@ -26,6 +26,7 @@ class JPEG {
       }
 
       if (marker.name === 'SOF') {
+        this.bits ||= marker.precision;
         this.width ||= marker.width;
         this.height ||= marker.height;
         this.colorSpace ||= COLOR_SPACE_MAP[marker.numberOfComponents];


### PR DESCRIPTION
Fix https://github.com/diegomura/react-pdf/issues/2625

Implementing the improved fix off of the back of oogas pull request, and information from this [comment thread.](https://github.com/diegomura/react-pdf/pull/2646)

- By dynamically adapting to the actual bit depth, we avoid hardcoding 8 bits (which would limit quality for higher bit-depth images).
- Avoids `this.bits` being undefined, which was problematic in more strict PDF viewers such as Adobe, Mac Preview and Safari.

I had the time and wanted to trial the open source flow anyway (Feel free to decline this if this is overstepping someone else's work I'm not trying to take credit or anything, I am simply looking to get this fix rolled out ASAP as we are using it in a company project).

Trying to be helpful in expediting is all.