### PR TITLE
refactor(pdfkit): align font.js with upstream pdfkit

### DIFF
--- a/packages/pdfkit/src/font.js
+++ b/packages/pdfkit/src/font.js
@@ -1,35 +1,5 @@
-import * as fontkit from 'fontkit';
-import createStandardFont from './font/standard';
-import createEmbeddedFont from './font/embedded';
-
-export class PDFFont {
-  static open(document, src, family, id) {
-    let font;
-
-    if (typeof src === 'string') {
-      if (StandardFont.isStandardFont(src)) {
-        return new StandardFont(document, src, id);
-      }
-
-      if (!BROWSER) {
-        font = fontkit.openSync(src, family);
-      } else {
-        throw new Error(`Can't open ${src} in browser build`);
-      }
-    } else if (src instanceof Uint8Array) {
-      font = fontkit.create(src, family);
-    } else if (src instanceof ArrayBuffer) {
-      font = fontkit.create(new Uint8Array(src), family);
-    } else if (typeof src === 'object') {
-      font = src;
-    }
-
-    if (font == null) {
-      throw new Error('Not a supported font format or standard PDF font.');
-    }
-
-    return new EmbeddedFont(document, font, id);
-  }
+class PDFFont {
+  constructor() {}
 
   encode() {
     throw new Error('Must be implemented by subclasses');
@@ -51,23 +21,17 @@ export class PDFFont {
     }
 
     this.embed();
-    return (this.embedded = true);
+    this.embedded = true;
   }
 
   embed() {
     throw new Error('Must be implemented by subclasses');
   }
 
-  lineHeight(size, includeGap) {
-    if (includeGap == null) {
-      includeGap = false;
-    }
+  lineHeight(size, includeGap = false) {
     const gap = includeGap ? this.lineGap : 0;
     return ((this.ascender + gap - this.descender) / 1000) * size;
   }
 }
-
-export const StandardFont = createStandardFont(PDFFont);
-export const EmbeddedFont = createEmbeddedFont(PDFFont);
 
 export default PDFFont;

--- a/packages/pdfkit/src/font_factory.js
+++ b/packages/pdfkit/src/font_factory.js
@@ -1,22 +1,31 @@
-import fs from 'fs';
 import * as fontkit from 'fontkit';
-import StandardFont from './font/standard';
-import EmbeddedFont from './font/embedded';
+import PDFFont from './font';
+import createStandardFont from './font/standard';
+import createEmbeddedFont from './font/embedded';
+
+const StandardFont = createStandardFont(PDFFont);
+const EmbeddedFont = createEmbeddedFont(PDFFont);
 
 class PDFFontFactory {
   static open(document, src, family, id) {
     let font;
+
     if (typeof src === 'string') {
       if (StandardFont.isStandardFont(src)) {
         return new StandardFont(document, src, id);
       }
 
-      src = fs.readFileSync(src);
-    }
-    if (src instanceof Uint8Array) {
+      if (!BROWSER) {
+        font = fontkit.openSync(src, family);
+      } else {
+        throw new Error(`Can't open ${src} in browser build`);
+      }
+    } else if (src instanceof Uint8Array) {
       font = fontkit.create(src, family);
     } else if (src instanceof ArrayBuffer) {
       font = fontkit.create(new Uint8Array(src), family);
+    } else if (typeof src === 'object') {
+      font = src;
     }
 
     if (font == null) {

--- a/packages/pdfkit/src/mixins/fonts.js
+++ b/packages/pdfkit/src/mixins/fonts.js
@@ -1,4 +1,4 @@
-import PDFFont from '../font';
+import PDFFontFactory from '../font_factory';
 
 export default {
   initFonts() {
@@ -47,7 +47,7 @@ export default {
 
     // load the font
     const id = `F${++this._fontCount}`;
-    this._font = PDFFont.open(this, src, family, id);
+    this._font = PDFFontFactory.open(this, src, family, id);
 
     // check for existing font familes with the same name already in the PDF
     // useful if the font was passed as a buffer

--- a/packages/pdfkit/tests/font/standard.test.ts
+++ b/packages/pdfkit/tests/font/standard.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import StandardFont from '../../src/font.js';
+import PDFFontFactory from '../../src/font_factory.js';
 
 describe('standard fonts', () => {
   it('should resolve advanceWidth of soft hyphen to be zero', () => {
     const SOFT_HYPHEN = '\u00AD';
-    const font = StandardFont.open({}, 'Helvetica', 'Helvetica', 'foobar');
+    const font = PDFFontFactory.open({}, 'Helvetica', 'Helvetica', 'foobar');
 
     expect(font.encode(SOFT_HYPHEN)[1][0].advanceWidth).toBe(0);
   });


### PR DESCRIPTION
Move factory logic (PDFFont.open) from font.js into font_factory.js, matching the upstream pdfkit structure where font.js is only the base class.