### PR TITLE
Bump types package

### DIFF
--- a/.changeset/giant-adults-deny.md
+++ b/.changeset/giant-adults-deny.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/types": minor
+---
+
+Allow passing a string array to fontFamily


### PR DESCRIPTION
We updated the `fontFamily` types in #2640 but forgot to bump the version of the types package.