### PR TITLE
feat(pdfdownloadlink): add a ref to the link component

### DIFF
--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -611,6 +611,7 @@ declare namespace ReactPDF {
         event: React.MouseEvent<HTMLAnchorElement, MouseEvent>,
         instance: UsePDFInstance,
       ) => void);
+    ref?: React.Ref<HTMLAnchorElement> | undefined;
   }
 
   /**

--- a/packages/renderer/src/dom/PDFDownloadLink.js
+++ b/packages/renderer/src/dom/PDFDownloadLink.js
@@ -1,15 +1,15 @@
-import { useEffect } from 'react';
+import { forwardRef, useEffect } from 'react';
 
 import usePDF from './usePDF';
 
-export const PDFDownloadLink = ({
+const PDFDownloadLinkBase = ({
   fileName = 'document.pdf',
   document: doc,
   children,
   onClick,
   href,
   ...rest
-}) => {
+}, ref) => {
   const [instance, updateInstance] = usePDF();
 
   useEffect(() => updateInstance(doc), [doc]);
@@ -32,10 +32,12 @@ export const PDFDownloadLink = ({
   };
 
   return (
-    <a href={instance.url} download={fileName} onClick={handleClick} {...rest}>
+    <a href={instance.url} download={fileName} onClick={handleClick} ref={ref} {...rest}>
       {typeof children === 'function' ? children(instance) : children}
     </a>
   );
 };
+
+export const PDFDownloadLink = forwardRef(PDFDownloadLinkBase)
 
 export default PDFDownloadLink;


### PR DESCRIPTION
The `PDFDownloadLink` component does not forward its ref to the inner anchor yet. Adding a ref would enable the caller to focus it programmatically, or to integrate it properly with libraries like MUI https://mui.com/material-ui/