### PR TITLE
fix: undefined and null bookmark prop values are rendered instead of being skipped

### DIFF
--- a/packages/layout/src/steps/resolveBookmarks.ts
+++ b/packages/layout/src/steps/resolveBookmarks.ts
@@ -31,7 +31,7 @@ const resolveBookmarks = (node: DocumentNode) => {
 
     let parent = element.parent;
 
-    if (child.props && 'bookmark' in child.props) {
+    if (child.props && 'bookmark' in child.props && child.props.bookmark) {
       const bookmark = getBookmarkValue(child.props.bookmark);
       const ref = refs++;
       const newHierarchy = { ref, parent: parent?.ref, ...bookmark };

--- a/packages/layout/tests/steps/resolveBookmarks.test.ts
+++ b/packages/layout/tests/steps/resolveBookmarks.test.ts
@@ -18,7 +18,72 @@ describe('layout resolveBookmarks', () => {
 
     const result = resolveBookmarks(root);
 
-    expect(result).toEqual(root);
+    expect(result).toEqual({
+      type: 'DOCUMENT',
+      props: {},
+      children: [
+        {
+          type: 'PAGE',
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    });
+  });
+
+  test('should keep nodes the same if an undefined bookmark passed', () => {
+    const root = {
+      type: 'DOCUMENT',
+      props: {},
+      children: [
+        {
+          type: 'PAGE',
+          props: { bookmark: undefined },
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    } as DocumentNode;
+
+    const result = resolveBookmarks(root);
+
+    expect(result).toEqual({
+      type: 'DOCUMENT',
+      props: {},
+      children: [
+        {
+          type: 'PAGE',
+          props: { bookmark: undefined },
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    });
+  });
+
+  test('should keep nodes the same if a null bookmark passed', () => {
+    const root = {
+      type: 'DOCUMENT',
+      props: {},
+      children: [
+        {
+          type: 'PAGE',
+          props: { bookmark: null },
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    } as DocumentNode;
+
+    const result = resolveBookmarks(root);
+
+    expect(result).toEqual({
+      type: 'DOCUMENT',
+      props: {},
+      children: [
+        {
+          type: 'PAGE',
+          props: { bookmark: null },
+          children: [{ type: 'VIEW', props: {} }],
+        },
+      ],
+    });
   });
 
   test('should resolve bookmark in page node', () => {


### PR DESCRIPTION
[This change](https://github.com/diegomura/react-pdf/commit/481b536f4ad145fb227829399b85a35838a506f8#diff-314d8c0c863d18f6faee1ffac3994f6e232801400e3f13ba9564a8fac61f42f8R34) introduced a regression where a `null` or `undefined` value for the `bookmark` props would be rendered like this

<img width="287" alt="Screenshot 2025-04-04 at 10 34 49 PM" src="https://github.com/user-attachments/assets/e0ea54a5-e3f9-43e4-8f12-e1167373ec43" />

instead of being skipped. This PR fixes that and introduced a test to catch that.