### PR TITLE
fix(layout): unbreak build after StyleProp type migration

### DIFF
--- a/packages/layout/src/steps/resolveStyles.ts
+++ b/packages/layout/src/steps/resolveStyles.ts
@@ -24,13 +24,9 @@ const DEFAULT_LINK_STYLES: Style = {
  * @returns Computed styles
  */
 const computeStyle = (container: Container, node: Node) => {
-  let baseStyle: Style[] = [node.style as Style];
-
-  if (isLink(node)) {
-    baseStyle = Array.isArray(node.style)
-      ? [DEFAULT_LINK_STYLES, ...node.style]
-      : [DEFAULT_LINK_STYLES, node.style];
-  }
+  const baseStyle = isLink(node)
+    ? [DEFAULT_LINK_STYLES, node.style]
+    : node.style;
 
   return stylesheet(container, baseStyle);
 };

--- a/packages/layout/src/types/g.ts
+++ b/packages/layout/src/types/g.ts
@@ -21,7 +21,7 @@ interface GProps extends SVGPresentationAttributes {
 }
 
 interface SafeGProps extends SafeSVGPresentationAttributes {
-  style?: Style;
+  style?: SafeStyle;
 }
 
 export type GNode = {

--- a/packages/stylesheet/src/flatten/index.ts
+++ b/packages/stylesheet/src/flatten/index.ts
@@ -1,7 +1,7 @@
 import { compose, castArray } from '@react-pdf/fns';
 import { Style } from '../types';
 
-type StyleInput = Style | StyleInput[] | null | undefined;
+type StyleInput = Style | readonly StyleInput[] | null | undefined;
 
 /**
  * Remove nil values from array

--- a/packages/stylesheet/src/index.ts
+++ b/packages/stylesheet/src/index.ts
@@ -2,10 +2,9 @@ import { compose } from '@react-pdf/fns';
 
 import flattenStyles from './flatten';
 import resolveMediaQueries from './mediaQueries';
-import { Container, Style } from './types';
+import { Container, StyleProp } from './types';
 import resolveStyle from './resolve';
 
-type StyleParam = Style | null | undefined;
 /**
  * Resolves styles
  *
@@ -15,7 +14,7 @@ type StyleParam = Style | null | undefined;
  */
 const resolveStyles = (
   container: Container,
-  style: StyleParam | StyleParam[],
+  style: StyleProp | null | undefined,
 ) => {
   const computeMediaQueries = (value) => resolveMediaQueries(container, value);
 


### PR DESCRIPTION
CI has been red on master since #3189: `SafeGProps` in `packages/layout/src/types/g.ts` still referenced `Style` after the import was swapped to `StyleProp`, so tsc emitted no `g.d.ts` and the dts rollup failed with `Could not resolve "./g"` — which breaks the `yarn --frozen-lockfile` postinstall build, and with it every CI job (Lint, Check size, tests).

This changes that field to `SafeStyle` (the Safe variant, matching `SafeGNode`), which alone unblocks the build. It also fixes the two type regressions from the same commit: `flatten` and `resolveStyles` in `@react-pdf/stylesheet` now accept `StyleProp` (readonly and recursive arrays), which lets `computeStyle` drop its `as Style` cast and manual array-spread branch.

Verified `yarn build`, `yarn lint`, and the test suite pass, and `yarn typecheck` is clean for layout/stylesheet. Two pre-existing typecheck errors in `packages/render` are untouched and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)