### PR TITLE
fix: support values of `0` in stroke-dasharray

### DIFF
--- a/.changeset/pretty-humans-add.md
+++ b/.changeset/pretty-humans-add.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/pdfkit": patch
+---
+
+fix: support values of `0` in stroke-dasharray

--- a/packages/pdfkit/src/mixins/vector.js
+++ b/packages/pdfkit/src/mixins/vector.js
@@ -67,12 +67,12 @@ export default {
       length = [length, options.space || length];
     }
 
-    const valid = length.every((x) => Number.isFinite(x) && x > 0);
+    const valid = length.every((x) => Number.isFinite(x) && x >= 0);
     if (!valid) {
       throw new Error(
         `dash(${JSON.stringify(originalLength)}, ${JSON.stringify(
           options
-        )}) invalid, lengths must be numeric and greater than zero`
+        )}) invalid, lengths must be numeric and greater than or equal to zero`
       );
     }
 


### PR DESCRIPTION
This code previously required the values in stroke-dasharray to be greater than zero, but zero is actually a valid value. It can be used with stroke-linecap to create dotted lines. [See here](https://codesandbox.io/p/sandbox/blissful-hooks-kslsln?file=%2Fsrc%2FApp.js%3A17%2C11&layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clvb71ixw000620671ab81ot2%2522%252C%2522sizes%2522%253A%255B100%252C0%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clvb71ixw00022067pngpkgya%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clvb71ixw00032067rkeh2nrw%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clvb71ixw000520675gcy9lu4%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clvb71ixw00022067pngpkgya%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clvb71ixw000120677atidcpw%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522clvb77qjx00022067af0oyn2h%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A17%252C%2522startColumn%2522%253A11%252C%2522endLineNumber%2522%253A17%252C%2522endColumn%2522%253A11%257D%255D%252C%2522filepath%2522%253A%2522%252Fsrc%252FApp.js%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clvb71ixw00022067pngpkgya%2522%252C%2522activeTabId%2522%253A%2522clvb77qjx00022067af0oyn2h%2522%257D%252C%2522clvb71ixw000520675gcy9lu4%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clvb71ixw00042067q8xgetxt%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clvb71ixw000520675gcy9lu4%2522%252C%2522activeTabId%2522%253A%2522clvb71ixw00042067q8xgetxt%2522%257D%252C%2522clvb71ixw00032067rkeh2nrw%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522clvb71ixw00032067rkeh2nrw%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)