### PR TITLE
Always return both height and width when measuring text

### DIFF
--- a/.changeset/lemon-dolphins-hunt.md
+++ b/.changeset/lemon-dolphins-hunt.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/layout": patch
+---
+
+Fix yoga error Invalid array length at Array.push(<anonymous>)

--- a/packages/layout/src/text/measureText.ts
+++ b/packages/layout/src/text/measureText.ts
@@ -26,7 +26,7 @@ const measureText =
     if (widthMode === Yoga.MeasureMode.Exactly) {
       if (!node.lines) node.lines = layoutText(node, width, height, fontStore);
 
-      return { height: linesHeight(node) };
+      return { height: linesHeight(node), width };
     }
 
     if (widthMode === Yoga.MeasureMode.AtMost) {

--- a/packages/layout/tests/text/measureText.test.ts
+++ b/packages/layout/tests/text/measureText.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'vitest';
+
+import * as P from '@react-pdf/primitives';
+import FontStore from '@react-pdf/font';
+import { SafeTextNode } from '../../src';
+import measureText from '../../src/text/measureText';
+
+const TEXT =
+  'Life can be much broader once you discover one simple fact: Everything around you that you call life was made up by people that were no smarter than you';
+
+const fontStore = new FontStore();
+
+const createTextNode = (
+  value: string,
+  style = {},
+  props = {},
+): SafeTextNode => ({
+  style,
+  props,
+  type: P.Text,
+  children: [{ type: P.TextInstance, value }],
+});
+
+describe('measureText', () => {
+  describe('widthMode Exactly', () => {
+    test('should return width and height', async () => {
+      const page = {
+        type: 'PAGE' as const,
+        props: {},
+        style: {},
+      };
+      const node = createTextNode(TEXT);
+      const measureFunc = measureText(page, node, fontStore);
+
+      const dimensions = measureFunc(100, 1 /*Yoga.MeasureMode.Exactly*/, 50);
+
+      expect(dimensions.width).toStrictEqual(100);
+      expect(dimensions.height).toBe(39.599999999999994);
+    });
+  });
+
+  describe('widthMode AtMost', () => {
+    test('should return width and height', async () => {
+      const page = {
+        type: 'PAGE' as const,
+        props: {},
+        style: {},
+      };
+      const node = createTextNode(TEXT);
+      const measureFunc = measureText(page, node, fontStore);
+
+      const dimensions = measureFunc(100, 2 /*Yoga.MeasureMode.AtMost*/, 50);
+
+      expect(dimensions.width).toStrictEqual(100);
+      expect(dimensions.height).toBe(39.599999999999994);
+    });
+  });
+});


### PR DESCRIPTION
Fixes #2974
Returning an undefined width translated into a NaN width when passing the measurement result back to yoga. This NaN width would then be converted to 0 and a warning as follows would be emitted: Measure function returned an invalid dimension to Yoga: [width=nan, height=21.779297]
The warnings in yoga's javascript bindings are stored into a long array buffer. If a document is very large (> 100 pages) and contains a lot of text nodes, this can produce millions of yoga warnings, inflating this array buffer, until at some point the browser refuses to push another character onto the end of the buffer. This results in the error `RangeError: Invalid array length at Array.push ()`