### PR TITLE
fix: check SVG node type is not currently supported

### DIFF
--- a/.changeset/pink-owls-drum.md
+++ b/.changeset/pink-owls-drum.md
@@ -1,0 +1,6 @@
+---
+"@react-pdf/render": patch
+---
+
+[fix] "TypeError: renderFn is not a function"
+It may also address issue #2644

--- a/packages/render/src/primitives/renderSvg.js
+++ b/packages/render/src/primitives/renderSvg.js
@@ -172,10 +172,10 @@ const renderFns = {
 const renderNode = (ctx, node) => {
   const renderFn = renderFns[node.type];
 
-  if (renderFns) {
+  if (renderFn) {
     renderFn(ctx, node);
   } else {
-    console.warn(`SVG node of type ${node.type} is not currenty supported`);
+    console.warn(`SVG node of type ${node.type} is not currently supported`);
   }
 };
 


### PR DESCRIPTION
The check tested the existence of `renderFns` instead of `renderFn`.