### PR TITLE
fix: calculate x position of tspan elements without explicit x prop

### DIFF
--- a/packages/layout/src/svg/inheritProps.js
+++ b/packages/layout/src/svg/inheritProps.js
@@ -43,6 +43,13 @@ const inheritProps = (node) => {
   const children = node.children.map((child) => {
     const props = Object.assign({}, inheritedProps, child.props || {});
     const newChild = Object.assign({}, child, { props });
+
+    // Do not inherit "x" for <tspan> elements from <text> parent
+    // If no explicit x is provided, the x-offset will be calculated in layoutText.js
+    if (child.type === 'TSPAN') {
+      newChild.props.x = child.props.x;
+    }
+
     return inheritProps(newChild);
   });
 


### PR DESCRIPTION
Fixes https://github.com/diegomura/react-pdf/issues/2931

If the `x` attribute of a `<tspan>` has not been defined explicitly, the current behavior causes the each `<tspan>` to inherit the `x` value of it's parent `<text>` element.

```js
<Svg>
    <Text x="10" y="30">
        <Tspan>One</Tspan>
        <Tspan>Two</Tspan>
        <Tspan>Three</Tspan>
    </Text>
</Svg>
```

**Is**:
![image](https://github.com/user-attachments/assets/ffdb75f8-8b94-44d3-9085-846c5fc59da6)

**Should**:
![image](https://github.com/user-attachments/assets/e14dfb76-691a-4468-a834-8624126dc783)



This PR fixes this issue by...
- resetting the inherited `x` value to the original `x` value of the `<tspan>`
- aggregating an offset for each children of a `<text>` node and using it as the child node's `x` value, if necessary