### PR TITLE
fix undefined glyph getting id

### DIFF
--- a/packages/textkit/src/layout/bidiReordering.js
+++ b/packages/textkit/src/layout/bidiReordering.js
@@ -77,6 +77,8 @@ const reorderLine = (attributedString) => {
 
       const glyph = getItemAtIndex(attributedString.runs, 'glyphs', index);
 
+      if (glyph === undefined) continue;
+
       if (addedGlyphs.has(glyph.id)) continue;
 
       updatedGlyphs.push(glyph);


### PR DESCRIPTION
i'm not js developer but i'm getting this error when i try to create bunch of pdfs from our tauri application.
![image](https://github.com/diegomura/react-pdf/assets/7499683/5fa77bf4-e07c-4413-bce9-a5b4112f4117)
![image](https://github.com/diegomura/react-pdf/assets/7499683/5bab6d1c-c81f-4b80-b6c2-ae3b8319273d)
it happens only on a few items, not all.
but this change fixes that.