### PR TITLE
fix: prevent unhandled promise rejections when loading emoji images

### DIFF
--- a/packages/layout/src/text/emoji.ts
+++ b/packages/layout/src/text/emoji.ts
@@ -52,10 +52,15 @@ export const fetchEmojis = (string: string, source?: EmojiSource) => {
       emojis[emoji] = { loading: true };
 
       promises.push(
-        resolveImage({ uri: emojiUrl }).then((image) => {
-          emojis[emoji].loading = false;
-          emojis[emoji].data = image.data;
-        }),
+        resolveImage({ uri: emojiUrl })
+          .then((image) => {
+            emojis[emoji].loading = false;
+            emojis[emoji].data = image.data;
+          })
+          .catch(e) => {
+            console.warn(e, 'Failed to load emoji image');
+            emojis[emoji].loading = false;
+          }),
       );
     }
   });


### PR DESCRIPTION
**Problem:**
When emoji images fail to load from the data source, the rendering process breaks with unhandled promise rejections.

**Solution:**
Added error handling to the `fetchEmojis` function in `@react-pdf/layout`.  
Emoji images that fail to load now gracefully fall back to text rendering, preventing the entire render process from breaking.

**Changes:**
* Added `.catch()` handler to prevent unhandled promise rejections
* Characters without valid emoji images now render as plain text