### PR TITLE
fix: treat wrap={undefined} like an omitted wrap prop

### DIFF
--- a/.changeset/fix-undefined-wrap.md
+++ b/.changeset/fix-undefined-wrap.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/layout': patch
+---
+
+Treat an explicit `wrap={undefined}` like an omitted `wrap` prop (default `true`). `null` and `false` still disable wrapping.

--- a/packages/layout/src/node/getWrap.ts
+++ b/packages/layout/src/node/getWrap.ts
@@ -8,7 +8,9 @@ const getWrap = (node: SafeNode) => {
 
   if (!node.props) return true;
 
-  return 'wrap' in node.props ? node.props.wrap : true;
+  return 'wrap' in node.props
+    ? node.props.wrap === undefined || node.props.wrap === true
+    : true;
 };
 
 export default getWrap;

--- a/packages/layout/tests/node/getWrap.test.ts
+++ b/packages/layout/tests/node/getWrap.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from 'vitest';
+
+import getWrap from '../../src/node/getWrap';
+
+describe('node getWrap', () => {
+  test('Should return false by default for non-wrap types', () => {
+    const svgResult = getWrap({ type: 'SVG', props: {}, style: {} });
+    expect(svgResult).toBe(false);
+
+    const noteResult = getWrap({ type: 'NOTE', props: {}, style: {} });
+    expect(noteResult).toBe(false);
+
+    const imageResult = getWrap({
+      type: 'IMAGE',
+      props: { src: '' },
+      style: {},
+    });
+    expect(imageResult).toBe(false);
+
+    const canvasResult = getWrap({
+      type: 'CANVAS',
+      props: { paint: () => null },
+      style: {},
+    });
+    expect(canvasResult).toBe(false);
+  });
+
+  test('Should return true by default for other types', () => {
+    const viewResult = getWrap({ type: 'VIEW', props: {}, style: {} });
+    expect(viewResult).toBe(true);
+
+    const textResult = getWrap({ type: 'TEXT', props: {}, style: {} });
+    expect(textResult).toBe(true);
+  });
+
+  test('Should return true if wrap value is undefined', () => {
+    const undefinedResult = getWrap({
+      type: 'VIEW',
+      props: { wrap: undefined },
+      style: {},
+    });
+    expect(undefinedResult).toBe(true);
+  });
+
+  test('Should return false if wrap value is null', () => {
+    // @ts-expect-error Deliberately testing an invalid case to ensure it's also handled gracefully
+    const nullResult = getWrap({
+      type: 'VIEW',
+      props: { wrap: null },
+      style: {},
+    });
+    expect(nullResult).toBe(false);
+  });
+
+  test('Should return the custom wrap value if provided', () => {
+    const trueResult = getWrap({
+      type: 'VIEW',
+      props: { wrap: true },
+      style: {},
+    });
+    expect(trueResult).toBe(true);
+
+    const falseResult = getWrap({
+      type: 'VIEW',
+      props: { wrap: false },
+      style: {},
+    });
+    expect(falseResult).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Similar to #3149 and #3142, this fixes a regression from [the layout TypeScript conversion](https://github.com/diegomura/react-pdf/commit/481b536f4ad145fb227829399b85a35838a506f8#diff-787134450138de88787ea4fed051cb798a2e3a5816955746ab7730617ae6d6e3R11).

After that change, an explicit `wrap={undefined}` was treated as falsy (no wrapping), while an omitted `wrap` prop still defaulted to `true`. Those should behave the same.

### Behaviour

| Usage | Result |
| --- | --- |
| `<View />` | `true` |
| `<View wrap={undefined} />` | `true` |
| `<View wrap={null} />` | `false` |
| `<View wrap={false} />` | `false` |
| `<View wrap={true} />` | `true` |

`null` stays falsy (disables wrapping). Only `undefined` / omitted use the default.

Also adds unit tests for `getWrap`.

## Test plan

- [x] `yarn vitest run packages/layout/tests/node/getWrap.test.ts`
- [ ] Confirm wrapping still works for views with no `wrap` prop
- [ ] Confirm `wrap={false}` still prevents page breaks inside the view