### PR TITLE
refactor(pdfkit): align structure_element.js with upstream

### DIFF
--- a/.changeset/align-structure-element-upstream.md
+++ b/.changeset/align-structure-element-upstream.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': minor
+---
+
+Align `structure_element.js` with upstream pdfkit

--- a/packages/pdfkit/src/structure_element.js
+++ b/packages/pdfkit/src/structure_element.js
@@ -25,30 +25,29 @@ class PDFStructureElement {
       options = {};
     }
 
-    if (typeof options.title !== 'undefined') {
+    if (options.title) {
       data.T = new String(options.title);
     }
-    if (typeof options.lang !== 'undefined') {
+    if (options.lang) {
       data.Lang = new String(options.lang);
     }
-    if (typeof options.alt !== 'undefined') {
+    if (options.alt) {
       data.Alt = new String(options.alt);
     }
-    if (typeof options.expanded !== 'undefined') {
+    if (options.expanded) {
       data.E = new String(options.expanded);
     }
-    if (typeof options.actual !== 'undefined') {
+    if (options.actual) {
       data.ActualText = new String(options.actual);
     }
-    if (
-      typeof options.bbox !== 'undefined' ||
-      typeof options.placement !== 'undefined'
-    ) {
+
+    const hasBbox = Array.isArray(options.bbox) && options.bbox.length === 4;
+    const hasPlacement = typeof options.placement === 'string';
+    if (hasBbox || hasPlacement) {
       const attrs = { O: 'Layout' };
-      attrs.Placement =
-        typeof options.placement !== 'undefined' ? options.placement : 'Block';
-      if (typeof options.bbox !== 'undefined') {
-        const height = this.document.page.height;
+      attrs.Placement = hasPlacement ? options.placement : 'Block';
+      if (hasBbox) {
+        const height = document.page.height;
         attrs.BBox = [
           options.bbox[0],
           height - options.bbox[3],
@@ -57,6 +56,14 @@ class PDFStructureElement {
         ];
       }
       data.A = attrs;
+    }
+
+    if (options.scope) {
+      data.A = {
+        ...(data.A || {}),
+        O: 'Table',
+        Scope: options.scope,
+      };
     }
 
     this._children = [];


### PR DESCRIPTION
Replaces `packages/pdfkit/src/structure_element.js` with the current [foliojs/pdfkit master](https://github.com/foliojs/pdfkit/blob/master/lib/structure_element.js) version, so the file stops drifting.

- Part of #2613
- Rebased on top of #3410

## Why

#3410 landed this file as upstream `0b01ef4` (2025-12-18) plus a hand-rewritten backport of the `bbox` block — a state that exists nowhere upstream. This replaces it with the real file, which picks up the two upstream commits #3410 predates.

## What comes across

- `scope` layout attribute for table headers (foliojs/pdfkit@743cc56)
- Runtime validation of `bbox` / `placement` — `Array.isArray(bbox) && bbox.length === 4` and `typeof placement === 'string'` (foliojs/pdfkit@fc63b5f). Previously a malformed `bbox` such as `[a, b, c]` produced a `BBox` containing `NaN`; it is now ignored.
- Upstream's truthy checks for `title` / `lang` / `alt` / `expanded` / `actual`

## Behaviour notes

- `title: ''` (and `lang` / `alt` / `expanded` / `actual`) are now omitted rather than emitted as empty PDF strings.
- react-pdf itself calls no structure APIs — no `.struct(`, `markStructureContent`, or `structParent` anywhere in `render` / `layout` / `renderer` / `svg`. This only reaches direct `@react-pdf/pdfkit` consumers.

## Verification

- `yarn test` — 217 files / 2256 tests pass; `yarn lint` clean
- Rendered two documents against `master` before/after — one with text, justified text, flex layout, borders/radius, a link, inline SVG and multi-page wrapping; one with four registered TTFs plus a standard font across 120 rows. `pdftoppm -r 200` diff is **0 pixels** on every page, and `pdftotext -layout` output is byte-identical.

Note for anyone byte-comparing PDFs: react-pdf's object numbering is not deterministic run to run (the same build emits `22 0 obj` vs `25 0 obj` for the same document), so `cmp` on two renders is not a valid regression check. That is pre-existing and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
