### PR TITLE
fix(textkit): make indentation only affect first line.

### DIFF
--- a/.changeset/selfish-rivers-serve.md
+++ b/.changeset/selfish-rivers-serve.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/textkit": patch
+---
+
+fix issue with indentation shrinking all lines

--- a/packages/textkit/src/layout/layoutParagraph.js
+++ b/packages/textkit/src/layout/layoutParagraph.js
@@ -82,7 +82,7 @@ const layoutParagraph = (engines, options) => {
     const rects = generateLineRects(container, height);
 
     const availableWidths = rects.map((r) => r.width);
-    availableWidths[0] -= indent;
+    availableWidths.unshift(availableWidths[0] - indent);
 
     const lines = engines.linebreaker(options)(paragraph, availableWidths);
 


### PR DESCRIPTION
Prepend width minus indentation instead of subtracting the indentation value in first entry of availableWidths.
In the linebreak algorithm, [a line length is determined by the length value provided in the lines array in a specific index](https://github.com/diegomura/react-pdf/blob/master/packages/textkit/src/engines/linebreaker/linebreak.js#L69) or by using the last item of the array, however most of the arrays provided when calling `layoutParagraph` have just a single value. By subtracting the indent from the first value in the array (which in most cases is also the last one) will make all lines that do not have a matching element in the array the same width, hence having a lot of extra whitespace on the right hand side when providing a value for indent.

Closes #2968 