### PR TITLE
fix(layout): parse inherited rgba/rgb SVG stroke and fill colors

### DIFF
--- a/packages/layout/src/steps/resolveSvg.ts
+++ b/packages/layout/src/steps/resolveSvg.ts
@@ -391,8 +391,8 @@ const resolveSvgRoot = (node: SafeSvgNode, fontStore: FontStore) => {
     parseText(fontStore),
     parseSvgProps,
     pickStyleProps,
-    inheritProps,
     resolveChildren(container),
+    inheritProps,
     resolveXLinks,
   )(node);
 };

--- a/packages/layout/tests/steps/resolveSvg.test.ts
+++ b/packages/layout/tests/steps/resolveSvg.test.ts
@@ -249,4 +249,154 @@ describe('layout resolveSvg', () => {
       expect(svgNode.style.height).toBe(100);
     });
   });
+
+  describe('SVG prop inheritance', () => {
+    const createMockPageNode = (children: SafeNode[]): SafePageNode =>
+      ({
+        type: P.Page,
+        props: {},
+        style: {},
+        children,
+      }) as SafePageNode;
+
+    test('should parse inherited rgba() stroke to hex', () => {
+      const svgNode: SafeSvgNode = {
+        type: P.Svg,
+        props: { stroke: 'rgba(115, 123, 117, 1)', width: 24, height: 24 },
+        style: {},
+        children: [
+          {
+            type: P.Path,
+            props: { d: 'M4 21H20' },
+            style: {},
+          },
+        ],
+      };
+
+      const pageNode = createMockPageNode([svgNode]);
+      const result = resolveSvg(pageNode, null as any) as SafePageNode;
+      const svg = result.children?.[0] as SafeSvgNode;
+      const path = svg.children?.[0] as SafeNode;
+
+      expect(path?.props.stroke).toBe('#737B75');
+    });
+
+    test('should parse inherited rgb() stroke to hex', () => {
+      const svgNode: SafeSvgNode = {
+        type: P.Svg,
+        props: { stroke: 'rgb(255, 0, 0)', width: 24, height: 24 },
+        style: {},
+        children: [
+          {
+            type: P.Path,
+            props: { d: 'M4 21H20' },
+            style: {},
+          },
+        ],
+      };
+
+      const pageNode = createMockPageNode([svgNode]);
+      const result = resolveSvg(pageNode, null as any) as SafePageNode;
+      const svg = result.children?.[0] as unknown as SafeSvgNode;
+      const path = svg.children?.[0] as SafeNode;
+
+      expect(path?.props.stroke).toBe('#FF0000');
+    });
+
+    test('should parse inherited rgba() fill to hex', () => {
+      const svgNode: SafeSvgNode = {
+        type: P.Svg,
+        props: { fill: 'rgba(115, 123, 117, 0.5)', width: 24, height: 24 },
+        style: {},
+        children: [
+          {
+            type: P.Path,
+            props: { d: 'M4 21H20' },
+            style: {},
+          },
+        ],
+      };
+
+      const pageNode = createMockPageNode([svgNode]);
+      const result = resolveSvg(pageNode, null as any) as SafePageNode;
+      const svg = result.children?.[0] as unknown as SafeSvgNode;
+      const path = svg.children?.[0] as SafeNode;
+
+      expect(path?.props.fill).toBe('#737B75');
+    });
+
+    test('should keep inherited hex stroke as-is', () => {
+      const svgNode: SafeSvgNode = {
+        type: P.Svg,
+        props: { stroke: '#737B75', width: 24, height: 24 },
+        style: {},
+        children: [
+          {
+            type: P.Path,
+            props: { d: 'M4 21H20' },
+            style: {},
+          },
+        ],
+      };
+
+      const pageNode = createMockPageNode([svgNode]);
+      const result = resolveSvg(pageNode, null as any) as SafePageNode;
+      const svg = result.children?.[0] as unknown as SafeSvgNode;
+      const path = svg.children?.[0] as SafeNode;
+
+      expect(path?.props.stroke).toBe('#737B75');
+    });
+
+    test('child explicit stroke should override inherited stroke', () => {
+      const svgNode: SafeSvgNode = {
+        type: P.Svg,
+        props: { stroke: 'rgba(115, 123, 117, 1)', width: 24, height: 24 },
+        style: {},
+        children: [
+          {
+            type: P.Path,
+            props: { d: 'M4 21H20', stroke: '#FF0000' },
+            style: {},
+          },
+        ],
+      };
+
+      const pageNode = createMockPageNode([svgNode]);
+      const result = resolveSvg(pageNode, null as any) as SafePageNode;
+      const svg = result.children?.[0] as unknown as SafeSvgNode;
+      const path = svg.children?.[0] as SafeNode;
+
+      expect(path?.props.stroke).toBe('#FF0000');
+    });
+
+    test('should parse inherited rgba() props through nested G element', () => {
+      const svgNode: SafeSvgNode = {
+        type: P.Svg,
+        props: { stroke: 'rgba(115, 123, 117, 1)', width: 24, height: 24 },
+        style: {},
+        children: [
+          {
+            type: P.G,
+            props: {},
+            style: {},
+            children: [
+              {
+                type: P.Path,
+                props: { d: 'M4 21H20' },
+                style: {},
+              },
+            ],
+          },
+        ],
+      };
+
+      const pageNode = createMockPageNode([svgNode]);
+      const result = resolveSvg(pageNode, null as any) as SafePageNode;
+      const svg = result.children?.[0] as unknown as SafeSvgNode;
+      const g = svg.children?.[0] as SafeNode;
+      const path = g.children?.[0] as SafeNode;
+
+      expect(path?.props.stroke).toBe('#737B75');
+    });
+  });
 });


### PR DESCRIPTION
# Fix inherited SVG `rgba()`/`rgb()` stroke and fill rendering

## Summary

Fixes an issue where inherited SVG `stroke` and `fill` properties using functional color syntax (`rgba()`, `rgb()`) were not rendered correctly in `@react-pdf/renderer`.

Previously, inherited color values from parent `<Svg>` elements reached child nodes before color normalization occurred, leaving raw `rgba(...)` strings untransformed when passed to PDFKit.

## Broken example

The following SVG failed to render strokes correctly:

```jsx id="4yxz8h"
<Svg
  viewBox="0 0 24 24"
  stroke="rgba(115, 123, 117, 1)"
  strokeWidth={1.5}
  strokeLinecap="round"
  strokeLinejoin="round"
>
  <Path d="M4 21H20" />
  <Path d="M4 18V6C4 4.34315 5.34315 3 7 3H17C18.6569 3 20 4.34315 20 6V18" />
</Svg>
```

Observed behavior:

* child `<Path>` strokes were not rendered
* moving `stroke="rgba(...)"` directly onto each `<Path>` worked
* replacing the inherited color with a hex value also worked

Example workaround:

```jsx id="g5izsl"
<Path
  d="M4 21H20"
  stroke="rgba(115, 123, 117, 1)"
/>
```

or:

```jsx id="czghvk"
<Svg stroke="#737B75">
```

## Root cause

The compose chain executed:

```txt id="4h2xuq"
resolveChildren(container)
→ inheritProps(...)
```

This caused child nodes to be resolved before inheriting parent paint properties. As a result:

* inherited `rgba(...)` / `rgb(...)` values bypassed `transformColorSafe`
* raw functional color strings reached the PDF renderer
* PDFKit failed to render those stroke/fill values

Hex and named colors appeared unaffected because they already passed through unchanged.

## Fix

Swapped the compose order so inherited props are applied before child resolution:

```txt id="k3upq9"
inheritProps(...)
→ resolveChildren(container)
```

This ensures inherited paint properties are normalized during child resolution through `transformColorSafe`.

## Result

Inherited SVG paint properties now render correctly for:

* `rgba()`
* `rgb()`
* hex colors
* named colors

Example now working correctly:

```jsx id="7xqvfi"
<Svg
  stroke="rgba(115, 123, 117, 1)"
  strokeWidth={1.5}
>
  <Path d="M4 21H20" />
</Svg>
```

Before:
<img width="500" alt="Screenshot 2026-05-28 at 10 03 24 AM" src="https://github.com/user-attachments/assets/9029d143-e627-4fb2-ba8c-75ab1839acad" />

After:
<img width="500" alt="Screenshot 2026-05-28 at 10 04 55 AM" src="https://github.com/user-attachments/assets/e813dc9b-e4b3-497f-9fd6-71f19f1cfb64" />


## Notes

* No behavioral changes for existing hex or named color usage.
* Fix applies to both inherited `stroke` and `fill` properties.
* Direct per-node color definitions were already working and remain unaffected.
