### PR TITLE
ci: Add Node 24 and React 19 to test matrix, and Use Node 24 for CI jobs (except release)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ concurrency:
 env:
   FORCE_COLOR: 2
   HUSKY: 0
-  NODE_VERSION: 20
+  NODE_VERSION: 24
 
 jobs:
   lint:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,8 +80,8 @@ jobs:
     strategy:
       matrix:
         # We aim to test all maintained LTS versions of Node.js as well as the latest stable version
-        node_version: [20, 22]
-        react_version: [16, 17, 18]
+        node_version: [20, 22, 24]
+        react_version: [16, 17, 18, 19]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         # We aim to test all maintained LTS versions of Node.js as well as the latest stable version
-        node_version: [20, 22]
+        node_version: [20, 22, 24]
         react_version: [16, 17, 18, 19]
 
     steps:


### PR DESCRIPTION
## Ref

### [Node.js EOL](https://endoflife.date/nodejs)
<img width="761" height="695" alt="image" src="https://github.com/user-attachments/assets/d2c15f06-69a4-4ec0-9602-efa8925d65bd" />

### [React EOL](https://endoflife.date/react)
<img width="758" height="454" alt="image" src="https://github.com/user-attachments/assets/2e7396dc-97f0-4711-b61e-cad4309cc8ea" />
