### PR TITLE
feat: add font feature settings support

### DIFF
--- a/.changeset/six-paws-tie.md
+++ b/.changeset/six-paws-tie.md
@@ -4,4 +4,4 @@
 "@react-pdf/types": minor
 ---
 
-Add support for fontFeatureSettings to customise ligatures, tabular number display, and other font features
+Add support for fontFeatureSettings to customize ligatures, tabular number display, and other font features.

--- a/.changeset/six-paws-tie.md
+++ b/.changeset/six-paws-tie.md
@@ -1,0 +1,7 @@
+---
+"@react-pdf/textkit": minor
+"@react-pdf/layout": minor
+"@react-pdf/types": minor
+---
+
+Add support for fontFeatureSettings to customise ligatures, tabular number display, and other font features

--- a/packages/examples/vite/src/examples/font-feature-settings/index.jsx
+++ b/packages/examples/vite/src/examples/font-feature-settings/index.jsx
@@ -1,0 +1,86 @@
+/* eslint react/prop-types: 0 */
+/* eslint react/jsx-sort-props: 0 */
+
+import { Document, Font, Page, StyleSheet, Text } from '@react-pdf/renderer';
+import React from 'react';
+
+import RobotoFont from '../../../public/Roboto-Regular.ttf';
+import RubikFont from '../../../public/Rubik-Regular.ttf';
+
+const styles = StyleSheet.create({
+  body: {
+    paddingTop: 35,
+    paddingBottom: 45,
+    paddingHorizontal: 35,
+    position: 'relative',
+    fontSize: 14,
+  },
+  headline: {
+    fontFamily: 'Roboto',
+    fontSize: '24',
+    paddingVertical: 12,
+  },
+  rubik: {
+    fontFamily: 'Rubik',
+  },
+  roboto: {
+    fontFamily: 'Roboto',
+  },
+  tabular: {
+    fontFeatureSettings: ['tnum'],
+  },
+  smallCapitals: {
+    fontFeatureSettings: ['smcp'],
+  },
+  disableCommonLigatures: {
+    fontFeatureSettings: { liga: 0 },
+  },
+});
+
+Font.register({
+  family: 'Rubik',
+  fonts: [{ src: RubikFont, fontWeight: 400 }],
+});
+Font.register({
+  family: 'Roboto',
+  fonts: [{ src: RobotoFont, fontWeight: 400 }],
+});
+
+const MyDoc = () => {
+  const longNumberExample = "012'345'678'901";
+  const commonLigaturesExample = 'A firefighter from Sheffield';
+  return (
+    <Page style={styles.body}>
+      <Text style={styles.headline}>Rubik</Text>
+      <Text style={styles.rubik}>{longNumberExample} – Default features</Text>
+      <Text style={[styles.rubik, styles.tabular]}>
+        {longNumberExample} – Tabular numbers
+      </Text>
+      <Text style={styles.headline}>Roboto</Text>
+      <Text style={styles.roboto}>
+        {commonLigaturesExample} – Default features
+      </Text>
+      <Text style={[styles.roboto, styles.disableCommonLigatures]}>
+        {commonLigaturesExample} – Common ligatures off
+      </Text>
+      <Text style={[styles.roboto, styles.smallCapitals]}>
+        {commonLigaturesExample} – Small capitals
+      </Text>
+    </Page>
+  );
+};
+
+const FontFeatureSettings = () => {
+  return (
+    <Document>
+      <MyDoc />
+    </Document>
+  );
+};
+
+export default {
+  id: 'font-feature-settings',
+  name: 'Font Feature Settings',
+  description: '',
+  Document: FontFeatureSettings,
+};

--- a/packages/examples/vite/src/examples/index.ts
+++ b/packages/examples/vite/src/examples/index.ts
@@ -2,7 +2,9 @@ import duplicatedImages from './duplicated-images';
 import ellipsis from './ellipsis';
 import emoji from './emoji';
 import fontFamilyFallback from './font-family-fallback';
+import fontFeatureSettings from './font-feature-settings';
 import fontWeight from './font-weight';
+import forms from './forms';
 import fractals from './fractals';
 import goTo from './go-to';
 import imageStressTest from './image-stress-test';
@@ -18,7 +20,6 @@ import resume from './resume';
 import svg from './svg';
 import svgTransform from './svg-transform';
 import transformOrigin from './transform-origin';
-import forms from './forms';
 
 const EXAMPLES = [
   duplicatedImages,
@@ -26,6 +27,7 @@ const EXAMPLES = [
   emoji,
   fontFamilyFallback,
   fontWeight,
+  fontFeatureSettings,
   fractals,
   goTo,
   JpgOrientation,

--- a/packages/examples/vite/src/index.tsx
+++ b/packages/examples/vite/src/index.tsx
@@ -1,8 +1,8 @@
 import './index.css';
 
+import { PDFViewer } from '@react-pdf/renderer';
 import React, { useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { PDFViewer } from '@react-pdf/renderer';
 
 import EXAMPLES from './examples';
 

--- a/packages/layout/src/steps/resolveInheritance.ts
+++ b/packages/layout/src/steps/resolveInheritance.ts
@@ -12,6 +12,7 @@ const BASE_INHERITABLE_PROPERTIES = [
   'fontSize',
   'fontStyle',
   'fontWeight',
+  'fontFeatureSettings',
   'letterSpacing',
   'opacity',
   'textDecoration',

--- a/packages/layout/src/svg/inheritProps.ts
+++ b/packages/layout/src/svg/inheritProps.ts
@@ -23,6 +23,7 @@ const BASE_SVG_INHERITED_PROPS = [
   'fontSize',
   'fontStyle',
   'fontWeight',
+  'fontFeatureSettings',
   'letterSpacing',
   'opacity',
   'textDecoration',

--- a/packages/layout/src/text/getAttributedString.ts
+++ b/packages/layout/src/text/getAttributedString.ts
@@ -47,6 +47,7 @@ const getFragments = (
     fontWeight,
     fontStyle,
     fontSize = 18,
+    fontFeatureSettings,
     textAlign,
     lineHeight,
     textDecoration,
@@ -100,6 +101,7 @@ const getFragments = (
     // @ts-expect-error allow this props access
     link: parentLink || instance.props?.src || instance.props?.href,
     align: textAlign || (direction === 'rtl' ? 'right' : 'left'),
+    features: fontFeatureSettings,
   };
 
   for (let i = 0; i < instance.children.length; i += 1) {

--- a/packages/layout/tests/steps/resolveInhritance.test.ts
+++ b/packages/layout/tests/steps/resolveInhritance.test.ts
@@ -175,4 +175,8 @@ describe('layout resolveInheritance', () => {
   test('Should inherit textAlign value', shouldInherit('textAlign'));
   test('Should inherit visibility value', shouldInherit('visibility'));
   test('Should inherit wordSpacing value', shouldInherit('wordSpacing'));
+  test(
+    'Should inherit fontFeatureSettings value',
+    shouldInherit('fontFeatureSettings'),
+  );
 });

--- a/packages/stylesheet/src/types.ts
+++ b/packages/stylesheet/src/types.ts
@@ -327,6 +327,7 @@ export type TextStyle = {
   fontFamily?: string | string[];
   fontStyle?: FontStyle;
   fontWeight?: FontWeight;
+  fontFeatureSettings?: string[] | Record<string, boolean>;
   letterSpacing?: number | string;
   lineHeight?: number | string;
   maxLines?: number;

--- a/packages/stylesheet/src/types.ts
+++ b/packages/stylesheet/src/types.ts
@@ -321,13 +321,44 @@ export type TextTransform =
 
 export type VerticalAlign = 'sub' | 'super';
 
+export type FontFeatureSetting =
+  | 'liga'
+  | 'dlig'
+  | 'onum'
+  | 'lnum'
+  | 'tnum'
+  | 'zero'
+  | 'frac'
+  | 'sups'
+  | 'subs'
+  | 'smcp'
+  | 'c2sc'
+  | 'case'
+  | 'hlig'
+  | 'calt'
+  | 'swsh'
+  | 'hist'
+  | 'ss**'
+  | 'kern'
+  | 'locl'
+  | 'rlig'
+  | 'medi'
+  | 'init'
+  | 'isol'
+  | 'fina'
+  | 'mark'
+  | 'mkmk';
+export type FontFeatureSettings =
+  | FontFeatureSetting[]
+  | Record<FontFeatureSetting, number>;
+
 export type TextStyle = {
   direction?: 'ltr' | 'rtl';
   fontSize?: number | string;
   fontFamily?: string | string[];
   fontStyle?: FontStyle;
   fontWeight?: FontWeight;
-  fontFeatureSettings?: string[] | Record<string, boolean>;
+  fontFeatureSettings?: FontFeatureSettings;
   letterSpacing?: number | string;
   lineHeight?: number | string;
   maxLines?: number;

--- a/packages/textkit/src/layout/generateGlyphs.ts
+++ b/packages/textkit/src/layout/generateGlyphs.ts
@@ -42,7 +42,7 @@ const layoutRun = (string: string) => {
    */
   return (run: Run) => {
     const { start, end, attributes = {} } = run;
-    const { font } = attributes;
+    const { font, features } = attributes;
 
     if (!font) return { ...run, glyphs: [], glyphIndices: [], positions: [] };
 
@@ -53,7 +53,7 @@ const layoutRun = (string: string) => {
     // passing LTR To force fontkit to not reverse the string
     const glyphRun = font[0].layout(
       runString,
-      undefined,
+      features,
       undefined,
       undefined,
       'ltr',

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -1,5 +1,6 @@
-import type { Glyph as FontkitGlyph } from 'fontkit';
 import type { Font } from '@react-pdf/font';
+import type { FontFeatureSettings } from '@react-pdf/stylesheet';
+import type { Glyph as FontkitGlyph } from 'fontkit';
 import { Factor as JustificationFactor } from './engines/justification/types';
 
 export type Coordinate = {
@@ -50,7 +51,7 @@ export type Attributes = {
   bullet?: unknown;
   characterSpacing?: number;
   color?: string;
-  direction?: 'rtl' | 'ltr';
+  direction?: FontFeatureSettings;
   features?: unknown[];
   fill?: boolean;
   font?: Font[];


### PR DESCRIPTION
Implements #2155.

This PR adds the `fontFeatureSettings` style property (see [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings) for the CSS equivalent). It takes a list of feature tags, which appends to the default set, or an object to turn on/off individual features, as [supported by fontkit](https://github.com/foliojs/fontkit/blob/5b10bbd91e54ba5972fc8382f325da081003a007/README.md?plain=1#L128-L129).

### Why it matters
This allows users to apply any font features supported by a given font, such as [tabular numbers](https://www.myfonts.com/pages/fontscom-learning-fontology-level-3-numbers-proportional-vs-tabular-figures), [fractions](https://fonts.google.com/knowledge/glossary/fractions), alternate glyphs, control over ligatures, etc.

### Usage
```tsx
const styles = StyleSheet.create({
  numeric: {
    fontFeatureSettings: ['tnum'],
  }
});
```

### Example
A full example is provided in the `examples` package. Here's how it looks like:

![CleanShot 2024-05-05 at 12 05 59@2x](https://github.com/diegomura/react-pdf/assets/5149339/3d5a9d81-d411-4381-ac28-85543b02c71e)