### PR TITLE
feat: remove cross-fetch

### DIFF
--- a/.changeset/fifty-rockets-relax.md
+++ b/.changeset/fifty-rockets-relax.md
@@ -1,0 +1,7 @@
+---
+"@react-pdf/font": patch
+"@react-pdf/image": patch
+"@react-pdf/layout": patch
+---
+
+feat: remove cross-fetch

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@react-pdf/types": "^2.7.0",
-    "cross-fetch": "^3.1.5",
     "fontkit": "^2.0.2",
     "is-url": "^1.2.4"
   },

--- a/packages/font/setupTests.js
+++ b/packages/font/setupTests.js
@@ -8,5 +8,3 @@ const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
 global.BROWSER = false;
-
-vi.mock('cross-fetch', () => ({ default: global.fetch }));

--- a/packages/font/src/font.js
+++ b/packages/font/src/font.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-classes-per-file */
 
 import isUrl from 'is-url';
-import fetch from 'cross-fetch';
 import * as fontkit from 'fontkit';
 
 const FONT_WEIGHTS = {

--- a/packages/image/package.json
+++ b/packages/image/package.json
@@ -23,7 +23,6 @@
   "dependencies": {
     "@babel/runtime": "^7.20.13",
     "@react-pdf/png-js": "^3.0.0",
-    "cross-fetch": "^3.1.5",
     "jay-peg": "^1.1.0"
   },
   "files": [

--- a/packages/image/src/resolve.js
+++ b/packages/image/src/resolve.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import url from 'url';
 import path from 'path';
-import fetch from 'cross-fetch';
 
 import PNG from './png';
 import JPEG from './jpeg';

--- a/packages/image/vitest.setup.js
+++ b/packages/image/vitest.setup.js
@@ -6,5 +6,3 @@ const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
 global.BROWSER = false;
-
-vi.mock('cross-fetch', () => ({ default: global.fetch }));

--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -26,7 +26,6 @@
     "@react-pdf/stylesheet": "^5.0.0",
     "@react-pdf/textkit": "^5.0.0",
     "@react-pdf/types": "^2.7.0",
-    "cross-fetch": "^3.1.5",
     "emoji-regex": "^10.3.0",
     "queue": "^6.0.1",
     "yoga-layout": "^3.1.0"

--- a/packages/layout/setupTests.js
+++ b/packages/layout/setupTests.js
@@ -8,5 +8,3 @@ const fetchMocker = createFetchMock(vi);
 fetchMocker.enableMocks();
 
 global.BROWSER = false;
-
-vi.mock('cross-fetch', () => ({ default: global.fetch }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4272,7 +4272,7 @@ cross-fetch@4.0.0:
   dependencies:
     node-fetch "^2.6.12"
 
-cross-fetch@^3.0.6, cross-fetch@^3.1.5:
+cross-fetch@^3.0.6:
   version "3.1.8"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.8.tgz#0327eba65fd68a7d119f8fb2bf9334a1a7956f82"
   integrity sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==


### PR DESCRIPTION
Closes: #2925

Node 18 (lowest version we support) has native fetch support so it does no make any point to keep using `cross-fetch`