### PR TITLE
fix: unbreak master CI build and lint

### DIFF
--- a/packages/image/src/resolve.ts
+++ b/packages/image/src/resolve.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { fileURLToPath } from 'url';
+import url from 'url';
 import path from 'path';
 
 import PNG from './png';
@@ -48,7 +48,7 @@ const getAbsoluteLocalPath = (src: string) => {
       return undefined;
     }
 
-    return fileURLToPath(parsed.href);
+    return url.fileURLToPath(parsed.href);
   } catch {
     if (!src) {
       return undefined;

--- a/packages/render/src/operations/setDestination.ts
+++ b/packages/render/src/operations/setDestination.ts
@@ -7,7 +7,13 @@ const setDestination = (ctx: Context, node: SafeNode) => {
   if (!node.props) return;
 
   if ('id' in node.props) {
-    ctx.addNamedDestination(node.props.id!, 'XYZ', node.box.left ?? 0, node.box.top, null);
+    ctx.addNamedDestination(
+      node.props.id!,
+      'XYZ',
+      node.box.left ?? 0,
+      node.box.top,
+      null,
+    );
   }
 };
 


### PR DESCRIPTION
Master has been red since #3429 for two independent reasons, both fixed here.

**Build (blocks every CI job):** the `@react-pdf/image` browser build stubs `fs`, `path` and `url` via `rollup-plugin-ignore`, whose placeholder module only exposes a default export — so the named `{ fileURLToPath }` import added in #3429 failed to resolve and broke `@react-pdf/image:build`. Since every job builds during `yarn --frozen-lockfile`, Lint, Check size and all 12 test matrix jobs died before running anything; importing `url` as a default (like the neighbouring `fs` and `path`) fixes it, and the browser bundle still tree-shakes the call away behind the `BROWSER` guard.

**Lint:** reformatted an `addNamedDestination` call in `packages/render` that was over prettier's print width.

Verified locally on Node 22: build, `yarn lint`, `yarn test` (216 files / 2244 tests) and the renderer size check all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)