### PR TITLE
feat: add closePath and transform in renderCanvas available methods

### DIFF
--- a/.changeset/ninety-mugs-marry.md
+++ b/.changeset/ninety-mugs-marry.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/render": minor
+---
+
+feat: add closePath and transform in renderCanvas available methods

--- a/packages/render/src/primitives/renderCanvas.js
+++ b/packages/render/src/primitives/renderCanvas.js
@@ -33,6 +33,8 @@ const availableMethods = [
   'quadraticCurveTo',
   'linearGradient',
   'radialGradient',
+  'closePath',
+  'transform',
 ];
 
 const painter = (ctx) => {


### PR DESCRIPTION
### Summary
This PR enable SVG rendering in the `<Canvas>` painter by using [svg-to-pdfkit](https://www.npmjs.com/package/svg-to-pdfkit).

### Background
Since the canvas painter is a doc from pdfkit, I investigated whether svgToPdfkit could be used directly. I found that it works as long as transform and clipPath are exposed.

### Related Issues
(None, but let me know if one should be created.)

### Usage
```tsx
import React from 'react';

import { Canvas } from '@react-pdf/renderer';

import SVGtoPDF from 'svg-to-pdfkit';

const svg = `
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
<path d="M50,3l12,36h38l-30,22l11,36l-31-21l-31,21l11-36l-30-22h38z" fill="#FF0" stroke="#FC0" stroke-width="2"/>
</svg>
`;

const Star = () => (
  <Canvas
    style={{
      width: '100%',
      height: 100,
    }}
    paint={(painter, availableWidth, availableHeight) => {
      SVGtoPDF(painter, svg, 0, 0, {
        width: availableWidth,
        height: availableHeight,
      });
    }}
  ></Canvas>
);

export default Star;
```

### Screenshots
![スクリーンショット 2025-02-17 21 11 42](https://github.com/user-attachments/assets/93392505-8b3b-4e89-b676-cc997be62338)
