### PR TITLE
fix: standard fonts not rendering

### DIFF
--- a/packages/layout/src/text/fontSubstitution.js
+++ b/packages/layout/src/text/fontSubstitution.js
@@ -6,6 +6,8 @@ const fontCache = {};
 
 const IGNORED_CODE_POINTS = [173];
 
+const standard = ['Courier', 'Courier-Bold', 'Courier-Oblique', 'Courier-BoldOblique', 'Helvetica', 'Helvetica-Bold', 'Helvetica-Oblique', 'Helvetica-BoldOblique', 'Times-Roman', 'Times-Bold', 'Times-Italic', 'Times-BoldItalic'];
+
 const getFontSize = (node) => node.attributes.fontSize || 12;
 
 const getOrCreateFont = (name) => {
@@ -23,6 +25,9 @@ const pickFontFromFontStack = (codePoint, fontStack, lastFont) => {
   const fontStackWithFallback = [...fontStack, lastFont, getFallbackFont()];
   for (let i = 0; i < fontStackWithFallback.length; i += 1) {
     const font = fontStackWithFallback[i];
+    if (standard.includes(font)) {
+      return getOrCreateFont(font);
+    }
     if (
       !IGNORED_CODE_POINTS.includes(codePoint) &&
       font &&


### PR DESCRIPTION
This is a follow up fix to my issue https://github.com/diegomura/react-pdf/issues/2818

Problem:
When styling `<Text/>` with standard `fontFamily` such font doesn't render and instead it falls back to `Helvetica` which is the currently configured default font.

Fix:
I copied the following code and included a condition inside `pickFontFromFontStack` to force selecting the font that the user actually picked.
```js
var standard = ['Courier', 'Courier-Bold', 'Courier-Oblique', 'Courier-BoldOblique', 'Helvetica', 'Helvetica-Bold', 'Helvetica-Oblique', 'Helvetica-BoldOblique', 'Times-Roman', 'Times-Bold', 'Times-Italic', 'Times-BoldItalic'];
```

Please review @diegomura 🙏