### PR TITLE
chore: be more specific on an error log

### DIFF
--- a/packages/font/src/font.js
+++ b/packages/font/src/font.js
@@ -137,7 +137,7 @@ class Font {
 
     if (!res) {
       throw new Error(
-        `Could not resolve font for ${this.family}, fontWeight ${fontWeight}`,
+        `Could not resolve font for ${this.family}, fontWeight ${fontWeight}, fontStyle ${fontStyle}`,
       );
     }
 


### PR DESCRIPTION
It helps knowing if the error is general (wrong source path...), or just a specific like an italic font missing.