### PR TITLE
fix: font selection regression

### DIFF
--- a/.changeset/nine-ways-walk.md
+++ b/.changeset/nine-ways-walk.md
@@ -1,0 +1,6 @@
+---
+"@react-pdf/examples": patch
+"@react-pdf/layout": patch
+---
+
+fix: font selection regression

--- a/packages/examples/src/fontFamilyFallback/index.jsx
+++ b/packages/examples/src/fontFamilyFallback/index.jsx
@@ -81,7 +81,7 @@ const MyDoc = () => {
       </Text>
 
       <Text style={{ fontSize: 10 }}>
-        The following is multiple font families, weights, and styles all on the
+        The following are multiple font families, weights, and styles all on the
         same line
       </Text>
       <Text style={{ fontFamily: 'Roboto' }}>

--- a/packages/examples/src/fontFamilyFallback/index.jsx
+++ b/packages/examples/src/fontFamilyFallback/index.jsx
@@ -5,6 +5,9 @@ import React from 'react';
 import { Document, Page, Text, StyleSheet, Font } from '@react-pdf/renderer';
 
 import RobotoFont from '../../public/Roboto-Regular.ttf';
+import RobotoBoldFont from '../../public/Roboto-Bold.ttf';
+import RobotItalicFont from '../../public/Roboto-Italic.ttf';
+
 import NotoSansArabicFont from '../../public/NotoSansArabic-Regular.ttf';
 
 const styles = StyleSheet.create({
@@ -30,7 +33,18 @@ Font.register({
   fonts: [
     {
       src: RobotoFont,
-      fontWeight: 400,
+      fontStyle: 'normal',
+      fontWeight: 'normal',
+    },
+    {
+      src: RobotItalicFont,
+      fontStyle: 'italic',
+      fontWeight: 'normal',
+    },
+    {
+      src: RobotoBoldFont,
+      fontStyle: 'normal',
+      fontWeight: 'bold',
     },
   ],
 });
@@ -48,19 +62,36 @@ Font.register({
 const MyDoc = () => {
   return (
     <Page style={styles.body}>
-      <Text style={{ fontFamily: 'Courier', marginBottom: '10px' }}>
+      <Text style={{ fontFamily: 'Courier', marginBottom: '20px' }}>
         This font is default Courier
       </Text>
+
       <Text style={{ fontSize: 10 }}>
         The following is partially Roboto and Noto Sans Arabic
       </Text>
-      <Text style={[styles.regular, { marginBottom: '10px' }]}>
+      <Text style={[styles.regular, { marginBottom: '20px' }]}>
         Roboto / امتحان
       </Text>
+
       <Text style={{ fontSize: 10 }}>
         The following is partially Courier-Bold and Noto Sans Arabic
       </Text>
-      <Text style={styles.default}>Courier-Bold / امتحان</Text>
+      <Text style={[styles.default, { marginBottom: '20px' }]}>
+        Courier-Bold / امتحان
+      </Text>
+
+      <Text style={{ fontSize: 10 }}>
+        The following is multiple font families, weights, and styles all on the
+        same line
+      </Text>
+      <Text style={{ fontFamily: 'Roboto' }}>
+        Roboto Normal{' / '}
+        <Text style={{ fontWeight: 'bold' }}>Roboto Bold</Text>
+        {' / '}
+        <Text style={{ fontStyle: 'italic' }}>Roboto Italic</Text>
+        {' / '}
+        <Text style={{ fontFamily: 'Courier' }}>Courier</Text>
+      </Text>
     </Page>
   );
 };

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -52,11 +52,6 @@ const fontSubstitution =
         typeof font === 'string' ? getOrCreateFont(font) : font,
       );
 
-      console.log(
-        'defaultFontGlyphCount',
-        defaultFont[0].src?.font?.attributes.CharacterSet,
-      );
-
       if (string.length === 0) {
         res.push({ start: 0, end: 0, attributes: { font: defaultFont } });
         break;

--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -20,10 +20,7 @@ const getOrCreateFont = (name) => {
 const getFallbackFont = () => getOrCreateFont('Helvetica');
 
 const pickFontFromFontStack = (codePoint, fontStack, lastFont) => {
-  const fontStackWithFallback = [...fontStack, getFallbackFont()];
-  if (lastFont) {
-    fontStackWithFallback.unshift(lastFont);
-  }
+  const fontStackWithFallback = [...fontStack, lastFont, getFallbackFont()];
   for (let i = 0; i < fontStackWithFallback.length; i += 1) {
     const font = fontStackWithFallback[i];
     if (
@@ -53,6 +50,11 @@ const fontSubstitution =
 
       const defaultFont = run.attributes.font.map((font) =>
         typeof font === 'string' ? getOrCreateFont(font) : font,
+      );
+
+      console.log(
+        'defaultFontGlyphCount',
+        defaultFont[0].src?.font?.attributes.CharacterSet,
       );
 
       if (string.length === 0) {

--- a/packages/layout/tests/text/fontSubstitution.test.js
+++ b/packages/layout/tests/text/fontSubstitution.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest';
+import fontSubstitution from '../../src/text/fontSubstitution';
+
+const instance = fontSubstitution();
+
+describe('FontSubstitution', () => {
+  test('should return empty array if no runs passed', () => {
+    const string = instance({ string: '', runs: [] });
+
+    expect(string).toHaveProperty('runs', []);
+    expect(string).toHaveProperty('string', '');
+  });
+
+  test('should merge consecutive runs with same font', () => {
+    const run1 = { start: 0, end: 3, attributes: { font: ['Helvetica'] } };
+    const run2 = { start: 3, end: 5, attributes: { font: ['Helvetica'] } };
+    const string = instance({ string: 'Lorem', runs: [run1, run2] });
+
+    expect(string).toHaveProperty('string', 'Lorem');
+    expect(string.runs).toHaveLength(1);
+    expect(string.runs[0]).toHaveProperty('start', 0);
+    expect(string.runs[0]).toHaveProperty('end', 5);
+    expect(string.runs[0].attributes.font.name).toBe('Helvetica');
+  });
+
+  test('should substitute many runs', () => {
+    const run1 = { start: 0, end: 3, attributes: { font: ['Courier'] } };
+    const run2 = { start: 3, end: 5, attributes: { font: ['Helvetica'] } };
+    const string = instance({ string: 'Lorem', runs: [run1, run2] });
+
+    expect(string).toHaveProperty('string', 'Lorem');
+    expect(string.runs).toHaveLength(2);
+    expect(string.runs[0]).toHaveProperty('start', 0);
+    expect(string.runs[0]).toHaveProperty('end', 3);
+    expect(string.runs[0].attributes.font.name).toBe('Courier');
+    expect(string.runs[1]).toHaveProperty('start', 3);
+    expect(string.runs[1]).toHaveProperty('end', 5);
+    expect(string.runs[1].attributes.font.name).toBe('Helvetica');
+  });
+
+  describe('Fallback Font', () => {
+    const SimplifiedChineseFont = {
+      name: 'SimplifiedChineseFont',
+      hasGlyphForCodePoint: (codePoint) => codePoint === 20320,
+    };
+
+    test('should utilize a fallback font that supports the provided glyph', () => {
+      const run = {
+        start: 0,
+        end: 1,
+        attributes: {
+          font: ['Courier', SimplifiedChineseFont],
+        },
+      };
+
+      const string = instance({ string: '你', runs: [run] });
+
+      expect(string).toHaveProperty('string', '你');
+      expect(string.runs).toHaveLength(1);
+      expect(string.runs[0]).toHaveProperty('start', 0);
+      expect(string.runs[0]).toHaveProperty('end', 1);
+      expect(string.runs[0].attributes.font.name).toBe(
+        SimplifiedChineseFont.name,
+      );
+    });
+
+    test('should split a run when fallback font is used on a portion of the run', () => {
+      const run = {
+        start: 0,
+        end: 2,
+        attributes: {
+          font: ['Courier', SimplifiedChineseFont],
+        },
+      };
+
+      const string = instance({ string: 'A你', runs: [run] });
+
+      expect(string).toHaveProperty('string', 'A你');
+      expect(string.runs).toHaveLength(2);
+      expect(string.runs[0]).toHaveProperty('start', 0);
+      expect(string.runs[0]).toHaveProperty('end', 1);
+      expect(string.runs[0].attributes.font.name).toBe('Courier');
+      expect(string.runs[1]).toHaveProperty('start', 1);
+      expect(string.runs[1]).toHaveProperty('end', 2);
+      expect(string.runs[1].attributes.font.name).toBe(
+        SimplifiedChineseFont.name,
+      );
+    });
+  });
+});


### PR DESCRIPTION
This recent change https://github.com/diegomura/react-pdf/pull/2640 appears to have caused a regression where the first font used in a line of text is utilized for the entire line. This includes usage of `fontFamily`, `fontWeight`, and `fontStyle`.


# Changes
* Fixed `pickFontFromFontStack` to select from `fontStack` before `lastFont`. This should now properly prioritize fonts
* Added unit tests: `packages/layout/tests/text/fontSubstitution.test.js`
* Updated example document to include this scenario


# Related

* https://github.com/diegomura/react-pdf/pull/2640
* https://github.com/diegomura/react-pdf/issues/2730
* https://github.com/wojtekmaj/react-pdf/issues/1790


# Example
```
<Text style={{ fontSize: 10 }}>
  The following are multiple font families, weights, and styles all on the
  same line
</Text>
<Text style={{ fontFamily: 'Roboto' }}>
  Roboto Normal{' / '}
  <Text style={{ fontWeight: 'bold' }}>Roboto Bold</Text>
  {' / '}
  <Text style={{ fontStyle: 'italic' }}>Roboto Italic</Text>
  {' / '}
  <Text style={{ fontFamily: 'Courier' }}>Courier</Text>
</Text>
```

## Before
<img width="710" alt="example-before" src="https://github.com/diegomura/react-pdf/assets/84044416/63d59db2-ac40-41f4-b813-ab01f5dc5208">

## After
<img width="711" alt="example-after" src="https://github.com/diegomura/react-pdf/assets/84044416/88f2f4f4-2afd-4399-b171-4cf038b07a88">
