### PR TITLE
fix(@react-pdf/layout): pin @react-pdf/image to 3.0.4 to prevent @react-pdf/svg 404 on npm install

### DIFF
--- a/packages/layout/package.json
+++ b/packages/layout/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@react-pdf/fns": "3.1.3",
-    "@react-pdf/image": "^3.1.0",
+    "@react-pdf/image": "3.0.4",
     "@react-pdf/primitives": "^4.3.0",
     "@react-pdf/stylesheet": "^6.2.0",
     "@react-pdf/textkit": "^6.2.0",


### PR DESCRIPTION
fix(@react-pdf/layout): pin @react-pdf/image to 3.0.4 to prevent @react-pdf/svg 404 on npm install

@react-pdf/image@3.1.0 introduced @react-pdf/svg as a dependency which
is not published on the npm registry, causing a hard E404 on all clean
installs. Pinning to 3.0.4 restores installability until @react-pdf/svg
is made publicly available.