### PR TITLE
fix(image): replace deprecated url parser

### DIFF
--- a/.changeset/quiet-paths-smile.md
+++ b/.changeset/quiet-paths-smile.md
@@ -1,0 +1,5 @@
+---
+"@react-pdf/image": patch
+---
+
+Replace deprecated url.parse usage in local image path resolution.

--- a/packages/image/src/resolve.ts
+++ b/packages/image/src/resolve.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import url from 'url';
+import { fileURLToPath } from 'url';
 import path from 'path';
 
 import PNG from './png';
@@ -36,22 +36,30 @@ const getAbsoluteLocalPath = (src: string) => {
     throw new Error('Cannot check local paths in client-side environment');
   }
 
-  const {
-    protocol,
-    auth,
-    host,
-    port,
-    hostname,
-    path: pathname,
-  } = url.parse(src);
+  try {
+    const parsed = new URL(src);
 
-  const absolutePath = pathname ? path.resolve(src) : undefined;
+    if (
+      parsed.protocol !== 'file:' ||
+      parsed.username ||
+      parsed.password ||
+      parsed.host
+    ) {
+      return undefined;
+    }
 
-  if ((protocol && protocol !== 'file:') || auth || host || port || hostname) {
-    return undefined;
+    return fileURLToPath(parsed.href);
+  } catch {
+    if (!src) {
+      return undefined;
+    }
+
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(src)) {
+      return undefined;
+    }
+
+    return path.resolve(src);
   }
-
-  return absolutePath;
 };
 
 const fetchLocalFile = (src: LocalImageSrc): Promise<Buffer> =>

--- a/packages/image/tests/resolve.test.ts
+++ b/packages/image/tests/resolve.test.ts
@@ -101,6 +101,17 @@ describe('image resolveImage', () => {
     expect(image?.height).toBeGreaterThan(0);
   });
 
+  test('Should render a local image from file URL', async () => {
+    const absolutePath = path.join(__dirname, './assets/test.jpg');
+    const image = await resolveImage({
+      uri: url.pathToFileURL(absolutePath).href,
+    });
+
+    expect(image?.data).toBeTruthy();
+    expect(image?.width).toBeGreaterThan(0);
+    expect(image?.height).toBeGreaterThan(0);
+  });
+
   test('Should render a local image from relative path', async () => {
     const image = await resolveImage({
       uri: 'packages/layout/tests/assets/test.jpg',


### PR DESCRIPTION
## Summary
- replace legacy url.parse usage in @react-pdf/image local path detection
- preserve local relative/absolute path support and reject remote URLs for local reads
- add coverage for file:// image URLs

## Test plan
- yarn workspace @react-pdf/primitives build
- yarn workspace @react-pdf/svg build
- yarn workspace @react-pdf/image typecheck
- yarn vitest packages/image/tests/resolve.test.ts --run