### PR TITLE
feat(textkit): expose line-breaking strategy

### DIFF
--- a/.changeset/tiny-hats-brake.md
+++ b/.changeset/tiny-hats-brake.md
@@ -1,0 +1,8 @@
+---
+'@react-pdf/layout': minor
+'@react-pdf/renderer': minor
+'@react-pdf/textkit': minor
+'@react-pdf/types': minor
+---
+
+Use faster best-fit line breaking for long non-justified text and expose a lineBreakStrategy option.

--- a/.changeset/tiny-hats-brake.md
+++ b/.changeset/tiny-hats-brake.md
@@ -1,0 +1,8 @@
+---
+'@react-pdf/layout': minor
+'@react-pdf/renderer': minor
+'@react-pdf/textkit': minor
+'@react-pdf/types': minor
+---
+
+Expose a lineBreakStrategy option for choosing faster best-fit line breaking.

--- a/packages/layout/src/svg/layoutText.ts
+++ b/packages/layout/src/svg/layoutText.ts
@@ -124,7 +124,11 @@ const layoutTspan = (fontStore: FontStore) => (node, xOffset) => {
     fontStore?.getHyphenationCallback() ||
     null;
 
-  const layoutOptions = { hyphenationCallback, shrinkWhitespaceFactor };
+  const layoutOptions = {
+    hyphenationCallback,
+    lineBreakStrategy: node.props.lineBreakStrategy,
+    shrinkWhitespaceFactor,
+  };
   const lines = engine(attributedString, container, layoutOptions).flat();
 
   return Object.assign({}, node, { lines });

--- a/packages/layout/src/text/layoutText.ts
+++ b/packages/layout/src/text/layoutText.ts
@@ -58,6 +58,7 @@ const getContainer = (width, height, node) => {
  */
 const getLayoutOptions = (fontStore, node) => ({
   hyphenationPenalty: node.props.hyphenationPenalty,
+  lineBreakStrategy: node.props.lineBreakStrategy,
   shrinkWhitespaceFactor: { before: -0.5, after: -0.5 },
   hyphenationCallback:
     node.props.hyphenationCallback ||

--- a/packages/layout/src/types/text.ts
+++ b/packages/layout/src/types/text.ts
@@ -22,6 +22,10 @@ interface TextProps extends NodeProps {
    */
   hyphenationCallback?: HyphenationCallback;
   /**
+   * Controls which line-breaking strategy textkit uses.
+   */
+  lineBreakStrategy?: 'auto' | 'best-fit' | 'knuth-plass';
+  /**
    * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
    * @see https://react-pdf.org/advanced#orphan-&-widow-protection
    */

--- a/packages/layout/src/types/text.ts
+++ b/packages/layout/src/types/text.ts
@@ -28,6 +28,11 @@ interface TextProps extends NodeProps {
    */
   hyphenationPenalty?: number;
   /**
+   * Controls which line-breaking strategy textkit uses.
+   * Defaults to Knuth-Plass.
+   */
+  lineBreakStrategy?: 'best-fit' | 'knuth-plass';
+  /**
    * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
    * @see https://react-pdf.org/advanced#orphan-&-widow-protection
    */

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -255,6 +255,10 @@ declare namespace ReactPDF {
      */
     hyphenationCallback?: HyphenationCallback;
     /**
+     * Controls which line-breaking strategy textkit uses.
+     */
+    lineBreakStrategy?: 'auto' | 'best-fit' | 'knuth-plass';
+    /**
      * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
      * @see https://react-pdf.org/advanced#orphan-&-widow-protection
      */

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -262,6 +262,11 @@ declare namespace ReactPDF {
      */
     hyphenationPenalty?: number;
     /**
+     * Controls which line-breaking strategy textkit uses.
+     * Defaults to Knuth-Plass.
+     */
+    lineBreakStrategy?: 'best-fit' | 'knuth-plass';
+    /**
      * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
      * @see https://react-pdf.org/advanced#orphan-&-widow-protection
      */

--- a/packages/textkit/README.md
+++ b/packages/textkit/README.md
@@ -97,12 +97,13 @@ const result = bidiEngine(attributedString);
 
 ### linebreaker
 
-Performs line breaking using the Knuth-Plass algorithm with fallback to best-fit. Handles hyphenation points and produces optimal line breaks.
+Performs line breaking using the Knuth-Plass algorithm with fallback to best-fit. Handles hyphenation points and produces optimal line breaks. In `auto` mode, long non-justified text uses best-fit line breaking to avoid expensive global line optimization.
 
 ```js
 import { linebreaker } from '@react-pdf/textkit';
 
 const linebreakerEngine = linebreaker({
+  lineBreakStrategy: 'auto',
   tolerance: 4,
   hyphenationPenalty: 100,
 });
@@ -318,6 +319,7 @@ type LayoutOptions = {
     word: string | null,
     fallback: (word: string | null) => string[],
   ) => string[];
+  lineBreakStrategy?: 'auto' | 'best-fit' | 'knuth-plass';
   tolerance?: number;
   hyphenationPenalty?: number;
   expandCharFactor?: JustificationFactor;

--- a/packages/textkit/README.md
+++ b/packages/textkit/README.md
@@ -97,7 +97,7 @@ const result = bidiEngine(attributedString);
 
 ### linebreaker
 
-Performs line breaking using the Knuth-Plass algorithm with fallback to best-fit. Handles hyphenation points and produces optimal line breaks. In `auto` mode, long non-justified text uses best-fit line breaking to avoid expensive global line optimization.
+Performs line breaking using Knuth-Plass or best-fit. Handles hyphenation points and produces optimal line breaks. In `auto` mode, long non-justified text uses best-fit line breaking up front to avoid expensive global line optimization; other text uses Knuth-Plass with best-fit fallback.
 
 ```js
 import { linebreaker } from '@react-pdf/textkit';

--- a/packages/textkit/README.md
+++ b/packages/textkit/README.md
@@ -97,12 +97,13 @@ const result = bidiEngine(attributedString);
 
 ### linebreaker
 
-Performs line breaking using the Knuth-Plass algorithm with fallback to best-fit. Handles hyphenation points and produces optimal line breaks.
+Performs line breaking using the Knuth-Plass algorithm with fallback to best-fit. Set `lineBreakStrategy` to `best-fit` to favor performance over globally optimized line breaks.
 
 ```js
 import { linebreaker } from '@react-pdf/textkit';
 
 const linebreakerEngine = linebreaker({
+  lineBreakStrategy: 'best-fit',
   tolerance: 4,
   hyphenationPenalty: 100,
 });
@@ -318,6 +319,7 @@ type LayoutOptions = {
     word: string | null,
     fallback: (word: string | null) => string[],
   ) => string[];
+  lineBreakStrategy?: 'best-fit' | 'knuth-plass';
   tolerance?: number;
   hyphenationPenalty?: number;
   expandCharFactor?: JustificationFactor;

--- a/packages/textkit/src/engines/linebreaker/index.ts
+++ b/packages/textkit/src/engines/linebreaker/index.ts
@@ -9,7 +9,8 @@ import { Node } from './types';
 const HYPHEN = 0x002d;
 const TOLERANCE_STEPS = 5;
 const TOLERANCE_LIMIT = 50;
-const BEST_FIT_THRESHOLD = 2000;
+// Keep ordinary paragraphs on Knuth-Plass, but avoid active-node blowups for long ragged text.
+const BEST_FIT_CHARACTER_THRESHOLD = 2000;
 
 const opts = {
   width: 3,
@@ -142,13 +143,13 @@ const shouldUseBestFit = (
 
   return (
     attributes.align !== 'justify' &&
-    attributedString.string.length > BEST_FIT_THRESHOLD
+    attributedString.string.length > BEST_FIT_CHARACTER_THRESHOLD
   );
 };
 
 /**
- * Performs Knuth & Plass line breaking algorithm
- * Fallbacks to best fit algorithm if latter not successful
+ * Performs line breaking using the configured strategy.
+ * Auto mode uses best-fit for long ragged text, otherwise Knuth-Plass with best-fit fallback.
  *
  * @param options - Layout options
  */

--- a/packages/textkit/src/engines/linebreaker/index.ts
+++ b/packages/textkit/src/engines/linebreaker/index.ts
@@ -9,6 +9,7 @@ import { Node } from './types';
 const HYPHEN = 0x002d;
 const TOLERANCE_STEPS = 5;
 const TOLERANCE_LIMIT = 50;
+const BEST_FIT_THRESHOLD = 2000;
 
 const opts = {
   width: 3,
@@ -131,6 +132,20 @@ const getAttributes = (attributedString: AttributedString) => {
   return attributedString.runs?.[0]?.attributes || {};
 };
 
+const shouldUseBestFit = (
+  attributedString: AttributedString,
+  attributes: Attributes,
+  options: LayoutOptions,
+) => {
+  if (options.lineBreakStrategy === 'best-fit') return true;
+  if (options.lineBreakStrategy === 'knuth-plass') return false;
+
+  return (
+    attributes.align !== 'justify' &&
+    attributedString.string.length > BEST_FIT_THRESHOLD
+  );
+};
+
 /**
  * Performs Knuth & Plass line breaking algorithm
  * Fallbacks to best fit algorithm if latter not successful
@@ -148,11 +163,14 @@ const linebreaker = (options: LayoutOptions) => {
 
     const attributes = getAttributes(attributedString);
     const nodes = getNodes(attributedString, attributes, options);
+    const useBestFit = shouldUseBestFit(attributedString, attributes, options);
 
-    let breaks = knuthPlass(nodes, availableWidths, tolerance);
+    let breaks = useBestFit
+      ? bestFit(nodes, availableWidths)
+      : knuthPlass(nodes, availableWidths, tolerance);
 
     // Try again with a higher tolerance if the line breaking failed.
-    while (breaks.length === 0 && tolerance < TOLERANCE_LIMIT) {
+    while (!useBestFit && breaks.length === 0 && tolerance < TOLERANCE_LIMIT) {
       tolerance += TOLERANCE_STEPS;
       breaks = knuthPlass(nodes, availableWidths, tolerance);
     }

--- a/packages/textkit/src/engines/linebreaker/index.ts
+++ b/packages/textkit/src/engines/linebreaker/index.ts
@@ -134,8 +134,8 @@ const getAttributes = (attributedString: AttributedString) => {
 };
 
 /**
- * Performs Knuth & Plass line breaking algorithm
- * Fallbacks to best fit algorithm if latter not successful
+ * Performs line breaking using the configured strategy.
+ * Defaults to Knuth-Plass with best-fit fallback.
  *
  * @param options - Layout options
  */
@@ -150,11 +150,14 @@ const linebreaker = (options: LayoutOptions) => {
 
     const attributes = getAttributes(attributedString);
     const nodes = getNodes(attributedString, attributes, options);
+    const useBestFit = options.lineBreakStrategy === 'best-fit';
 
-    let breaks = knuthPlass(nodes, availableWidths, tolerance);
+    let breaks = useBestFit
+      ? bestFit(nodes, availableWidths)
+      : knuthPlass(nodes, availableWidths, tolerance);
 
     // Try again with a higher tolerance if the line breaking failed.
-    while (breaks.length === 0 && tolerance < TOLERANCE_LIMIT) {
+    while (!useBestFit && breaks.length === 0 && tolerance < TOLERANCE_LIMIT) {
       tolerance += TOLERANCE_STEPS;
       breaks = knuthPlass(nodes, availableWidths, tolerance);
     }

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -134,6 +134,7 @@ export type LayoutOptions = {
     word: string | null,
     fallback: (word: string | null) => string[],
   ) => string[];
+  lineBreakStrategy?: 'auto' | 'best-fit' | 'knuth-plass';
   tolerance?: number;
   hyphenationPenalty?: number;
   expandCharFactor?: JustificationFactor;

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -134,6 +134,7 @@ export type LayoutOptions = {
     word: string | null,
     fallback: (word: string | null) => string[],
   ) => string[];
+  lineBreakStrategy?: 'best-fit' | 'knuth-plass';
   tolerance?: number;
   hyphenationPenalty?: number;
   expandCharFactor?: JustificationFactor;

--- a/packages/textkit/tests/engines/linebreaker.test.ts
+++ b/packages/textkit/tests/engines/linebreaker.test.ts
@@ -10,6 +10,33 @@ const width = 50;
 describe('linebreaker', () => {
   const linebreaker = linebreakerFactory({});
 
+  const createLongAttributedString = (attributes = {}) => {
+    const string = Array(600).fill('word').join(' ');
+    const indices = Array.from({ length: string.length }, (_, index) => index);
+
+    return {
+      string,
+      runs: [
+        {
+          start: 0,
+          end: string.length,
+          attributes: { font: [font], ...attributes },
+          stringIndices: indices,
+          glyphIndices: indices,
+          positions: indices.map(() => ({
+            xAdvance: 1,
+            yAdvance: 0,
+            xOffset: 0,
+            yOffset: 0,
+            advanceWidth: 1,
+          })),
+          glyphs: [],
+        },
+      ],
+      syllables: string.split(/([ ]+)/g).filter(Boolean),
+    };
+  };
+
   test('should break lines and adds hyphens only where indicated', () => {
     const attributedString = {
       string: 'Potentieel broeikasgasemissierapport',
@@ -295,6 +322,31 @@ describe('linebreaker', () => {
       'emissie-',
       'rapport',
     ]);
+  });
+
+  test('should use best-fit for long non-justified text in auto mode', () => {
+    const attributedString = createLongAttributedString();
+    const result = linebreakerFactory({})(attributedString, [50]);
+    const bestFitResult = linebreakerFactory({ lineBreakStrategy: 'best-fit' })(
+      attributedString,
+      [50],
+    );
+
+    expect(result.map((line) => line.string)).toEqual(
+      bestFitResult.map((line) => line.string),
+    );
+  });
+
+  test('should keep Knuth-Plass for long justified text in auto mode', () => {
+    const attributedString = createLongAttributedString({ align: 'justify' });
+    const result = linebreakerFactory({})(attributedString, [50]);
+    const knuthPlassResult = linebreakerFactory({
+      lineBreakStrategy: 'knuth-plass',
+    })(attributedString, [50]);
+
+    expect(result.map((line) => line.string)).toEqual(
+      knuthPlassResult.map((line) => line.string),
+    );
   });
 });
 

--- a/packages/textkit/tests/engines/linebreaker.test.ts
+++ b/packages/textkit/tests/engines/linebreaker.test.ts
@@ -1,4 +1,23 @@
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('../../src/engines/linebreaker/bestFit', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../src/engines/linebreaker/bestFit')
+    >();
+
+  return { default: vi.fn(actual.default) };
+});
+
+vi.mock('../../src/engines/linebreaker/knuthPlass', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('../../src/engines/linebreaker/knuthPlass')
+    >();
+  const fn = vi.fn(actual.default);
+
+  return { default: Object.assign(fn, actual.default) };
+});
 
 import linebreakerFactory from '../../src/engines/linebreaker';
 import applyBestFit from '../../src/engines/linebreaker/bestFit';
@@ -9,6 +28,11 @@ const width = 50;
 
 describe('linebreaker', () => {
   const linebreaker = linebreakerFactory({});
+
+  beforeEach(() => {
+    vi.mocked(applyBestFit).mockClear();
+    vi.mocked(applyKnuthPlass).mockClear();
+  });
 
   const createLongAttributedString = (attributes = {}) => {
     const string = Array(600).fill('word').join(' ');
@@ -326,27 +350,20 @@ describe('linebreaker', () => {
 
   test('should use best-fit for long non-justified text in auto mode', () => {
     const attributedString = createLongAttributedString();
-    const result = linebreakerFactory({})(attributedString, [50]);
-    const bestFitResult = linebreakerFactory({ lineBreakStrategy: 'best-fit' })(
-      attributedString,
-      [50],
-    );
 
-    expect(result.map((line) => line.string)).toEqual(
-      bestFitResult.map((line) => line.string),
-    );
+    linebreakerFactory({})(attributedString, [50]);
+
+    expect(applyBestFit).toHaveBeenCalledTimes(1);
+    expect(applyKnuthPlass).not.toHaveBeenCalled();
   });
 
   test('should keep Knuth-Plass for long justified text in auto mode', () => {
     const attributedString = createLongAttributedString({ align: 'justify' });
-    const result = linebreakerFactory({})(attributedString, [50]);
-    const knuthPlassResult = linebreakerFactory({
-      lineBreakStrategy: 'knuth-plass',
-    })(attributedString, [50]);
 
-    expect(result.map((line) => line.string)).toEqual(
-      knuthPlassResult.map((line) => line.string),
-    );
+    linebreakerFactory({})(attributedString, [50]);
+
+    expect(applyKnuthPlass).toHaveBeenCalled();
+    expect(applyBestFit).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/textkit/tests/engines/linebreaker.test.ts
+++ b/packages/textkit/tests/engines/linebreaker.test.ts
@@ -10,8 +10,8 @@ const width = 50;
 describe('linebreaker', () => {
   const linebreaker = linebreakerFactory({});
 
-  const createLongAttributedString = (attributes = {}) => {
-    const string = Array(600).fill('word').join(' ');
+  const createAttributedString = () => {
+    const string = 'a b c d e f';
     const indices = Array.from({ length: string.length }, (_, index) => index);
 
     return {
@@ -20,15 +20,15 @@ describe('linebreaker', () => {
         {
           start: 0,
           end: string.length,
-          attributes: { font: [font], ...attributes },
+          attributes: { font: [font] },
           stringIndices: indices,
           glyphIndices: indices,
-          positions: indices.map(() => ({
-            xAdvance: 1,
+          positions: Array.from(string, (character) => ({
+            xAdvance: character === ' ' ? 2 : 3,
             yAdvance: 0,
             xOffset: 0,
             yOffset: 0,
-            advanceWidth: 1,
+            advanceWidth: character === ' ' ? 2 : 3,
           })),
           glyphs: [],
         },
@@ -324,29 +324,23 @@ describe('linebreaker', () => {
     ]);
   });
 
-  test('should use best-fit for long non-justified text in auto mode', () => {
-    const attributedString = createLongAttributedString();
-    const result = linebreakerFactory({})(attributedString, [50]);
-    const bestFitResult = linebreakerFactory({ lineBreakStrategy: 'best-fit' })(
+  test('should use best-fit when configured', () => {
+    const attributedString = createAttributedString();
+
+    const result = linebreakerFactory({ lineBreakStrategy: 'best-fit' })(
       attributedString,
-      [50],
+      [12],
     );
 
-    expect(result.map((line) => line.string)).toEqual(
-      bestFitResult.map((line) => line.string),
-    );
+    expect(result.map((line) => line.string)).toEqual(['a b ', 'c d ', 'e f']);
   });
 
-  test('should keep Knuth-Plass for long justified text in auto mode', () => {
-    const attributedString = createLongAttributedString({ align: 'justify' });
-    const result = linebreakerFactory({})(attributedString, [50]);
-    const knuthPlassResult = linebreakerFactory({
-      lineBreakStrategy: 'knuth-plass',
-    })(attributedString, [50]);
+  test('should use Knuth-Plass by default', () => {
+    const attributedString = createAttributedString();
 
-    expect(result.map((line) => line.string)).toEqual(
-      knuthPlassResult.map((line) => line.string),
-    );
+    const result = linebreakerFactory({})(attributedString, [12]);
+
+    expect(result.map((line) => line.string)).toEqual(['a b c ', 'd e f']);
   });
 });
 

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -24,6 +24,7 @@ interface TextProps extends BaseProps {
   orphans?: number;
   render?: DynamicRenderCallback;
   hyphenationCallback?: HyphenationCallback;
+  lineBreakStrategy?: 'auto' | 'best-fit' | 'knuth-plass';
 }
 
 interface ViewProps extends BaseProps {

--- a/packages/types/node.d.ts
+++ b/packages/types/node.d.ts
@@ -24,6 +24,7 @@ interface TextProps extends BaseProps {
   orphans?: number;
   render?: DynamicRenderCallback;
   hyphenationCallback?: HyphenationCallback;
+  lineBreakStrategy?: 'best-fit' | 'knuth-plass';
 }
 
 interface ViewProps extends BaseProps {


### PR DESCRIPTION
This exposes `lineBreakStrategy` on `<Text />` and in textkit layout options so callers can choose between `best-fit` and `knuth-plass` line breaking.

The default remains Knuth–Plass with best-fit fallback. Following the review feedback, this revision removes the automatic long-text threshold, so existing documents keep their current typography and users opt into the performance tradeoff explicitly:

```jsx
<Text lineBreakStrategy="best-fit">...</Text>
```

Why: in a downstream PDF generator, customer-editable body copy can contain very long paragraphs. Profiling showed the hot path was textkit's Knuth–Plass active-node search. For a 50k-character paragraph, the linebreaker built ~20,650 syllables and ~30,431 nodes; node creation took ~6ms, but Knuth–Plass took ~769ms and the heap jumped to ~277MB.

Measured downstream with best-fit selected for long body text:

```text
Knuth–Plass, 200k chars: ~31.3s wall, ~43.5s CPU, ~3.38GB maxRSS
Best-fit, 200k chars:     ~2.3s wall,  ~3.0s CPU,  ~0.5GB maxRSS
```

The generated PDF size was essentially unchanged (~180KB), so the win comes from avoiding intermediate layout work rather than output compression.

The tests use a fixture where Knuth–Plass and best-fit produce different line breaks, verifying both explicit best-fit selection and the unchanged default.
