### PR TITLE
fix(pdfkit): add pako as a direct dependency

### DIFF
--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -35,7 +35,8 @@
     "fontkit": "^2.0.2",
     "jay-peg": "^1.1.1",
     "linebreak": "^1.1.0",
-    "vite-compatible-readable-stream": "^3.6.1"
+    "vite-compatible-readable-stream": "^3.6.1",
+    "pako": "~1.0.5"
   },
   "devDependencies": {
     "iconv-lite": "^0.4.13"


### PR DESCRIPTION
From https://github.com/diegomura/react-pdf/issues/2335 

`yarn modern` doesnt see `pako` as a dependency and throws errors like this:
```
The Yarn Plug'n'Play manifest forbids importing "pako" here because it's not listed as a dependency of this package:
 ```

Adding `pako` as a direct dependency may help.. 
Such package.json modification doesnt lead to yarn.lock change - so there souldnt be any impact

`pako@~1.0.5` is a dependency introduced by `browserify-zlib`
`pako@^0.2.5` is a dependency introduced by `unicode-trie`, which is not a direct dependency and doesnt seem to break yarn