### PR TITLE
fix: load yoga binaries only once

### DIFF
--- a/.changeset/bright-ghosts-drum.md
+++ b/.changeset/bright-ghosts-drum.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/layout": patch
+---
+
+Prevent loading yoga-layout wasm binaries more than once

--- a/packages/layout/src/yoga/index.js
+++ b/packages/layout/src/yoga/index.js
@@ -2,8 +2,15 @@
 
 import * as Yoga from 'yoga-layout';
 
+let instance;
+
 export const loadYoga = async () => {
-  const instance = await Yoga.loadYoga();
+  if (!instance) {
+    // Yoga WASM binaries must be asynchronously compiled and loaded
+    // to prevent Event emitter memory leak warnings, Yoga must be loaded only once
+    instance = await Yoga.loadYoga();
+  }
+
   const config = instance.Config.create();
 
   config.setPointScaleFactor(0);


### PR DESCRIPTION
This PR should fix the #2825 

It's not necessary to load and compile yoga-layout WebAssembly binaries more than once. 
https://github.com/facebook/yoga/issues/1320#issuecomment-1616187392

Current master is a bit broken but this is tested top of the [latest release commit](https://github.com/diegomura/react-pdf/commit/6bf9d990723db757232c42e3a040bbfaa5ceb308)
