### PR TITLE
fix: prevent infinite loop while splitting pages

### DIFF
--- a/.changeset/fair-rocks-leave.md
+++ b/.changeset/fair-rocks-leave.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/layout": patch
+---
+
+fix: prevent infinite loop while splitting pages

--- a/packages/layout/src/steps/resolvePagination.js
+++ b/packages/layout/src/steps/resolvePagination.js
@@ -100,13 +100,19 @@ const splitNodes = (height, contentArea, nodes) => {
 
       // All children are moved to the next page, it doesn't make sense to show the parent on the current page
       if (child.children.length > 0 && currentChild.children.length === 0) {
-        const box = Object.assign({}, child.box, {
-          top: child.box.top - height,
-        });
-        const next = Object.assign({}, child, { box });
+        // But if the current page is empty then we can just include the parent on the current page
+        if (currentChildren.length === 0) {
+          currentChildren.push(child, ...futureFixedNodes);
+          nextChildren.push(...futureNodes);
+        } else {
+          const box = Object.assign({}, child.box, {
+            top: child.box.top - height,
+          });
+          const next = Object.assign({}, child, { box });
 
-        currentChildren.push(...futureFixedNodes);
-        nextChildren.push(next, ...futureNodes);
+          currentChildren.push(...futureFixedNodes);
+          nextChildren.push(next, ...futureNodes);
+        }
         break;
       }
 

--- a/packages/layout/tests/steps/resolvePagination.test.js
+++ b/packages/layout/tests/steps/resolvePagination.test.js
@@ -249,4 +249,44 @@ describe('pagination step', () => {
     expect(page2.children.length).toBe(1);
     expect(page2.children[0].box.height).toBe(40);
   });
+
+  test('should not infinitely loop when splitting pages', async () => {
+    const yoga = await loadYoga();
+
+    const root = {
+      type: 'DOCUMENT',
+      yoga,
+      children: [
+        {
+          type: 'PAGE',
+          box: {},
+          style: {
+            height: 400,
+          },
+          children: [
+            {
+              type: 'VIEW',
+              box: {},
+              style: { height: 401 },
+              children: [
+                {
+                  type: 'VIEW',
+                  box: {},
+                  style: {
+                    height: 400,
+                  },
+                  props: { wrap: false, break: true },
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    calcLayout(root);
+
+    // If calcLayout returns then we did not hit an infinite loop
+    expect(true).toBe(true);
+  });
 });


### PR DESCRIPTION
The existing check for whether all children got moved the next page makes sense if we're already partly through the page - but if this happens before we have anything in `currentChildren` then we'll essentially leave a blank page and move everything to the "next" page, which results in an infinite loop (since the next page never gets smaller).

This PR checks for this situation, and in this case will add the current node to the current page and push the remaining nodes to the next page. This ensures that the next page will get smaller by at least one node so that future iteration won't infinitely loop.

I added a test case that reproduces it - the test doesn't fail it will just hang forever, but if it doesn't loop then the test will pass successfully.

Fixes https://github.com/diegomura/react-pdf/issues/2659