### PR TITLE
Implement hyphenless word breaking

### DIFF
--- a/.changeset/orange-lamps-add.md
+++ b/.changeset/orange-lamps-add.md
@@ -1,0 +1,30 @@
+---
+"@react-pdf/textkit": minor
+---
+
+Custom hyphenation callbacks can now decide for each split point, whether
+a hyphen should be inserted at the end of the line when breaking at said
+split point.
+This change is backwards compatible. If a custom hyphenation callback
+returns an array of strings, it is assumed that all except the last part
+should get a hyphen added when breaking.
+Hyphens can be turned off for all parts of a word by returning an object
+in the format:
+`{ parts: <string array as previously>, hyphen: null }`
+This may be useful for URLs or similar technical identifiers which
+should be broken but should not be hyphenated.
+Alternatively, the hyphen can be activated or deactivated for each part
+separately, by returning an array of part objects:
+
+```
+[
+  { string: 'blue', hyphen: '-' },
+  { string: 'ish-', hyphen: null },
+  { string: 'green', hyphen: null }
+]
+```
+
+For now, only a dash `'-'` or `null` are valid choices for `hyphen`.
+Also, for now, the last part of a word is always forced to `hyphen: null`.
+Finally, unless specified specifically, parts ending in a dash will not
+get an added hyphen, and the default hyphenation will split text on hyphens.

--- a/packages/textkit/src/engines/linebreaker/knuthPlass.ts
+++ b/packages/textkit/src/engines/linebreaker/knuthPlass.ts
@@ -374,11 +374,13 @@ linebreak.penalty = (
   width: number,
   penalty: number,
   flagged: number,
+  hyphen?: '-',
 ): PenaltyNode => ({
   type: 'penalty',
   width,
   penalty,
   flagged,
+  hyphen,
 });
 
 export default linebreak;

--- a/packages/textkit/src/engines/linebreaker/types.ts
+++ b/packages/textkit/src/engines/linebreaker/types.ts
@@ -7,6 +7,7 @@ export type PenaltyNode = {
   width: number;
   penalty: number;
   flagged?: number;
+  hyphen?: '-';
 };
 
 export type BoxNode = {

--- a/packages/textkit/src/engines/wordHyphenation/index.ts
+++ b/packages/textkit/src/engines/wordHyphenation/index.ts
@@ -1,6 +1,7 @@
 import hyphen from 'hyphen';
 import pattern from 'hyphen/patterns/en-us.js';
 import { isNil } from '@react-pdf/fns';
+import { HyphenatedWord } from '../../types';
 
 const SOFT_HYPHEN = '\u00ad';
 const hyphenator = hyphen(pattern);
@@ -13,7 +14,7 @@ const splitHyphen = (word: string) => {
   return word.split(SOFT_HYPHEN);
 };
 
-const cache: Record<string, string[]> = {};
+const cache: Record<string, HyphenatedWord> = {};
 
 /**
  * @param word
@@ -21,7 +22,7 @@ const cache: Record<string, string[]> = {};
  */
 const getParts = (word: string) => {
   const base = word.includes(SOFT_HYPHEN) ? word : hyphenator(word);
-  return splitHyphen(base);
+  return { parts: splitHyphen(base), hyphen: '-' as const };
 };
 
 const wordHyphenation = () => {
@@ -32,7 +33,7 @@ const wordHyphenation = () => {
   return (word: string | null) => {
     const cacheKey = `_${word}`;
 
-    if (isNil(word)) return [];
+    if (isNil(word)) return { parts: [], hyphen: '-' as const };
     if (cache[cacheKey]) return cache[cacheKey];
 
     cache[cacheKey] = getParts(word);

--- a/packages/textkit/src/engines/wordHyphenation/index.ts
+++ b/packages/textkit/src/engines/wordHyphenation/index.ts
@@ -11,7 +11,7 @@ const hyphenator = hyphen(pattern);
  * @returns Word parts
  */
 const splitHyphen = (word: string) => {
-  return word.split(SOFT_HYPHEN);
+  return word.split(SOFT_HYPHEN).flatMap((part) => part.split(/(?<=[-])/g));
 };
 
 const cache: Record<string, HyphenatedWord> = {};

--- a/packages/textkit/src/layout/wrapWords.ts
+++ b/packages/textkit/src/layout/wrapWords.ts
@@ -1,6 +1,11 @@
 import fromFragments from '../attributedString/fromFragments';
 import { Engines } from '../engines';
-import { AttributedString, LayoutOptions } from '../types';
+import {
+  AttributedString,
+  HyphenatedWord,
+  LayoutOptions,
+  HyphenatedPart,
+} from '../types';
 
 const SOFT_HYPHEN = '\u00ad';
 
@@ -16,11 +21,58 @@ const defaultHyphenate = (word: string) => [word];
 /**
  * Remove soft hyphens from word
  *
- * @param word
  * @returns Word without soft hyphens
+ * @param part
  */
-const removeSoftHyphens = (word: string) => {
-  return word.replaceAll(SOFT_HYPHEN, '');
+const removeSoftHyphens = (part: HyphenatedPart) => {
+  part.string = part.string.replaceAll(SOFT_HYPHEN, '');
+  return part;
+};
+
+/**
+ * Coerce a string or HyphenatedPart to a HyphenatedPart, and optionally enforce the
+ * hyphenation character.
+ * If the hyphenation character is not forced, it is set to a hyphen, except if the last
+ * character of the syllable is already a hyphen.
+ *
+ * @param part
+ * @param forceHyphen
+ */
+const normalizeHyphenatedPart = (
+  part: string | HyphenatedPart,
+  forceHyphen?: '-',
+) => {
+  const p = typeof part === 'string' ? { string: part, hyphen: '-' } : part;
+  let hyphen = p.hyphen;
+  if (hyphen !== '-' && hyphen !== null) hyphen = '-';
+  if (typeof part === 'string' && part.slice(-1) === '-') hyphen = null;
+  if (forceHyphen !== undefined) hyphen = forceHyphen;
+
+  return { string: p.string, hyphen: hyphen as '-' };
+};
+
+/**
+ * Convert the various supported output formats of hyphenation callbacks into
+ * one single format: A list of Syllables.
+ * For now, only a hyphen or null are supported as hyphenation character after a Syllable.
+ * Also, the last syllable in a word is always forced to have no hyphen character.
+ *
+ * @param hyphenatedWord
+ */
+const normalizeHyphenatedWord: (HyphenatedWord) => HyphenatedPart[] = (
+  hyphenatedWord: HyphenatedWord,
+) => {
+  const normalized =
+    hyphenatedWord instanceof Array
+      ? hyphenatedWord.map((part) => normalizeHyphenatedPart(part))
+      : hyphenatedWord.parts.map((part) =>
+          normalizeHyphenatedPart(
+            part,
+            hyphenatedWord.hyphen === null ? null : undefined,
+          ),
+        );
+  if (normalized.length > 0) normalized[normalized.length - 1].hyphen = null;
+  return normalized;
 };
 
 /**
@@ -59,10 +111,12 @@ const wrapWords = (
 
       for (let j = 0; j < words.length; j += 1) {
         const word = words[j];
-        const parts = hyphenate(word, builtinHyphenate).map(removeSoftHyphens);
+        const parts = normalizeHyphenatedWord(
+          hyphenate(word, builtinHyphenate),
+        ).map(removeSoftHyphens);
 
         syllables.push(...parts);
-        string += parts.join('');
+        string += parts.map((part) => part.string).join('');
       }
 
       // Modify run start and end based on removed soft hyphens.

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -107,7 +107,7 @@ export type DecorationLine = {
 
 export type AttributedString = {
   string: string;
-  syllables?: string[];
+  syllables?: HyphenatedPart[];
   runs: Run[];
   box?: Rect;
   decorationLines?: DecorationLine[];
@@ -129,8 +129,8 @@ export type Paragraph = AttributedString[];
 export type LayoutOptions = {
   hyphenationCallback?: (
     word: string | null,
-    fallback: (word: string | null) => string[],
-  ) => string[];
+    fallback: (word: string | null) => HyphenatedWord,
+  ) => HyphenatedWord;
   tolerance?: number;
   hyphenationPenalty?: number;
   expandCharFactor?: JustificationFactor;
@@ -138,5 +138,18 @@ export type LayoutOptions = {
   expandWhitespaceFactor?: JustificationFactor;
   shrinkWhitespaceFactor?: JustificationFactor;
 };
+
+export type HyphenatedPart = {
+  string: string;
+  hyphen?: '-';
+};
+
+export type HyphenatedWord =
+  | string[]
+  | {
+      parts: string[];
+      hyphen?: '-';
+    }
+  | HyphenatedPart[];
 
 export type { Font } from '@react-pdf/font';

--- a/packages/textkit/tests/engines/linebreaker.test.ts
+++ b/packages/textkit/tests/engines/linebreaker.test.ts
@@ -280,7 +280,13 @@ describe('linebreaker', () => {
           string: 'Potentieel broeikasgasemissierapport',
         },
       ],
-      syllables: ['Potentieel', ' ', 'broeikasgas', 'emissie', 'rapport'],
+      syllables: [
+        { string: 'Potentieel', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'broeikasgas', hyphen: '-' as const },
+        { string: 'emissie', hyphen: '-' as const },
+        { string: 'rapport', hyphen: null },
+      ],
     };
 
     const result = linebreaker(attributedString, [10]);

--- a/packages/textkit/tests/engines/wordHyphenation.test.ts
+++ b/packages/textkit/tests/engines/wordHyphenation.test.ts
@@ -14,7 +14,10 @@ vi.mock('hyphen', () => ({ default: () => hyphenator }));
 const wordHyphenation = (await import('../../src/engines/wordHyphenation'))
   .default;
 
-const instance = wordHyphenation();
+const instance = wordHyphenation() as (word: null | string) => {
+  parts: string[];
+  hyphen?: '-';
+};
 
 describe('wordHyphenation', () => {
   beforeEach(() => {
@@ -22,54 +25,58 @@ describe('wordHyphenation', () => {
   });
 
   test('should return empty array if null param', () => {
-    expect(instance(null)).toEqual([]);
+    expect(instance(null).parts).toEqual([]);
     expect(hyphenator.mock.calls).toHaveLength(0);
   });
 
   test('should return empty part for empty string', () => {
-    expect(instance('')).toEqual(['']);
+    expect(instance('').parts).toEqual(['']);
     expect(hyphenator.mock.calls).toHaveLength(1);
   });
 
   test('should hyphenate word', () => {
     const word = 'something';
-    const parts = instance(word);
+    const { parts, hyphen } = instance(word);
 
     expect(parts).toHaveLength(2);
     expect(parts[0]).toEqual('some');
     expect(parts[1]).toEqual('thing');
+    expect(hyphen).toEqual('-');
     expect(hyphenator.mock.calls).toHaveLength(1);
   });
 
   test('should hyphenate word in many parts', () => {
     const word = 'neumonia';
-    const parts = instance(word);
+    const { parts, hyphen } = instance(word);
 
     expect(parts).toHaveLength(3);
     expect(parts[0]).toEqual('neu');
     expect(parts[1]).toEqual('mo');
     expect(parts[2]).toEqual('nia');
+    expect(hyphen).toEqual('-');
     expect(hyphenator.mock.calls).toHaveLength(1);
   });
 
   test('should hyphenate word with soft hyphen', () => {
     const word = 'so\u00admething';
-    const parts = instance(word);
+    const { parts, hyphen } = instance(word);
 
     expect(parts).toHaveLength(2);
     expect(parts[0]).toEqual('so');
     expect(parts[1]).toEqual('mething');
+    expect(hyphen).toEqual('-');
     expect(hyphenator.mock.calls).toHaveLength(0);
   });
 
   test('should hyphenate word with many soft hyphen', () => {
     const word = 'so\u00adme\u00adthing';
-    const parts = instance(word);
+    const { parts, hyphen } = instance(word);
 
     expect(parts).toHaveLength(3);
     expect(parts[0]).toEqual('so');
     expect(parts[1]).toEqual('me');
     expect(parts[2]).toEqual('thing');
+    expect(hyphen).toEqual('-');
     expect(hyphenator.mock.calls).toHaveLength(0);
   });
 
@@ -84,12 +91,13 @@ describe('wordHyphenation', () => {
     // Hyphen called once for word
     expect(hyphenator.mock.calls).toHaveLength(1);
 
-    const parts = instance(word);
+    const { parts, hyphen } = instance(word);
 
     expect(parts).toHaveLength(3);
     expect(parts[0]).toEqual('pro');
     expect(parts[1]).toEqual('gram');
     expect(parts[2]).toEqual('ming');
+    expect(hyphen).toEqual('-');
 
     // Hyphen not called again. Got value from cache
     expect(hyphenator.mock.calls).toHaveLength(1);

--- a/packages/textkit/tests/layout/wrapWords.test.ts
+++ b/packages/textkit/tests/layout/wrapWords.test.ts
@@ -242,6 +242,27 @@ describe('wrapWords', () => {
       expect(result.runs[1]).toHaveProperty('end', 11);
     });
 
+    test('should split at hyphen and not duplicate hyphen in hyphenation', () => {
+      const result = builtinInstance({
+        string: 'Lo-rem ipsum-',
+        runs: [
+          {
+            start: 0,
+            end: 13,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lo-', hyphen: null },
+        { string: 'rem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum-', hyphen: null },
+      ]);
+    });
+
     test('should not apply default english syllable split to word containing soft hyphen', () => {
       const result = builtinInstance({
         string: 'Lorem ips\u00adum',

--- a/packages/textkit/tests/layout/wrapWords.test.ts
+++ b/packages/textkit/tests/layout/wrapWords.test.ts
@@ -1,10 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import wrapWords from '../../src/layout/wrapWords';
+import wordHyphenation from '../../src/engines/wordHyphenation';
 
 const emptyInstance = wrapWords({}, {});
-const wordHyphenationEngine = vi.fn((x) => [x]);
-const defaultInstance = wrapWords(
-  { wordHyphenation: () => wordHyphenationEngine },
+const noopWordHyphenationEngine = vi.fn((x) => [x]);
+const noopInstance = wrapWords(
+  { wordHyphenation: () => noopWordHyphenationEngine },
   {},
 );
 const mutateWordHyphenationEngine = vi.fn((x) => (x === ' ' ? [x] : [`${x}o`]));
@@ -12,24 +13,27 @@ const mutateInstance = wrapWords(
   { wordHyphenation: () => mutateWordHyphenationEngine },
   {},
 );
+const builtinInstance = wrapWords({ wordHyphenation }, {});
+const customizedInstance = (hyphenationCallback) =>
+  wrapWords({ wordHyphenation }, { hyphenationCallback });
 
 describe('wrapWords', () => {
   describe('when engine provided', () => {
     beforeEach(() => {
-      wordHyphenationEngine.mockClear();
+      noopWordHyphenationEngine.mockClear();
       mutateWordHyphenationEngine.mockClear();
     });
 
     test('should return no syllables when empty string provided', () => {
-      const result = defaultInstance({ string: '', runs: [] });
+      const result = noopInstance({ string: '', runs: [] });
 
       expect(result.syllables).toEqual([]);
       expect(result.string).toEqual('');
-      expect(wordHyphenationEngine.mock.calls).toHaveLength(0);
+      expect(noopWordHyphenationEngine.mock.calls).toHaveLength(0);
     });
 
     test('should return syllables when single run string', () => {
-      const result = defaultInstance({
+      const result = noopInstance({
         string: 'Lorem ipsum',
         runs: [
           {
@@ -40,19 +44,23 @@ describe('wrapWords', () => {
         ],
       });
 
-      expect(result.syllables).toEqual(['Lorem', ' ', 'ipsum']);
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ipsum', hyphen: null },
+      ]);
       expect(result.runs).toHaveLength(1);
       expect(result.runs[0]).toHaveProperty('start', 0);
       expect(result.runs[0]).toHaveProperty('end', 11);
 
-      expect(wordHyphenationEngine.mock.calls).toHaveLength(3);
-      expect(wordHyphenationEngine.mock.calls[0][0]).toEqual('Lorem');
-      expect(wordHyphenationEngine.mock.calls[1][0]).toEqual(' ');
-      expect(wordHyphenationEngine.mock.calls[2][0]).toEqual('ipsum');
+      expect(noopWordHyphenationEngine.mock.calls).toHaveLength(3);
+      expect(noopWordHyphenationEngine.mock.calls[0][0]).toEqual('Lorem');
+      expect(noopWordHyphenationEngine.mock.calls[1][0]).toEqual(' ');
+      expect(noopWordHyphenationEngine.mock.calls[2][0]).toEqual('ipsum');
     });
 
     test('should return syllables when multipe runs string', () => {
-      const result = defaultInstance({
+      const result = noopInstance({
         string: 'Lorem ipsum',
         runs: [
           {
@@ -68,17 +76,21 @@ describe('wrapWords', () => {
         ],
       });
 
-      expect(result.syllables).toEqual(['Lorem', ' ', 'ipsum']);
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ipsum', hyphen: null },
+      ]);
       expect(result.runs).toHaveLength(2);
       expect(result.runs[0]).toHaveProperty('start', 0);
       expect(result.runs[0]).toHaveProperty('end', 5);
       expect(result.runs[1]).toHaveProperty('start', 5);
       expect(result.runs[1]).toHaveProperty('end', 11);
 
-      expect(wordHyphenationEngine.mock.calls).toHaveLength(3);
-      expect(wordHyphenationEngine.mock.calls[0][0]).toEqual('Lorem');
-      expect(wordHyphenationEngine.mock.calls[1][0]).toEqual(' ');
-      expect(wordHyphenationEngine.mock.calls[2][0]).toEqual('ipsum');
+      expect(noopWordHyphenationEngine.mock.calls).toHaveLength(3);
+      expect(noopWordHyphenationEngine.mock.calls[0][0]).toEqual('Lorem');
+      expect(noopWordHyphenationEngine.mock.calls[1][0]).toEqual(' ');
+      expect(noopWordHyphenationEngine.mock.calls[2][0]).toEqual('ipsum');
     });
 
     test('should return mutated string if engine changes string value', () => {
@@ -93,7 +105,11 @@ describe('wrapWords', () => {
         ],
       });
 
-      expect(result.syllables).toEqual(['Loremo', ' ', 'ipsumo']);
+      expect(result.syllables).toEqual([
+        { string: 'Loremo', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ipsumo', hyphen: null },
+      ]);
       expect(result.runs).toHaveLength(1);
       expect(result.runs[0]).toHaveProperty('start', 0);
       expect(result.runs[0]).toHaveProperty('end', 13);
@@ -125,13 +141,17 @@ describe('wrapWords', () => {
         ],
       });
 
-      expect(result.syllables).toEqual(['Lorem', ' ', 'ipsum']);
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ipsum', hyphen: null },
+      ]);
       expect(result.runs).toHaveLength(1);
       expect(result.runs[0]).toHaveProperty('start', 0);
       expect(result.runs[0]).toHaveProperty('end', 11);
     });
 
-    test('should return unhyphenated syllables when multipe runs string', () => {
+    test('should return unhyphenated syllables when multiple runs string', () => {
       const result = emptyInstance({
         string: 'Lorem ipsum',
         runs: [
@@ -148,12 +168,396 @@ describe('wrapWords', () => {
         ],
       });
 
-      expect(result.syllables).toEqual(['Lorem', ' ', 'ipsum']);
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ipsum', hyphen: null },
+      ]);
       expect(result.runs).toHaveLength(2);
       expect(result.runs[0]).toHaveProperty('start', 0);
       expect(result.runs[0]).toHaveProperty('end', 5);
       expect(result.runs[1]).toHaveProperty('start', 5);
       expect(result.runs[1]).toHaveProperty('end', 11);
+    });
+  });
+
+  describe('with builtin engine', () => {
+    test('should return no syllables when empty string provided', () => {
+      const result = builtinInstance({ string: '', runs: [] });
+
+      expect(result.syllables).toEqual([]);
+      expect(result.string).toEqual('');
+    });
+
+    test('should return hyphenated syllables when single run string', () => {
+      const result = builtinInstance({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum', hyphen: null },
+      ]);
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0]).toHaveProperty('start', 0);
+      expect(result.runs[0]).toHaveProperty('end', 11);
+    });
+
+    test('should return hyphenated syllables when multiple runs string', () => {
+      const result = builtinInstance({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 5,
+            attributes: {},
+          },
+          {
+            start: 5,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum', hyphen: null },
+      ]);
+      expect(result.runs).toHaveLength(2);
+      expect(result.runs[0]).toHaveProperty('start', 0);
+      expect(result.runs[0]).toHaveProperty('end', 5);
+      expect(result.runs[1]).toHaveProperty('start', 5);
+      expect(result.runs[1]).toHaveProperty('end', 11);
+    });
+
+    test('should not apply default english syllable split to word containing soft hyphen', () => {
+      const result = builtinInstance({
+        string: 'Lorem ips\u00adum',
+        runs: [
+          {
+            start: 0,
+            end: 12,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ips', hyphen: '-' },
+        { string: 'um', hyphen: null },
+      ]);
+    });
+  });
+
+  describe('with custom hyphenation callback', () => {
+    const customHyphenation = (word, original) => {
+      return {
+        parts: original(word).parts.flatMap((part) => part.split(/(?<=[./])/g)),
+        hyphen: '-',
+      };
+    };
+    test('should return no syllables when empty string provided', () => {
+      const result = customizedInstance(customHyphenation)({
+        string: '',
+        runs: [],
+      });
+
+      expect(result.syllables).toEqual([]);
+      expect(result.string).toEqual('');
+    });
+
+    test('should return hyphenated syllables when single run string', () => {
+      const result = customizedInstance(customHyphenation)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum', hyphen: null },
+      ]);
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0]).toHaveProperty('start', 0);
+      expect(result.runs[0]).toHaveProperty('end', 11);
+    });
+
+    test('should return hyphenated syllables when multiple runs string', () => {
+      const result = customizedInstance(customHyphenation)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 5,
+            attributes: {},
+          },
+          {
+            start: 5,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum', hyphen: null },
+      ]);
+      expect(result.runs).toHaveLength(2);
+      expect(result.runs[0]).toHaveProperty('start', 0);
+      expect(result.runs[0]).toHaveProperty('end', 5);
+      expect(result.runs[1]).toHaveProperty('start', 5);
+      expect(result.runs[1]).toHaveProperty('end', 11);
+    });
+
+    test('should be able to turn off hyphenation', () => {
+      const hyphenationCallback = (word, original) => {
+        return { parts: original(word).parts, hyphen: null };
+      };
+      const result = customizedInstance(hyphenationCallback)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: null },
+        { string: 'sum', hyphen: null },
+      ]);
+    });
+
+    test('should tolerate missing hyphen specification', () => {
+      const hyphenationCallback = (word, original) => {
+        return { parts: original(word).parts };
+      };
+      const result = customizedInstance(hyphenationCallback)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum', hyphen: null },
+      ]);
+    });
+
+    test('should work when returning simple string array', () => {
+      const hyphenationCallback = (word) => {
+        return word.split(/(?<=[aeiou])/g);
+      };
+      const result = customizedInstance(hyphenationCallback)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lo', hyphen: '-' },
+        { string: 're', hyphen: '-' },
+        { string: 'm', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'i', hyphen: '-' },
+        { string: 'psu', hyphen: '-' },
+        { string: 'm', hyphen: null },
+      ]);
+    });
+
+    test('should work when returning specific hyphenation instructions', () => {
+      const hyphenationCallback = (word) => {
+        if (word === 'Lor-em') {
+          return [
+            { string: 'Lor-', hyphen: '-' },
+            { string: 'em', hyphen: '-' },
+          ];
+        }
+        if (word === 'ipsum') {
+          return [
+            { string: 'ip', hyphen: null },
+            { string: 'sum', hyphen: null },
+          ];
+        }
+        return [word];
+      };
+      const result = customizedInstance(hyphenationCallback)({
+        string: 'Lor-em ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 12,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lor-', hyphen: '-' }, // can force adding hyphen on part ending in dash
+        { string: 'em', hyphen: null }, // last hyphen of the word is forced to null
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: null }, // can force omitting hyphen inside word
+        { string: 'sum', hyphen: null },
+      ]);
+    });
+
+    test('should force hyphen character to be a dash', () => {
+      const hyphenationCallback = (word) => {
+        if (word === 'Lorem') {
+          return [
+            { string: 'Lor', hyphen: '.' },
+            { string: 'e', hyphen: '' },
+            { string: 'm', hyphen: null },
+          ];
+        }
+        if (word === 'ipsum') {
+          return [
+            { string: 'ip', hyphen: 'p' },
+            { string: 'su', hyphen: undefined },
+            { string: 'm', hyphen: null },
+          ];
+        }
+        return [word];
+      };
+      const result = customizedInstance(hyphenationCallback)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 11,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lor', hyphen: '-' },
+        { string: 'e', hyphen: '-' },
+        { string: 'm', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'su', hyphen: '-' },
+        { string: 'm', hyphen: null },
+      ]);
+    });
+
+    test('should be able to split at additional special characters', () => {
+      const result = customizedInstance(customHyphenation)({
+        string: 'Lo.re/m ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 13,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lo.', hyphen: '-' },
+        { string: 're/', hyphen: '-' },
+        { string: 'm', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: '-' },
+        { string: 'sum', hyphen: null },
+      ]);
+    });
+
+    test('should not apply default english syllable split to word containing soft hyphen', () => {
+      const result = customizedInstance(customHyphenation)({
+        string: 'Lorem ips\u00adum.um',
+        runs: [
+          {
+            start: 0,
+            end: 15,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lorem', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ips', hyphen: '-' },
+        { string: 'um.', hyphen: '-' },
+        { string: 'um', hyphen: null },
+      ]);
+    });
+
+    test('should remove soft hyphens left over after hyphenation', () => {
+      const hyphenationCallback = (word) => {
+        if (word === 'Lorem') {
+          return [
+            { string: 'Lor\u00ad', hyphen: '-' },
+            { string: 'em', hyphen: null },
+          ];
+        }
+        if (word === 'ipsum') {
+          return [
+            { string: 'ip\u00ad', hyphen: null },
+            { string: 'sum', hyphen: null },
+          ];
+        }
+        return [word];
+      };
+      const result = customizedInstance(hyphenationCallback)({
+        string: 'Lorem ipsum',
+        runs: [
+          {
+            start: 0,
+            end: 15,
+            attributes: {},
+          },
+        ],
+      });
+
+      expect(result.syllables).toEqual([
+        { string: 'Lor', hyphen: '-' },
+        { string: 'em', hyphen: null },
+        { string: ' ', hyphen: null },
+        { string: 'ip', hyphen: null },
+        { string: 'sum', hyphen: null },
+      ]);
     });
   });
 });


### PR DESCRIPTION
Implements the feature discussed in #3267

After the previous implementation of #3188 being partially reverted in #3267, this PR re-implements the following use cases:
Fixes #1642
Fixes #2456
Fixes #2564
Fixes #2739
Fixes #3039
Re-enables better solutions for the following issues:
Fixes #1238
Fixes #1380
Fixes #1416
Fixes #1662