### PR TITLE
Add back functionality for bookmark props

### DIFF
--- a/packages/pdfkit/src/mixins/outline.js
+++ b/packages/pdfkit/src/mixins/outline.js
@@ -9,7 +9,9 @@ export default {
     this.outline.endOutline();
     if (this.outline.children.length > 0) {
       this._root.data.Outlines = this.outline.dictionary;
-      return (this._root.data.PageMode = 'UseOutlines');
+      /* Custom fork start */
+      return (this._root.data.PageMode = this._root.data.PageMode || 'UseOutlines');
+      /* Custom fork end */
     }
   }
 };

--- a/packages/pdfkit/src/outline.js
+++ b/packages/pdfkit/src/outline.js
@@ -1,11 +1,32 @@
+/* Custom fork start */
+const DEFAULT_OPTIONS = {
+  top: 0,
+  left: 0,
+  zoom: 0,
+  fit: false,
+  pageNumber: null,
+  expanded: false
+};
+/* Custom fork end */
+
 class PDFOutline {
-  constructor(document, parent, title, dest, options = { expanded: false }) {
+  constructor(document, parent, title, dest, options = DEFAULT_OPTIONS) {
     this.document = document;
     this.options = options;
     this.outlineData = {};
 
     if (dest !== null) {
-      this.outlineData['Dest'] = [dest.dictionary, 'Fit'];
+      /* Custom fork start */
+      const destWidth = dest.data.MediaBox[2];
+      const destHeight = dest.data.MediaBox[3];
+      const top = destHeight - (options.top || 0);
+      const left = destWidth - (options.left || 0);
+      const zoom = options.zoom || 0;
+
+      this.outlineData['Dest'] = options.fit
+        ? [dest, 'Fit']
+        : [dest, 'XYZ', left, top, zoom];
+      /* Custom fork end */
     }
 
     if (parent !== null) {
@@ -20,12 +41,21 @@ class PDFOutline {
     this.children = [];
   }
 
-  addItem(title, options = { expanded: false }) {
+  addItem(title, options = DEFAULT_OPTIONS) {
+    /* Custom fork start */
+    const pages = this.document._root.data.Pages.data.Kids;
+
+    const dest =
+      options.pageNumber !== null
+        ? pages[options.pageNumber]
+        : this.document.page.dictionary;
+    /* Custom fork end */
+
     const result = new PDFOutline(
       this.document,
       this.dictionary,
       title,
-      this.document.page,
+      dest,
       options
     );
     this.children.push(result);


### PR DESCRIPTION
This restores functionality that seemed to have accidentally erased in a [minor version update](https://github.com/diegomura/react-pdf/pull/2532/commits/5139b942eec7674a97195f90b04f4badeeae283d#diff-b715dda1c414782f098d4d383a10d77477178e2f015970666e180a0c20b0da44) to converge the forked `pdfkit` vendor package. This resulted in all bookmarks being created in `fit` mode on the last page not respecting any of the props.

I additionally added some comments to roughly show where the custom logic of this file exists to give some signal that this should not be altered in future fork maintenance.

I tested this locally in a simple repro and observed both the raw output and the PDF in Adobe Reader were again properly linking to the page and respecting props.

There are no unit tests for the custom logic in this vendor package hence I did not add any new ones.

Resolves https://github.com/diegomura/react-pdf/issues/2700