### PR TITLE
fix: strokeLinecap type

### DIFF
--- a/packages/types/svg.d.ts
+++ b/packages/types/svg.d.ts
@@ -10,7 +10,7 @@ export interface SVGPresentationAttributes {
   fillRule?: 'nonzero' | 'evenodd';
   strokeOpacity?: string | number;
   textAnchor?: 'start' | 'middle' | 'end';
-  strokeLineCap?: 'butt' | 'round' | 'square';
+  strokeLinecap?: 'butt' | 'round' | 'square';
   strokeLinejoin?: 'butt' | 'round' | 'square';
   visibility?: 'visible' | 'hidden' | 'collapse';
   clipPath?: string;


### PR DESCRIPTION
fix for the strokeLinecap type for SVGs

Closes #2707 