### PR TITLE
fix: make stop method available for Canvas painter objects

### DIFF
--- a/packages/layout/src/canvas/measureCanvas.js
+++ b/packages/layout/src/canvas/measureCanvas.js
@@ -85,6 +85,7 @@ const measureCtx = () => {
   ctx.strokeOpacity = nil;
   ctx.linearGradient = nil;
   ctx.radialGradient = nil;
+  ctx.stop = nil;
 
   ctx.getWidth = () => getMax(points.map((p) => p[0]));
   ctx.getHeight = () => getMax(points.map((p) => p[1]));

--- a/packages/render/src/primitives/renderCanvas.js
+++ b/packages/render/src/primitives/renderCanvas.js
@@ -33,20 +33,23 @@ const availableMethods = [
   'quadraticCurveTo',
   'linearGradient',
   'radialGradient',
+  // 'stop',
 ];
 
+const gradientMethods = ['linearGradient', 'radialGradient'];
+
 const painter = (ctx) => {
-  const p = availableMethods.reduce(
-    (acc, prop) => ({
-      ...acc,
-      [prop]: (...args) => {
+  const p = {};
+  availableMethods.forEach((prop) => {
+    if (gradientMethods.includes(prop)) {
+      p[prop] = (...args) => ctx[prop](...args);
+    } else {
+      p[prop] = (...args) => {
         ctx[prop](...args);
         return p;
-      },
-    }),
-    {},
-  );
-
+      };
+    }
+  });
   return p;
 };
 

--- a/packages/render/tests/ctx.js
+++ b/packages/render/tests/ctx.js
@@ -51,6 +51,7 @@ const createCTX = () => {
   instance._root = { data: { AcroForm: {} } };
   instance.textInput = vi.fn().mockReturnValue(instance);
   instance.formField = vi.fn().mockReturnValue(instance);
+  instance.stop = vi.fn().mockReturnValue(instance);
 
   return instance;
 };

--- a/packages/render/tests/primitives/renderCanvas.test.js
+++ b/packages/render/tests/primitives/renderCanvas.test.js
@@ -68,3 +68,12 @@ describe('primitive renderCanvas', () => {
     renderCanvas(ctx, node);
   });
 });
+test('should be scoped operation - gradient', () => {
+  const ctx = createCTX();
+  const box = { top: 20, left: 40, width: 140, height: 200 };
+  const node = { type: P.Canvas, box, props: {} };
+  ctx.radialGradient(1, 2, 3, 4, 5, 6);
+  ctx.stop();
+  renderCanvas(ctx, node);
+  expect(ctx.stop.mock.calls).toHaveLength(1);
+});


### PR DESCRIPTION
### Describe the bug

In order to use radialGradient in Canvas, we need to call the stop method, and the stop method is not available.

<img width="400" alt="스크린샷 2025-02-10 오후 4 20 00" src="https://github.com/user-attachments/assets/b04773e7-739c-44f7-ad89-30921cfa5b85" />


### To Reproduce

If you call the stop method after using radialGradient on the painter object in Canvas, as shown in the code below, you will get an error.

```jsx
<Canvas
        paint={(painter) => {
          const centerX = 250;
          const centerY = 250;
          const startRadius = 30;
          const fillRadius = 30;
          const subStartAngle = 0;
          const subEndAngle = 2 * Math.PI;
          // Attempt to create a radial gradient with color stops
          const gradient = painter.radialGradient(
            centerX,
            centerY,
            startRadius,
            centerX,
            centerY,
            fillRadius,
          );
          gradient.stop(0, '#FFF');
          gradient.stop(1, '#000');
          painter
            .save()
            .path(
              drawSector(
                centerX,
                centerY,
                fillRadius,
                subStartAngle,
                subEndAngle,
              ),
            )
            .fill(gradient)
            .restore();
          return painter;
        }}
      />
```

### Expected behavior

1. add gradientMethods
```js
// renderCanvas.js
const gradientMethods = ['linearGradient', 'radialGradient'];

const painter = (ctx) => {
  const p = {};
  availableMethods.forEach((prop) => {
    if (gradientMethods.includes(prop)) {
      p[prop] = (...args) => ctx[prop](...args);
    } else {
      p[prop] = (...args) => {
        ctx[prop](...args);
        return p;
      };
    }
  });
  return p;
};
```

2. add ctx.stop in `measureCanvas.js`
```js
// measureCanvas.js
const measureCtx = () => {
  const ctx = {};
  const points = [];
  const nil = () => ctx;
  ...
  ctx.linearGradient = nil;
  ctx.radialGradient = nil;
  ctx.stop = nil;

  ctx.getWidth = () => getMax(points.map((p) => p[0]));
  ctx.getHeight = () => getMax(points.map((p) => p[1]));

  return ctx;
};
```

### Screenshots

This is a canvas chart using a radial gradient that I wanted to implement.

<img width="438" alt="스크린샷 2025-02-10 오후 4 17 57" src="https://github.com/user-attachments/assets/3b29925f-8d54-44fe-9fd8-6ff89e604e2e" />




### Desktop (please complete the following information):

    OS: [MacOS]
    Browser: [Chrome, Safari]
    React-pdf version: [4.2.1]

