### PR TITLE
Allow src and href attributes to also be numbers

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -214,8 +214,8 @@ declare namespace ReactPDF {
      * @see https://react-pdf.org/advanced#debugging
      */
     debug?: boolean;
-    href?: string;
-    src?: string;
+    href?: number | string;
+    src?: number | string;
   }
 
   /**


### PR DESCRIPTION
In the `link` annotation, we can see that numbers are accepted to allow linking directly to page numbers.

https://github.com/diegomura/react-pdf/blob/3f5bf67d84ee784b6685cf603f04ac5f568a146d/packages/pdfkit/src/mixins/annotations.js#L57

This PR updates the type definitions of the `src` and `href` attribute on the `Link` component to allow passing in page numbers.