### PR TITLE
refactor(pdfkit): use byte-level PNG magic check in image.js

### DIFF
--- a/.changeset/png-magic-byte-check.md
+++ b/.changeset/png-magic-byte-check.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/pdfkit": patch
+---
+
+refactor(pdfkit): use byte-level PNG magic check in image.js

--- a/packages/pdfkit/src/binary.js
+++ b/packages/pdfkit/src/binary.js
@@ -12,6 +12,16 @@ export const toBinaryString = (bytes) => {
   return out;
 };
 
+export const fromBase64 = (b64) => {
+  const binary = atob(b64);
+  const len = binary.length;
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) {
+    out[i] = binary.charCodeAt(i);
+  }
+  return out;
+};
+
 export const readUInt16BE = (bytes, offset = 0) =>
   ((bytes[offset] << 8) | bytes[offset + 1]) >>> 0;
 

--- a/packages/pdfkit/src/image.js
+++ b/packages/pdfkit/src/image.js
@@ -4,6 +4,7 @@ By Devon Govett
 */
 
 import fs from 'fs';
+import { fromBase64 } from './binary';
 import JPEG from './image/jpeg';
 import PNG from './image/png';
 
@@ -17,7 +18,7 @@ class PDFImage {
     } else {
       const match = /^data:.+?;base64,(.*)$/.exec(src);
       if (match) {
-        data = Buffer.from(match[1], 'base64');
+        data = fromBase64(match[1]);
       } else {
         data = fs.readFileSync(src);
         if (!data) {
@@ -28,7 +29,12 @@ class PDFImage {
 
     if (data[0] === 0xff && data[1] === 0xd8) {
       return new JPEG(data, label);
-    } else if (data[0] === 0x89 && data.toString('ascii', 1, 4) === 'PNG') {
+    } else if (
+      data[0] === 0x89 &&
+      data[1] === 0x50 &&
+      data[2] === 0x4e &&
+      data[3] === 0x47
+    ) {
       return new PNG(data, label);
     } else {
       throw new Error('Unknown image format.');


### PR DESCRIPTION
Replaces `data.toString('ascii', 1, 4) === 'PNG'` with four byte comparisons to avoid a string allocation per image open. Adds a `fromBase64` helper to `binary.js` and uses it for the data-URI path.