### PR TITLE
feat: Use monochrome emojis contained in the font family if no emoji source available

### DIFF
--- a/.changeset/nasty-bags-pay.md
+++ b/.changeset/nasty-bags-pay.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/layout": minor
+---
+
+Use monochrome emojis contained in the font family if no emoji source available

--- a/packages/layout/src/text/emoji.js
+++ b/packages/layout/src/text/emoji.js
@@ -69,8 +69,6 @@ export const fetchEmojis = (string, source) => {
   return promises;
 };
 
-const specialCases = ['©️', '®', '™']; // Do not treat these as emojis if emoji not present
-
 export const embedEmojis = (fragments) => {
   const result = [];
 
@@ -82,8 +80,6 @@ export const embedEmojis = (fragments) => {
     Array.from(fragment.string.matchAll(regex)).forEach((match) => {
       const { index } = match;
       const emoji = match[0];
-      const isSpecialCase = specialCases.includes(emoji);
-
       const emojiSize = fragment.attributes.fontSize;
       const chunk = fragment.string.slice(lastIndex, index + match[0].length);
 
@@ -102,12 +98,10 @@ export const embedEmojis = (fragments) => {
             },
           },
         });
-      } else if (isSpecialCase) {
-        result.push({ string: chunk, attributes: fragment.attributes });
       } else {
-        // If no emoji data, we just replace the emoji with a nodef char
+        // If no emoji data, we try to use emojis in the font
         result.push({
-          string: chunk.replace(match, String.fromCharCode(0)),
+          string: chunk,
           attributes: fragment.attributes,
         });
       }

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -60,7 +60,7 @@ const fontSubstitution =
         break;
       }
 
-      const chars = string.slice(run.start, run.end);
+      const chars = [...string.slice(run.start, run.end)];
 
       for (let j = 0; j < chars.length; j += 1) {
         const char = chars[j];

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -60,7 +60,7 @@ const fontSubstitution =
         break;
       }
 
-      const chars = [...string.slice(run.start, run.end)];
+      const chars = string.slice(run.start, run.end);
 
       for (let j = 0; j < chars.length; j += 1) {
         const char = chars[j];


### PR DESCRIPTION
This pull request proposes to add fallback to monochrome emojis if no emoji image source available. Though react-pdf does not support colour emojis yet, it is useful for monochrome or grayscale documents if we can fallback to the monochrome emojis.