### PR TITLE
fix: Prevent Yoga init from running more than once

### DIFF
--- a/.changeset/slow-ravens-type.md
+++ b/.changeset/slow-ravens-type.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/layout": patch
+---
+
+Prevent Yoga init from running more than once

--- a/packages/layout/src/yoga/index.js
+++ b/packages/layout/src/yoga/index.js
@@ -2,14 +2,12 @@
 
 import { loadYoga as yogaLoadYoga } from 'yoga-layout/load';
 
-let instance;
+let instancePromise;
 
 export const loadYoga = async () => {
-  if (!instance) {
-    // Yoga WASM binaries must be asynchronously compiled and loaded
-    // to prevent Event emitter memory leak warnings, Yoga must be loaded only once
-    instance = await yogaLoadYoga();
-  }
+  // Yoga WASM binaries must be asynchronously compiled and loaded
+  // to prevent Event emitter memory leak warnings, Yoga must be loaded only once
+  const instance = await (instancePromise ??= yogaLoadYoga());
 
   const config = instance.Config.create();
 


### PR DESCRIPTION
When quickly calling `loadYoga()` multiple times (in a script or web server that generates PDFs, for example), Yoga would try to initialize multiple times and eventually throw a strange error like:

`BindingError: Expected null or instance of Config, got an instance of Config`

Fixes #2892 