### PR TITLE
fix: font fallbacks types

### DIFF
--- a/.changeset/rare-moles-raise.md
+++ b/.changeset/rare-moles-raise.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/types": minor
+---
+
+accept string array for `fontFamily` in stylesheets

--- a/.changeset/rare-moles-raise.md
+++ b/.changeset/rare-moles-raise.md
@@ -1,5 +1,5 @@
 ---
-"@react-pdf/types": minor
+"@react-pdf/types": patch
 ---
 
 accept string array for `fontFamily` in stylesheets

--- a/packages/types/font.d.ts
+++ b/packages/types/font.d.ts
@@ -20,7 +20,7 @@ export interface FontDescriptor {
 
 interface FontSource {
   src: string;
-  fontFamily: string | string[];
+  fontFamily: string;
   fontStyle: FontStyle;
   fontWeight: number;
   data: any;

--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -64,7 +64,7 @@ export interface Style {
   // Text
 
   fontSize?: number | string;
-  fontFamily?: string;
+  fontFamily?: string | string[];
   fontStyle?: string | 'normal';
   fontWeight?:
     | number


### PR DESCRIPTION
## Context

#2640 Added support for font fallbacks, but we updated the types incorrectly.

`FontSource` should still accept just a `string`.

However, in stylesheets we should be able to specify an array of font families (as shown in the font fallbacks example [here](https://github.com/diegomura/react-pdf/blob/6bf9d990723db757232c42e3a040bbfaa5ceb308/packages/examples/src/fontFamilyFallback/index.jsx#L18)).

## Changes

- Update `FontSource` and `Style` type declarations accordingly
- Bump `types` version