### PR TITLE
feat: expose `hyphenationPenalty`

### DIFF
--- a/.changeset/expose-hyphenation-penalty.md
+++ b/.changeset/expose-hyphenation-penalty.md
@@ -5,8 +5,3 @@
 
 feat: expose `hyphenationPenalty` on `Text` props
 
-The `hyphenationPenalty` layout option was already honoured at runtime but
-was missing from the public `TextProps` types. Consumers can work around this
-with type-casting or type augmentation, but surfacing this prop removes the
-need for consumers to handle this in undefined ways. Setting this to `Infinity`
-disables automatic hyphenation for a given text block.

--- a/.changeset/expose-hyphenation-penalty.md
+++ b/.changeset/expose-hyphenation-penalty.md
@@ -1,0 +1,12 @@
+---
+"@react-pdf/renderer": minor
+"@react-pdf/layout": minor
+---
+
+feat: expose `hyphenationPenalty` on `Text` props
+
+The `hyphenationPenalty` layout option was already honoured at runtime but
+was missing from the public `TextProps` types. Consumers can work around this
+with type-casting or type augmentation, but surfacing this prop removes the
+need for consumers to handle this in undefined ways. Setting this to `Infinity`
+disables automatic hyphenation for a given text block.

--- a/packages/layout/src/types/text.ts
+++ b/packages/layout/src/types/text.ts
@@ -22,6 +22,12 @@ interface TextProps extends NodeProps {
    */
   hyphenationCallback?: HyphenationCallback;
   /**
+   * Override the default hyphenation penalty
+   * Defaults to 100 for justified text and 600 otherwise.
+   * @see https://react-pdf.org/fonts#hyphenationpenalty
+   */
+  hyphenationPenalty?: number;
+  /**
    * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
    * @see https://react-pdf.org/advanced#orphan-&-widow-protection
    */

--- a/packages/layout/tests/text/layoutText.test.ts
+++ b/packages/layout/tests/text/layoutText.test.ts
@@ -103,4 +103,36 @@ describe('text layoutText', () => {
       expect.any(Function),
     );
   });
+
+  test('should suppress hyphenation when `hyphenationPenalty` is set to `Infinity`', () => {
+    const text = 'Lorem ipsum dolor sit amet consectetur adipiscing elit';
+
+    // Using `justify` text uses a hyphenation penalty of 100 by default.
+    // This produces at least one line break with a trailing hyphen.
+    const defaultLines = layoutText(
+      createTextNode(text, { textAlign: 'justify' }),
+      180,
+      200,
+      fontStore,
+    );
+    expect(defaultLines[0].string).toEqual('Lorem ipsum dolor sit ');
+    expect(defaultLines[1].string).toEqual('amet consectetur adip-');
+    expect(defaultLines[2].string).toEqual('iscing elit');
+
+    // Setting a hyphenation penalty of `Infinity` makes hyphenation nearly
+    // impossible, so lines break only at word boundaries.
+    const noHyphenLines = layoutText(
+      createTextNode(
+        text,
+        { textAlign: 'justify' },
+        { hyphenationPenalty: Infinity },
+      ),
+      180,
+      200,
+      fontStore,
+    );
+    expect(noHyphenLines[0].string).toEqual('Lorem ipsum dolor ');
+    expect(noHyphenLines[1].string).toEqual('sit amet consectetur ');
+    expect(noHyphenLines[2].string).toEqual('adipiscing elit');
+  });
 });

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -255,6 +255,12 @@ declare namespace ReactPDF {
      */
     hyphenationCallback?: HyphenationCallback;
     /**
+     * Override the default hyphenation penalty
+     * Defaults to 100 for justified text and 600 otherwise.
+     * @see https://react-pdf.org/fonts#hyphenationpenalty
+     */
+    hyphenationPenalty?: number;
+    /**
      * Specifies the minimum number of lines in a text element that must be shown at the bottom of a page or its container.
      * @see https://react-pdf.org/advanced#orphan-&-widow-protection
      */


### PR DESCRIPTION
I found being able to set `hyphenationPenalty` perfect for solving some challenging hyphenation cases with localisation and inline addresses.

Locally, I augmented the types to expose it, but thought it would be great to have this available on the actual API too :)

Docs PR: https://github.com/diegomura/react-pdf-site/pull/176