### PR TITLE
Don't insert hyphen after existing hyphen during line split.

### DIFF
--- a/packages/textkit/src/engines/linebreaker/index.js
+++ b/packages/textkit/src/engines/linebreaker/index.js
@@ -9,7 +9,7 @@ import advanceWidthBetween from '../../attributedString/advanceWidthBetween';
  * @typedef {import('../../types.js').Attributes} Attributes
  */
 
-const HYPHEN = 0x002d;
+const HYPHEN = '-';
 const TOLERANCE_STEPS = 5;
 const TOLERANCE_LIMIT = 50;
 
@@ -43,7 +43,9 @@ const breakLines = (string, nodes, breaks) => {
       end = prevNode.value.end;
 
       line = slice(start, end, string);
-      line = insertGlyph(line.length, HYPHEN, line);
+      if (!line.string?.endsWith(HYPHEN)) {
+        line = insertGlyph(line.length, HYPHEN.charCodeAt(0), line);
+      }
     } else {
       end = node.value.end;
       line = slice(start, end, string);


### PR DESCRIPTION
This solves https://github.com/diegomura/react-pdf/issues/2564. When user provides a hyphenation logic that splits text on existing text, an additional hyphen is added currently.

Before - hyphens are duplicated: 
![Duplicated hyphens](https://github.com/diegomura/react-pdf/assets/10278469/efbf9d5a-abc2-45a3-b956-f302312ff568)


After - hyphens are not duplicated: 
![No duplicated hyphens](https://github.com/diegomura/react-pdf/assets/10278469/bc971499-e902-4f08-b6b9-bb96c20faa4c)


[Issue reproduction](https://react-pdf.org/repl?code=3187b0760ce02e00408a057025803c450298c0bc300500943807cf805030c00f0022230080b6198531165d400a02180e619da74e5400a8614b03b0cad0027801b0cd80378a80ee4800994001600b860026000c2600d0c0066e0a00652400bc33e80cc2602f8798d2655d4185a3e329cba72000eba2c3c5048e000c23c0a0a00463cc000d6aaea20004e41d8a42abec20090a090b0e13cb95010383039f9007410e10a485078004400b4dd0400dc64a5a3b9185008b96030d5b510cd8c3ce178f873509648605a12448530c52147304856f85b3b2838d8b8eb0b4a607c7a30bd008c4487c747e393d3b335506197c641e1297c7e5319bac60006a181f5ba40e04c03c0430650bc4223a61a0bd1c6c1f1788c3406084fc582a8007a71248b1942a6f00458aa5d018cc563b08664320009430e92817068003166b8db6185c9e0a888543a0b094e217280000).

I've tested it manually. I don't see existing unit tests for linebreaker.index logic (only for bestFit) and creating them without full understanding of the flow would take me some time.