### PR TITLE
fix: rollup config

### DIFF
--- a/packages/renderer/rollup.config.js
+++ b/packages/renderer/rollup.config.js
@@ -46,7 +46,7 @@ const getExternal = ({ browser }) => [
 ];
 
 const getPlugins = ({ browser, declarationDests, minify = false }) => [
-  json(),
+  json({ namedExports: false }),
   ...(browser ? [ignore(['fs', 'path', 'url'])] : []),
   alias({
     entries: {


### PR DESCRIPTION
There is an issue with the latest version in my project (Next.js app):
<img width="942" alt="image" src="https://github.com/user-attachments/assets/3a22a885-c12c-425b-958f-7ff376f3aa17">

After debugging I came to consideration that the issue appears because of rollup config and `module` variable overwrite in `packages/renderer/lib/react-pdf.browser.js` file:
![image](https://github.com/user-attachments/assets/91549233-6b12-4c06-9e9c-9f628f7c6fce)

This overwrite breaks HMR work and crashes all the page.
