### PR TITLE
fix(math,mermaid): declare @react-pdf/primitives dependency

### DIFF
--- a/.changeset/declare-primitives-dependency.md
+++ b/.changeset/declare-primitives-dependency.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/mermaid': patch
+'@react-pdf/math': patch
+---
+
+Declare `@react-pdf/primitives` dependency.

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -23,6 +23,7 @@
     "lib"
   ],
   "dependencies": {
+    "@react-pdf/primitives": "^4.3.0",
     "@react-pdf/svg": "^1.1.0",
     "mathjax-full": "^3.2.2"
   },

--- a/packages/mermaid/package.json
+++ b/packages/mermaid/package.json
@@ -23,6 +23,7 @@
     "lib"
   ],
   "dependencies": {
+    "@react-pdf/primitives": "^4.3.0",
     "@react-pdf/svg": "^1.1.0",
     "beautiful-mermaid": "^1.1.3"
   },


### PR DESCRIPTION
## Problem

`@react-pdf/math` and `@react-pdf/mermaid` both import `@react-pdf/primitives` at runtime:

- `packages/math/src/mapSvg.tsx:2`
- `packages/mermaid/src/mapSvg.tsx:2`

Neither declares it in `dependencies`. The import survives the build as a bare external in `lib/index.js`, so it only resolves because Yarn hoists `@react-pdf/primitives` to the root — it's pulled in transitively via `@react-pdf/svg`. Under strict/isolated layouts (pnpm, Yarn PnP, isolated global stores) the bare import has nothing to resolve against and consumers fail to bundle.

Same class of bug as #3453, different packages.

## Fix

Declare `@react-pdf/primitives@^4.3.0` in both packages, matching how `svg`, `layout`, `render`, `renderer`, and `types` already declare it.

## Validation

- `yarn install` — `yarn.lock` unchanged (workspace resolution)
- Full monorepo build passes (14 projects)
- Prettier check clean on all changed files
- Re-ran a sweep comparing every package's built imports against its declared deps; `math` and `mermaid` are now clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)