### PR TITLE
fix: conditional rendering

### DIFF
--- a/.changeset/long-elephants-cross.md
+++ b/.changeset/long-elephants-cross.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/reconciler": patch
+---
+
+fix: conditional rendering

--- a/packages/reconciler/package.json
+++ b/packages/reconciler/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "ast-types": "^0.14.2",
-    "react-reconciler-26": "npm:react-reconciler@0.26.0",
+    "react-reconciler-23": "npm:react-reconciler@0.23.0",
     "react-reconciler-31": "npm:react-reconciler@0.31.0-rc-603e6108-20241029",
     "recast": "^0.23.9"
   }

--- a/packages/reconciler/rollup.config.js
+++ b/packages/reconciler/rollup.config.js
@@ -10,13 +10,13 @@ export default [
   {
     input: 'src/index.js',
     output: { format: 'es', file: 'lib/index.js' },
-    external: ['./reconciler-26.js', './reconciler-31.js'],
+    external: ['./reconciler-23.js', './reconciler-31.js'],
   },
   {
-    input: 'src/reconciler-26.js',
-    output: { format: 'es', file: 'lib/reconciler-26.js' },
+    input: 'src/reconciler-23.js',
+    output: { format: 'es', file: 'lib/reconciler-23.js' },
     plugins: [
-      resolve({ resolveOnly: ['react-reconciler-26'] }),
+      resolve({ resolveOnly: ['react-reconciler-23'] }),
       commonjs({ esmExternals: (id) => id === 'scheduler' }),
       trimReconciler(),
       terser({ compress: { dead_code: true } }),

--- a/packages/reconciler/src/index.js
+++ b/packages/reconciler/src/index.js
@@ -3,7 +3,7 @@
 
 import React from 'react';
 import createRendererForReact19 from './reconciler-31.js';
-import createRendererForReact18AndLess from './reconciler-26.js';
+import createRendererForReact18AndLess from './reconciler-23.js';
 
 const isReact19 = React.version.startsWith('19');
 

--- a/packages/reconciler/src/reconciler-23.js
+++ b/packages/reconciler/src/reconciler-23.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/extensions */
 /* eslint-disable import/no-extraneous-dependencies */
-import Reconciler from 'react-reconciler-26/cjs/react-reconciler.production.min.js';
+import Reconciler from 'react-reconciler-23/cjs/react-reconciler.production.min.js';
 
 import propsEqual from './propsEqual';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8734,14 +8734,15 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
-"react-reconciler-26@npm:react-reconciler@0.26.0":
-  version "0.26.0"
-  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.26.0.tgz#053ae2fd1607e38a960e7a694ad694732e4989b6"
-  integrity sha512-n2FJE9vPSiZ0Dn/jaV/iOAO6rXepnk74QGRcgwPSgmN/2syUJnbfEz7Bw5yodBfJhjA3L7cu1YdImYISTj4KZQ==
+"react-reconciler-23@npm:react-reconciler@0.23.0":
+  version "0.23.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.23.0.tgz#5f0bfc35dda030b0220c07de11f93131c5d6db63"
+  integrity sha512-vV0KlLimP9a/NuRcM6GRVakkmT6MKSzhfo8K72fjHMnlXMOhz9GlPe+/tCp5CWBkg+lsMUt/CR1nypJBTPfwuw==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-    scheduler "^0.20.0"
+    prop-types "^15.6.2"
+    scheduler "^0.17.0"
 
 "react-reconciler-31@npm:react-reconciler@0.31.0-rc-603e6108-20241029":
   version "0.31.0-rc-603e6108-20241029"
@@ -9232,6 +9233,14 @@ scheduler@0.25.0-rc-66855b96-20241106:
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.25.0-rc-66855b96-20241106.tgz#8bbb728eca4de5a5deca1f18370fbce41aee91d1"
   integrity sha512-HQXp/Mnp/MMRSXMQF7urNFla+gmtXW/Gr1KliuR0iboTit4KvZRY8KYaq5ccCTAOJiUqQh2rE2F3wgUekmgdlA==
 
+scheduler@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.17.0.tgz#7c9c673e4ec781fac853927916d1c426b6f3ddfe"
+  integrity sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 scheduler@^0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.19.1.tgz#4f3e2ed2c1a7d65681f4c854fa8c5a1ccb40f196"
@@ -9240,7 +9249,7 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
-scheduler@^0.20.0, scheduler@^0.20.2:
+scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
   integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==


### PR DESCRIPTION
Fixes #2978
Fixes #2982
Fixes #2973
Fixes #2957

Rollback to reconciler v23 for React 16, 17 and 18, which is what we historically used. I bumped it on the latest changes thinking it would be fine, but apparently I need a change I ignore. There's no reason why not going back to this. Has been working great for many years. People will start migrating to React 19 eventually and this will get deprecated over time