### PR TITLE
fix: available Font Family Regression

### DIFF
--- a/packages/examples/src/fontFamilyFallback/index.jsx
+++ b/packages/examples/src/fontFamilyFallback/index.jsx
@@ -16,7 +16,12 @@ const styles = StyleSheet.create({
   },
   regular: {
     fontFamily: ['Roboto', 'NotoSansArabic'],
+    fontSize: '14',
     fontWeight: 900,
+  },
+  default: {
+    fontFamily: ['Courier-Bold', 'NotoSansArabic'],
+    fontSize: '14',
   },
 });
 
@@ -43,7 +48,19 @@ Font.register({
 const MyDoc = () => {
   return (
     <Page style={styles.body}>
-      <Text style={styles.regular}>Test امتحان</Text>
+      <Text style={{ fontFamily: 'Courier', marginBottom: '10px' }}>
+        This font is default Courier
+      </Text>
+      <Text style={{ fontSize: 10 }}>
+        The following is partially Roboto and Noto Sans Arabic
+      </Text>
+      <Text style={[styles.regular, { marginBottom: '10px' }]}>
+        Roboto / امتحان
+      </Text>
+      <Text style={{ fontSize: 10 }}>
+        The following is partially Courier-Bold and Noto Sans Arabic
+      </Text>
+      <Text style={styles.default}>Courier-Bold / امتحان</Text>
     </Page>
   );
 };

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -51,10 +51,9 @@ const fontSubstitution =
     for (let i = 0; i < runs.length; i += 1) {
       const run = runs[i];
 
-      const defaultFont =
-        typeof run.attributes.font === 'string'
-          ? getOrCreateFont(run.attributes.font)
-          : run.attributes.font;
+      const defaultFont = run.attributes.font.map((font) =>
+        typeof font === 'string' ? getOrCreateFont(font) : font,
+      );
 
       if (string.length === 0) {
         res.push({ start: 0, end: 0, attributes: { font: defaultFont } });
@@ -67,11 +66,7 @@ const fontSubstitution =
         const char = chars[j];
         const codePoint = char.codePointAt();
         // If the default font does not have a glyph and the fallback font does, we use it
-        const font = pickFontFromFontStack(
-          codePoint,
-          run.attributes.font,
-          lastFont,
-        );
+        const font = pickFontFromFontStack(codePoint, defaultFont, lastFont);
         const fontSize = getFontSize(run);
 
         // If anything that would impact res has changed, update it


### PR DESCRIPTION
Changes in #2640 caused a regression by not providing proper support for [font families made available within the library](https://react-pdf.org/fonts#register). This has caused any font families that are built-in to the library to default to Helvetica.

# Changes
- Properly handles `run.attributes.font` as an array so any strings properly`getOrCreateFont` their associated fonts.
- Update the test page to include fonts made available within the library.

# Related
Issue: #2730

# Example
Before the change:
![image](https://github.com/diegomura/react-pdf/assets/24698696/9497718f-7c3d-476a-ab7e-fe3c355dd98a)

After the change:
![image](https://github.com/diegomura/react-pdf/assets/24698696/34b98834-250e-4291-a008-278c6f1098c2)
