### PR TITLE
fix: PDFDownloadLink Children Function Type Error

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -496,11 +496,14 @@ declare namespace ReactPDF {
   export class PDFViewer extends React.Component<PDFViewerProps> {}
 
   interface PDFDownloadLinkProps
-    extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+    extends Omit<
+      React.AnchorHTMLAttributes<HTMLAnchorElement>,
+      'href' | 'children'
+    > {
     /** PDF filename. Alias for anchor tag `download` attribute. */
     fileName?: string;
     document: React.ReactElement<DocumentProps>;
-    children?: React.ReactNode | React.ReactElement<BlobProviderParams>;
+    children?: React.ReactNode | React.FC<BlobProviderParams>;
     onClick?: React.AnchorHTMLAttributes<HTMLAnchorElement>['onClick'] &
       ((
         event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,


### PR DESCRIPTION
name: Bug report  
about: Children Function Type Incompatibility in PDFDownloadLinkProps
title: 'TS2769: No overload matches this call in PDFDownloadLink'  
labels: 'bug'  
assignees: @islam-kamel

---

**Describe the bug**  
Encountering a TypeScript error `TS2769: No overload matches this call` when using `PDFDownloadLink`. The error suggests that the provided `({loading}: { loading: any; }) => Element` is not assignable to the expected type `ReactNode | ReactElement<BlobProviderParams, string | JSXElementConstructor<any>>`.  

**To Reproduce**  
Steps to reproduce the behavior:  

1. Use `PDFDownloadLink` with the following setup:  
    ```tsx
    import { PDFDownloadLink } from '@react-pdf/renderer';

    const MyDocument = () => (
      <Document>
        <Page>
          <Text>Hello, world!</Text>
        </Page>
      </Document>
    );

    const DownloadLink = () => (
      <PDFDownloadLink document={<MyDocument />} fileName="example.pdf">
        {({ loading }) => (loading ? 'Loading...' : 'Download PDF')}
      </PDFDownloadLink>
    );
    ```

2. Run `tsc` or start the application.  
3. Observe the TypeScript error:  

    ```
    TS2769: No overload matches this call.
    Overload 1 of 2,
    (props: PDFDownloadLinkProps | Readonly<PDFDownloadLinkProps>): PDFDownloadLink,
    gave the following error.
    Type ({loading}: { loading: any; }) => Element is not assignable to type
    ReactNode | ReactElement<BlobProviderParams, string | JSXElementConstructor<any>>.
    Overload 2 of 2,
    (props: PDFDownloadLinkProps, context: any): PDFDownloadLink,
    gave the following error.
    Type ({loading}: { loading: any; }) => Element is not assignable to type
    ReactNode | ReactElement<BlobProviderParams, string | JSXElementConstructor<any>>.
    ```

**Expected behavior**  
The `PDFDownloadLink` should correctly accept the child render function and render "Loading..." while the document is being prepared or "Download PDF" when ready.  

**Screenshots**  
![image](https://github.com/user-attachments/assets/336b2eb8-f4dc-45af-ae8a-7b91dd34bb58)

**Desktop (please complete the following information):**  

- **OS**: [Windows]  
- **Browser**: [Edge]  
- **React-pdf version**: [4.1.6]  
- **TypeScript version**: [5.6.2]  
