### PR TITLE
fix: clamp extreme number values to valid PDF range

### DIFF
--- a/.changeset/hip-rockets-punch.md
+++ b/.changeset/hip-rockets-punch.md
@@ -1,0 +1,6 @@
+---
+"@react-pdf/pdfkit": patch
+"@react-pdf/render": patch
+---
+
+fix: clamp extreme number values to valid PDF range

--- a/packages/pdfkit/src/object.js
+++ b/packages/pdfkit/src/object.js
@@ -116,11 +116,9 @@ class PDFObject {
   }
 
   static number(n) {
-    if (n > -1e21 && n < 1e21) {
-      return Math.round(n * 1e6) / 1e6;
-    }
-
-    throw new Error(`unsupported number: ${n}`);
+    // Clamp to valid PDF number range to prevent errors with extreme values
+    const clamped = Math.max(-1e21 + 1, Math.min(1e21 - 1, n));
+    return Math.round(clamped * 1e6) / 1e6;
   }
 }
 

--- a/packages/render/src/primitives/renderGlyphs.ts
+++ b/packages/render/src/primitives/renderGlyphs.ts
@@ -5,11 +5,9 @@ import { Context } from '../types';
 import encodeGlyphs from '../operations/encodeGlyphs';
 
 const number = (n: number) => {
-  if (n > -1e21 && n < 1e21) {
-    return Math.round(n * 1e6) / 1e6;
-  }
-
-  throw new Error(`unsupported number: ${n}`);
+  // Clamp to valid PDF number range to prevent errors with extreme values
+  const clamped = Math.max(-1e21 + 1, Math.min(1e21 - 1, n));
+  return Math.round(clamped * 1e6) / 1e6;
 };
 
 const _renderGlyphs = (


### PR DESCRIPTION
Fixes #3277

The number() function would throw an error when values exceeded the PDF-valid range of -1e21 to 1e21. This occurred when calculating glyph advance positions with certain font/text combinations.

Instead of throwing, we now clamp values to the valid range, allowing PDF generation to continue while maintaining valid output.

## Changes
- packages/render/src/primitives/renderGlyphs.ts: Clamp instead of throw
- packages/pdfkit/src/object.js: Clamp instead of throw