### PR TITLE
fix: page dpi

### DIFF
--- a/.changeset/pretty-jars-begin.md
+++ b/.changeset/pretty-jars-begin.md
@@ -1,0 +1,9 @@
+---
+'@react-pdf/layout': minor
+'@react-pdf/pdfkit': minor
+'@react-pdf/render': minor
+'@react-pdf/stylesheet': minor
+'@react-pdf/types': minor
+---
+
+fix: fix dpi

--- a/packages/layout/src/page/getSize.js
+++ b/packages/layout/src/page/getSize.js
@@ -71,18 +71,6 @@ const toSizeObject = (v) => ({ width: v[0], height: v[1] });
 const flipSizeObject = (v) => ({ width: v.height, height: v.width });
 
 /**
- * Adjust page size to passed DPI
- *
- * @param {{ width: number, height: number }} v size object
- * @param {number} dpi DPI
- * @returns {{ width: number, height: number }} adjusted size object
- */
-const adjustDpi = (v, dpi) => ({
-  width: v.width ? v.width * dpi : v.width,
-  height: v.height ? v.height * dpi : v.height,
-});
-
-/**
  * Returns size object from a given string
  *
  * @param {string} v page size string
@@ -108,7 +96,6 @@ const getNumberSize = (n) => toSizeObject([n]);
  */
 const getSize = (page) => {
   const value = page.props?.size || 'A4';
-  const dpi = parseFloat(page.props?.dpi || 72);
 
   const type = typeof value;
 
@@ -126,8 +113,6 @@ const getSize = (page) => {
   } else {
     size = value;
   }
-
-  size = adjustDpi(size, dpi / 72);
 
   return isLandscape(page) ? flipSizeObject(size) : size;
 };

--- a/packages/layout/src/page/getSize.js
+++ b/packages/layout/src/page/getSize.js
@@ -71,6 +71,18 @@ const toSizeObject = (v) => ({ width: v[0], height: v[1] });
 const flipSizeObject = (v) => ({ width: v.height, height: v.width });
 
 /**
+ * Adjust page size to passed DPI
+ *
+ * @param {{ width: number, height: number }} v size object
+ * @param {number} dpi DPI
+ * @returns {{ width: number, height: number }} adjusted size object
+ */
+const adjustDpi = (v, dpi) => ({
+  width: v.width ? v.width * (72 / dpi) : v.width,
+  height: v.height ? v.height * (72 / dpi) : v.height,
+});
+
+/**
  * Returns size object from a given string
  *
  * @param {string} v page size string
@@ -96,6 +108,7 @@ const getNumberSize = (n) => toSizeObject([n]);
  */
 const getSize = (page) => {
   const value = page.props?.size || 'A4';
+  const dpi = parseFloat(page.props?.dpi || 72);
 
   const type = typeof value;
 
@@ -108,10 +121,13 @@ const getSize = (page) => {
     size = getStringSize(value);
   } else if (Array.isArray(value)) {
     size = toSizeObject(value);
+    size = adjustDpi(size, dpi);
   } else if (type === 'number') {
     size = getNumberSize(value);
+    size = adjustDpi(size, dpi);
   } else {
     size = value;
+    size = adjustDpi(size, dpi);
   }
 
   return isLandscape(page) ? flipSizeObject(size) : size;

--- a/packages/layout/src/steps/resolveStyles.js
+++ b/packages/layout/src/steps/resolveStyles.js
@@ -56,7 +56,7 @@ const resolveNodeStyles = (container) => (node) => {
  * @returns {Object} document page with resolved styles
  */
 export const resolvePageStyles = (page) => {
-  const dpi = page.props?.dpi || 72;
+  const dpi = 72; // Removed: page.props?.dpi || 72;
   const width = page.box?.width || page.style.width;
   const height = page.box?.height || page.style.height;
   const orientation = page.props?.orientation || 'portrait';

--- a/packages/stylesheet/src/transform/units.js
+++ b/packages/stylesheet/src/transform/units.js
@@ -22,7 +22,7 @@ const parseValue = (value) => {
 const transformUnit = (container, value) => {
   const scalar = parseValue(value);
 
-  const dpi = container.dpi || 72;
+  const dpi = 72; // Removed: container.dpi || 72
   const mmFactor = (1 / 25.4) * dpi;
   const cmFactor = (1 / 2.54) * dpi;
 


### PR DESCRIPTION
Fix for dpi issue implemented with #1869

fixes #1953 
fixes #2006
fixes #2668 

Unfortunately was~~n't~~ able to get it linked locally so this is **~~untested~~ tested**. Maybe someone could test or have some tip how to get the package tested locally. I followed the steps in the CONTRIBUTION.md and it says it's linked but it does not detect changes using `yarn watch` and doesn't make any changes in my test setup. `yarn bootstrap` is not working for me but for my understanding also should not be needed anymore?

**Edit:** I was able to test this not in local development but in my build and it does the desired job.

## How to test:
- Set up PDF with `<Image style={{width: 100}} />` and `<Text style={{fontSize: 12}}/>` and some basic style. `<page size="A4">`
- Have a look at the result (it's with 72 dpi)
- Change page dpi to 300: `<page size="A4" dpi={300}>`

### Current behavior: (bug)
- After dpi change font gets smaller and page size gets multiplied. So instead of 210x297mm we have 875 x 1238 mm.

### Expected behavior:
- After dpi change layout should remain visually unchanged. Text should be same size and also image.
- Page size should remain 210x297mm, while resulution should be 595x842px in 72 dpi and 2.480x3.508px in 300dpi.