### PR TITLE
fix: PDFDownloadLinkProps Type Error

### DIFF
--- a/.changeset/neat-otters-jump.md
+++ b/.changeset/neat-otters-jump.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/renderer": patch
+---
+
+fix: PDFDownloadLinkProps Type Error

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -496,11 +496,14 @@ declare namespace ReactPDF {
   export class PDFViewer extends React.Component<PDFViewerProps> {}
 
   interface PDFDownloadLinkProps
-    extends Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'href'> {
+    extends Omit<
+      React.AnchorHTMLAttributes<HTMLAnchorElement>,
+      'href' | 'children'
+    > {
     /** PDF filename. Alias for anchor tag `download` attribute. */
     fileName?: string;
     document: React.ReactElement<DocumentProps>;
-    children?: React.ReactNode | React.ReactElement<BlobProviderParams>;
+    children?: React.ReactNode | React.FC<BlobProviderParams>;
     onClick?: React.AnchorHTMLAttributes<HTMLAnchorElement>['onClick'] &
       ((
         event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,


### PR DESCRIPTION
Fix #3012 
**Description:**
This pull request addresses the TypeScript error `TS2769: No overload matches this call` that occurs when using `PDFDownloadLink` as described in issue [#3012](https://github.com/diegomura/react-pdf/issues/3012).

**Changes:**
- Updated the type definitions for `PDFDownloadLink` to correctly accept the child render function.
- Adjusted the implementation to align with the expected types.

**Steps to Reproduce:**
1. Use `PDFDownloadLink` with the following setup:
    ```tsx
    import { PDFDownloadLink } from '@react-pdf/renderer';

    const MyDocument = () => (
      <Document>
        <Page>
          <Text>Hello, world!</Text>
        </Page>
      </Document>
    );

    const DownloadLink = () => (
      <PDFDownloadLink document={<MyDocument />} fileName="example.pdf">
        {({ loading }) => (loading ? 'Loading...' : 'Download PDF')}
      </PDFDownloadLink>
    );
    ```
2. Run `tsc` or start the application.
3. Observe the TypeScript error.