### PR TITLE
Generate the document's ID on demand instead of the class constructor

### DIFF
--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -115,9 +115,6 @@ class PDFDocument extends stream.Readable {
       });
     }
 
-    // Generate file ID
-    this._id = PDFSecurity.generateFileID(this.info);
-
     // Initialize security settings
     // this._security = PDFSecurity.create(this, options);
 
@@ -131,6 +128,10 @@ class PDFDocument extends stream.Readable {
     if (this.options.autoFirstPage !== false) {
       this.addPage();
     }
+  }
+
+  _id() {
+    return PDFSecurity.generateFileID(this.info);
   }
 
   addPage(options) {
@@ -300,11 +301,12 @@ class PDFDocument extends stream.Readable {
     }
 
     // trailer
+    const id = this._id();
     const trailer = {
       Size: this._offsets.length + 1,
       Root: this._root,
       Info: this._info,
-      ID: [this._id, this._id]
+      ID: [id, id]
     };
 
     // if (this._security) {


### PR DESCRIPTION
Solves #2813.

Referring to #2813, subsequent `<Document />` renders produces a PDF file with non-deterministic `/ID` even though the `creationDate` and `modificationDate` props were set. If I managed to understand correctly, the ID is generated when the `PDFDocument` class was instantiated. However, some of the `.info` object's fields were updated from outside the class instance during the rendering process:

```js
const setPDFMetadata = (target) => (key, value) => {
  if (value) target.info[key] = value;
};

const addMetadata = (ctx, doc) => {
  const setProp = setPDFMetadata(ctx);

  // ...
  const creationDate = props.creationDate || new Date();
  const modificationDate = props.modificationDate || null;

  // ...
  setProp('CreationDate', creationDate);
  setProp('ModificationDate', modificationDate);
};
```

However, the ID was generated based on the `.info` in the constructor and was not updated after the `.info` object was updated. This means that the ID is generated with the default `CreationDate` which is the current time.

```js
// Initialize the metadata
this.info = {
  Producer: 'PDFKit',
  Creator: 'PDFKit',
  CreationDate: new Date()
};

if (this.options.info) {
  for (let key in this.options.info) {
    const val = this.options.info[key];
    this.info[key] = val;
  }
}

this._id = PDFSecurity.generateFileID(this.info);
```

This PR changes the behaviour so that the ID is not generated in the constructor but rather only when it is needed. Therefore, the modifications in the `.info` object should already be made at that point.