### PR TITLE
fix(render): specify the left coordinate in named destinations so internal links navigate in macOS Preview

### DIFF
--- a/.changeset/named-destination-left-coordinate.md
+++ b/.changeset/named-destination-left-coordinate.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/render': patch
+---
+
+fix(render): specify the left coordinate in named destinations so internal links navigate in macOS Preview

--- a/packages/render/src/operations/setDestination.ts
+++ b/packages/render/src/operations/setDestination.ts
@@ -7,7 +7,7 @@ const setDestination = (ctx: Context, node: SafeNode) => {
   if (!node.props) return;
 
   if ('id' in node.props) {
-    ctx.addNamedDestination(node.props.id!, 'XYZ', null, node.box.top, null);
+    ctx.addNamedDestination(node.props.id!, 'XYZ', node.box.left ?? 0, node.box.top, null);
   }
 };
 

--- a/packages/render/tests/operations/setDestination.test.ts
+++ b/packages/render/tests/operations/setDestination.test.ts
@@ -17,6 +17,20 @@ describe('operations setDestination', () => {
 
     expect(ctx.addNamedDestination.mock.calls).toHaveLength(1);
     expect(ctx.addNamedDestination.mock.calls[0][0]).toBe('test');
+    expect(ctx.addNamedDestination.mock.calls[0][2]).toBe(0);
+    expect(ctx.addNamedDestination.mock.calls[0][3]).toBe(20);
+  });
+
+  test('should pass the node left coordinate as the destination left', () => {
+    const ctx = createCTX();
+    const box = { top: 20, left: 15 };
+    const props = { id: 'test' };
+    const doc = { type: P.View, style: {}, props, box } as SafeNode;
+
+    setDestination(ctx, doc);
+
+    expect(ctx.addNamedDestination.mock.calls).toHaveLength(1);
+    expect(ctx.addNamedDestination.mock.calls[0][2]).toBe(15);
     expect(ctx.addNamedDestination.mock.calls[0][3]).toBe(20);
   });
 


### PR DESCRIPTION
Fixes #3461.

`setDestination` currently registers named destinations as `/XYZ null <top> null`. Apple's PDFKit (which powers Preview and any macOS/iOS app embedding `PDFView`) discards the destination's top coordinate when the left coordinate is unspecified, and simply navigates to the top of the target page. On single-page documents this makes every internal `<Link src="#id">` appear completely dead.

This PR passes the node's `box.left` (falling back to 0) instead of `null`, producing `/XYZ 0 <top> null`: the same explicit form Acrobat writes. Verified with a headless `PDFView` harness: with `null` left the view does not move; with a specified left it scrolls to the exact destination. Chrome (PDFium), Firefox (pdf.js), Edge and Acrobat resolve both forms, so behaviour there is unchanged.

Includes updated unit tests and a changeset.

Context: found while debugging [Site Kit by Google](https://github.com/google/site-kit-wp) (react-pdf powers its dashboard PDF export), where section links in the generated report worked in Chrome, Firefox, Edge and Acrobat but were dead in Apple Preview: [google/site-kit-wp#13212](https://github.com/google/site-kit-wp/issues/13212). Site Kit currently ships this fix as a `patch-package` patch ([google/site-kit-wp#13225](https://github.com/google/site-kit-wp/pull/13225)) and will drop it once a release containing this change is adopted.
