### PR TITLE
Fix: Add 'none' option to textTransform property in style interface

### DIFF
--- a/packages/types/style.d.ts
+++ b/packages/types/style.d.ts
@@ -97,7 +97,7 @@ export interface Style {
   textDecorationStyle?: 'dashed' | 'dotted' | 'solid' | string; // ?
   textIndent?: any; // ?
   textOverflow?: 'ellipsis';
-  textTransform?: 'capitalize' | 'lowercase' | 'uppercase';
+  textTransform?: 'capitalize' | 'lowercase' | 'uppercase' | 'none';
   verticalAlign?: 'sub' | 'super';
 
   // Sizing/positioning


### PR DESCRIPTION
**What was changed**: Added the 'none' option to the textTransform property in the style interface.

**Reason for change**: This allows developers to explicitly set textTransform to 'none', which prevents any automatic capitalization or case changes. It provides more flexibility in text styling where no transformation is desired.