### PR TITLE
refactor(pdfkit): align page.js and document.js with upstream

### DIFF
--- a/.changeset/plenty-donkeys-shave.md
+++ b/.changeset/plenty-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+refactor(pdfkit): align page.js and document.js with upstream

--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -142,17 +142,23 @@ class PDFDocument extends stream.Readable {
   }
 
   addPage(options) {
-    if (options == null) {
-      ({ options } = this);
-    }
+    const documentOptions = this.options;
 
     // end the current page if needed
-    if (!this.options.bufferPages) {
+    if (!documentOptions.bufferPages) {
       this.flushPages();
     }
 
+    const font = options?.font;
+    if (font) {
+      this.font(font, options.fontFamily);
+    }
+
+    const fontSize = options?.fontSize;
+    if (fontSize) this.fontSize(fontSize);
+
     // create a page object
-    this.page = new PDFPage(this, options);
+    this.page = new PDFPage(this, options || documentOptions);
     this._pageBuffer.push(this.page);
 
     // add the page to the object store

--- a/packages/pdfkit/src/page.js
+++ b/packages/pdfkit/src/page.js
@@ -69,7 +69,7 @@ const SIZES = {
 };
 
 class PDFPage {
-  constructor(document, options = {}) {
+  constructor(document, options) {
     this.document = document;
     this._options = options;
     this.size = options.size || 'letter';
@@ -84,9 +84,6 @@ class PDFPage {
     this.height = dimensions[this.layout === 'portrait' ? 1 : 0];
 
     this.content = this.document.ref();
-
-    if (options.font) document.font(options.font, options.fontFamily);
-    if (options.fontSize) document.fontSize(options.fontSize);
 
     // process margins
     // Margin calculation must occur after font assignment to ensure any dynamic sizes are calculated correctly


### PR DESCRIPTION
Part of #2613 — closes both the "user units param" and "multiple document class differences" items.

`userUnit` has already landed upstream ([page.js#L77](https://github.com/foliojs/pdfkit/blob/master/lib/page.js#L77)), so the only thing keeping `page.js` from matching was *where* the page font gets applied:

- **ours:** inside the `PDFPage` constructor
- **upstream:** in `PDFDocument#addPage()`, just before `new PDFPage(...)`

Both land before margin normalization, which is the ordering that matters — `em`-based margins need the font size resolved first (as the comment above `this.margins` says).

Moving it back to `addPage()` makes **`page.js` and `document.js` both byte-identical** with upstream. `addPage` was the last divergence left in `document.js`.

### Behavior note

One narrow semantic change comes with matching upstream exactly: document-level `fontSize` / `fontFamily` no longer apply to the auto-created first page.

```js
new PDFDocument({ fontSize: 20 })  // first page now renders at 12, as upstream does
```

Upstream's constructor only forwards `options.font` (via `initFonts(options.font)`), and its no-arg `addPage()` reads `options?.fontSize` from the undefined argument. Passing `fontSize` per page — `addPage({ fontSize: 20 })` — works exactly as before.

This does not affect `@react-pdf/renderer`: it constructs the document with `autoFirstPage: false` and `renderPage` passes explicit per-page options that never include `font` or `fontSize`.

### Verification

- `diff` against upstream master for both files: empty
- `yarn build` in `packages/pdfkit`: clean
- `packages/render` + `packages/layout` test suites pass (61 files, 519 tests)
- Smoke-checked against the built `lib`: document options reach the auto first page (`size`, `margin`, `userUnit`), per-page `font`/`fontSize` are applied, a `'2em'` margin correctly resolves to 48pt at `fontSize: 24`, and `continueOnNewPage()` still inherits page options

Note: `yarn build` currently fails on `master` in `@react-pdf/layout` (`Could not resolve "./g" from lib/types/types/index.d.ts`), which blocks the `packages/renderer` visual-regression suite. That breakage is pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)