### PR TITLE
customize styles for wrapped sub-pages

### DIFF
--- a/packages/layout/src/steps/resolvePagination.ts
+++ b/packages/layout/src/steps/resolvePagination.ts
@@ -274,6 +274,7 @@ const resolvePageIndices = (fontStore, yoga, page, pageNumber, pages) => {
 const assocSubPageData = (
   subpages: SafePageNode[],
   originalPage?: SafePageNode,
+  startPageNumber?: number,
 ) => {
   return subpages.map((page, i) => {
     const basePage = {
@@ -282,9 +283,18 @@ const assocSubPageData = (
       subPageTotalPages: subpages.length,
     };
 
-    // Apply wrapStyles if provided and this is a wrapped page
-    if (originalPage?.props?.wrapStyles && subpages.length > 1) {
-      const wrapStyles = originalPage.props.wrapStyles(i, subpages.length);
+    // Apply wrapStyles if provided
+    // Always apply wrapStyles (even for single pages) to ensure correct styling
+    // based on absolute page number in the document
+    if (originalPage?.props?.wrapStyles) {
+      // Calculate absolute page number for this subpage
+      const absolutePageNumber =
+        startPageNumber !== undefined ? startPageNumber + i : i + 1;
+      const wrapStyles = originalPage.props.wrapStyles(
+        i,
+        subpages.length,
+        absolutePageNumber,
+      );
       if (wrapStyles) {
         // Merge wrapStyles with existing style
         basePage.style = Array.isArray(basePage.style)
@@ -350,7 +360,7 @@ const resolvePagination = (
     const page = root.children[i];
     let subpages = paginate(page, pageNumber, fontStore, root.yoga);
 
-    subpages = assocSubPageData(subpages, page);
+    subpages = assocSubPageData(subpages, page, pageNumber);
     pageNumber += subpages.length;
     pages = pages.concat(subpages);
   }

--- a/packages/layout/src/types/page.ts
+++ b/packages/layout/src/types/page.ts
@@ -84,6 +84,11 @@ interface PageProps extends NodeProps {
    * @see https://react-pdf.org/components#page-wrapping
    */
   wrap?: boolean;
+  /**
+   * Styles to apply to each page when wrapping occurs.
+   * Function receives page index (0-based) and total pages count.
+   */
+  wrapStyles?: (pageIndex: number, totalPages: number) => Style | Style[];
   size?: PageSize;
   orientation?: Orientation;
   dpi?: number;

--- a/packages/layout/src/types/page.ts
+++ b/packages/layout/src/types/page.ts
@@ -86,9 +86,13 @@ interface PageProps extends NodeProps {
   wrap?: boolean;
   /**
    * Styles to apply to each page when wrapping occurs.
-   * Function receives page index (0-based) and total pages count.
+   * Function receives page index (0-based), total pages count, and absolute page number.
    */
-  wrapStyles?: (pageIndex: number, totalPages: number) => Style | Style[];
+  wrapStyles?: (
+    pageIndex: number,
+    totalPages: number,
+    absolutePageNumber: number,
+  ) => Style | Style[];
   size?: PageSize;
   orientation?: Orientation;
   dpi?: number;

--- a/packages/layout/tests/steps/resolvePagination.test.ts
+++ b/packages/layout/tests/steps/resolvePagination.test.ts
@@ -339,4 +339,138 @@ describe('pagination step', () => {
     // If calcLayout returns then we did not hit an infinite loop
     expect(true).toBe(true);
   });
+
+  test('should apply wrapStyles to each wrapped page', async () => {
+    const yoga = await loadYoga();
+
+    const layout = calcLayout({
+      type: 'DOCUMENT',
+      yoga,
+      props: {},
+      style: {},
+      children: [
+        {
+          type: 'PAGE',
+          style: {
+            width: 5,
+            height: 60,
+          },
+          props: {
+            wrap: true,
+            wrapStyles: (pageIndex: number) => ({
+              backgroundColor: pageIndex === 0 ? 'red' : 'blue',
+              padding: pageIndex * 10,
+            }),
+          },
+          children: [
+            {
+              type: 'VIEW',
+              style: { height: 130 },
+              props: {},
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(layout.children.length).toBe(3);
+
+    // First page should have red background and no padding
+    const page1 = layout.children[0];
+    expect(page1.style).toEqual([
+      { width: 5, height: 60 },
+      { backgroundColor: 'red', padding: 0 },
+    ]);
+
+    // Second page should have blue background and padding of 10
+    const page2 = layout.children[1];
+    expect(page2.style).toEqual([
+      { width: 5, height: 60 },
+      { backgroundColor: 'blue', padding: 10 },
+    ]);
+
+    // Third page should have blue background and padding of 20
+    const page3 = layout.children[2];
+    expect(page3.style).toEqual([
+      { width: 5, height: 60 },
+      { backgroundColor: 'blue', padding: 20 },
+    ]);
+  });
+
+  test('should not apply wrapStyles when wrap is false', async () => {
+    const yoga = await loadYoga();
+
+    const layout = calcLayout({
+      type: 'DOCUMENT',
+      yoga,
+      props: {},
+      style: {},
+      children: [
+        {
+          type: 'PAGE',
+          style: {
+            width: 5,
+            height: 60,
+          },
+          props: {
+            wrap: false,
+            wrapStyles: () => ({
+              backgroundColor: 'red',
+            }),
+          },
+          children: [
+            {
+              type: 'VIEW',
+              style: { height: 130 },
+              props: {},
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(layout.children.length).toBe(1);
+    const page = layout.children[0];
+    expect(page.style).toEqual({ width: 5, height: 60 });
+  });
+
+  test('should not apply wrapStyles when only one page is generated', async () => {
+    const yoga = await loadYoga();
+
+    const layout = calcLayout({
+      type: 'DOCUMENT',
+      yoga,
+      props: {},
+      style: {},
+      children: [
+        {
+          type: 'PAGE',
+          style: {
+            width: 5,
+            height: 60,
+          },
+          props: {
+            wrap: true,
+            wrapStyles: () => ({
+              backgroundColor: 'red',
+            }),
+          },
+          children: [
+            {
+              type: 'VIEW',
+              style: { height: 30 },
+              props: {},
+              children: [],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(layout.children.length).toBe(1);
+    const page = layout.children[0];
+    expect(page.style).toEqual({ width: 5, height: 60 });
+  });
 });

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -90,9 +90,13 @@ declare namespace ReactPDF {
     debug?: boolean;
     /**
      * Styles to apply to each page when wrapping occurs.
-     * Function receives page index (0-based) and total pages count.
+     * Function receives page index (0-based), total pages count, and absolute page number.
      */
-    wrapStyles?: (pageIndex: number, totalPages: number) => Style | Style[];
+    wrapStyles?: (
+      pageIndex: number,
+      totalPages: number,
+      absolutePageNumber: number,
+    ) => Style | Style[];
     size?: PageSize;
     orientation?: Orientation;
     dpi?: number;

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -88,6 +88,11 @@ declare namespace ReactPDF {
      * @see https://react-pdf.org/advanced#debugging
      */
     debug?: boolean;
+    /**
+     * Styles to apply to each page when wrapping occurs.
+     * Function receives page index (0-based) and total pages count.
+     */
+    wrapStyles?: (pageIndex: number, totalPages: number) => Style | Style[];
     size?: PageSize;
     orientation?: Orientation;
     dpi?: number;

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -33,6 +33,11 @@ interface ViewProps extends BaseProps {
 
 interface PageProps extends BaseProps {
   wrap?: boolean;
+  /**
+   * Styles to apply to each page when wrapping occurs.
+   * Function receives page index (0-based) and total pages count.
+   */
+  wrapStyles?: (pageIndex: number, totalPages: number) => Style | Style[];
   size?: PageSize;
   orientation?: Orientation;
   dpi?: number;

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -35,9 +35,13 @@ interface PageProps extends BaseProps {
   wrap?: boolean;
   /**
    * Styles to apply to each page when wrapping occurs.
-   * Function receives page index (0-based) and total pages count.
+   * Function receives page index (0-based), total pages count, and absolute page number.
    */
-  wrapStyles?: (pageIndex: number, totalPages: number) => Style | Style[];
+  wrapStyles?: (
+    pageIndex: number,
+    totalPages: number,
+    absolutePageNumber: number,
+  ) => Style | Style[];
   size?: PageSize;
   orientation?: Orientation;
   dpi?: number;


### PR DESCRIPTION
I am working on a book printing tool. And need to have a differentiated gutter on every other page. But I also want the built in page wrap functionality. This makes it possible to customize the style of each of the generated sub-pages from a given long piece of wrapped content. (at least that is my intention)