### PR TITLE
feat: update SourceURLObject Type

### DIFF
--- a/packages/types/image.d.ts
+++ b/packages/types/image.d.ts
@@ -10,9 +10,9 @@ type SourceDataBuffer = { data: Buffer; format: 'png' | 'jpg' };
 
 type SourceURLObject = {
   uri: string;
-  method: HTTPMethod;
-  body: any;
-  headers: any;
+  method?: HTTPMethod;
+  body?: any;
+  headers?: any;
   credentials?: 'omit' | 'same-origin' | 'include';
 };
 


### PR DESCRIPTION
`<Image src={{ uri: 'https://someurl.com/image.png', credentials: 'include' }}  />`should also be allowed by the type and not throw an error and (except the ts warning) is working as expected.