### PR TITLE
perf(textkit): improve line slicing performance

### DIFF
--- a/.changeset/smart-maps-pay.md
+++ b/.changeset/smart-maps-pay.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/textkit': patch
+---
+
+Improve text line slicing performance for long paragraphs.

--- a/packages/textkit/src/engines/linebreaker/index.ts
+++ b/packages/textkit/src/engines/linebreaker/index.ts
@@ -32,12 +32,14 @@ const breakLines = (
   let start = 0;
   let end = null;
 
-  const lines: AttributedString[] = breaks.reduce((acc, breakPoint) => {
+  const lines: AttributedString[] = [];
+
+  for (const breakPoint of breaks) {
     const node = nodes[breakPoint];
     const prevNode = nodes[breakPoint - 1];
 
     // Last breakpoint corresponds to K&P mandatory final glue
-    if (breakPoint === nodes.length - 1) return acc;
+    if (breakPoint === nodes.length - 1) continue;
 
     let line: AttributedString;
     if (node.type === 'penalty') {
@@ -54,8 +56,8 @@ const breakLines = (
 
     start = end;
 
-    return [...acc, line];
-  }, []);
+    lines.push(line);
+  }
 
   lines.push(slice(start, attributedString.string.length, attributedString));
 

--- a/packages/textkit/src/run/glyphIndexAt.ts
+++ b/packages/textkit/src/run/glyphIndexAt.ts
@@ -23,12 +23,18 @@ const glyphIndexAt = (index: number, run: Run) => {
     return glyphIndices.length;
   }
 
+  let low = 0;
+  let high = glyphIndices.length - 1;
   let result = index;
 
-  for (let i = glyphIndices.length - 1; i >= 0; i -= 1) {
-    if (glyphIndices[i] <= index) {
-      result = i;
-      break;
+  while (low <= high) {
+    const mid = (low + high) >> 1;
+
+    if (glyphIndices[mid] <= index) {
+      result = mid;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
     }
   }
 

--- a/packages/textkit/src/run/offset.ts
+++ b/packages/textkit/src/run/offset.ts
@@ -19,7 +19,15 @@ const offset = (index: number, run: Run) => {
   const stringIndices = run.stringIndices || [];
   const value = stringIndices[index];
 
-  return stringIndices.slice(0, index).filter((i) => i === value).length;
+  if (value === undefined) return 0;
+
+  let result = 0;
+
+  for (let i = index - 1; i >= 0 && stringIndices[i] === value; i -= 1) {
+    result += 1;
+  }
+
+  return result;
 };
 
 export default offset;


### PR DESCRIPTION
This improves textkit line slicing performance for long paragraphs without changing line-breaking behavior.

Changes:
- use binary search in `glyphIndexAt` instead of scanning backward through the full glyph index array
- count ligature offsets by scanning the local repeated-index cluster instead of slicing/filtering the whole prefix
- build `breakLines` with `push` instead of copying the accumulated line array on every breakpoint

Measured in a downstream PDF generator with a single long left-aligned body paragraph:

```text
Baseline, 200k chars: ~31.3s wall, ~43.5s CPU, ~3.38GB maxRSS
With these textkit changes: ~17.0s wall, ~26.4s CPU, ~3.33GB maxRSS
```

Together with #3421, this improves performance in the same downstream PDF generator by:

```text
Baseline, 50k chars: ~2.4s wall, ~3.0s CPU, ~563MB maxRSS
With #3420 + #3421: ~713ms wall, ~1.11s CPU, ~291MB maxRSS

Baseline, 100k chars: ~8.1s wall, ~10.1s CPU, ~1.18GB maxRSS
With #3420 + #3421: ~1.21s wall, ~1.73s CPU, ~423MB maxRSS

Baseline, 200k chars: ~31.3s wall, ~43.5s CPU, ~3.38GB maxRSS
With #3420 + #3421: ~2.28s wall, ~2.96s CPU, ~513MB maxRSS
```

The memory profile is mostly unchanged with this PR alone because the dominant heap allocation comes from the Knuth-Plass active-node search, but the CPU/wall-time improvement is still measurable.