### PR TITLE
fix: Buffer is not defined when fetching image

### DIFF
--- a/packages/layout/src/image/fetchImage.ts
+++ b/packages/layout/src/image/fetchImage.ts
@@ -28,7 +28,11 @@ const fetchImage = async (node: SafeImageNode) => {
 
     node.image = await resolveImage(source, { cache });
 
-    if (Buffer.isBuffer(source) || source instanceof Blob) return;
+    if (
+      (typeof Buffer !== 'undefined' && Buffer.isBuffer(source)) ||
+      source instanceof Blob
+    )
+      return;
 
     node.image.key = 'data' in source ? source.data.toString() : source.uri;
   } catch (e: any) {


### PR DESCRIPTION
We are using `<PDFDownloadLink>` along with PDF documents that contain images. We noticed that when the PDF is generated, a number of `Buffer is not defined` warnings are displayed in the console.

<img width="1116" height="448" alt="CleanShot 2026-01-09 at 18 01 05@2x" src="https://github.com/user-attachments/assets/daf6bb57-d594-4c3a-8db5-7ff0a01bbda7" />


I created a simple reproduction here (be sure to check your browser console): https://stackblitz.com/edit/vitejs-vite-7mvymqcx?file=src%2FApp.tsx

These warnings appear to be benign because the PDF still renders correctly, but it'd be nice to silence these warnings which is what this PR aims to do.

