### PR TITLE
refactor(pdfkit): parse images from plain Uint8Array

### DIFF
--- a/.changeset/uint8array-image-parsing.md
+++ b/.changeset/uint8array-image-parsing.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+refactor(pdfkit): parse images from plain Uint8Array without Buffer

--- a/packages/pdfkit/src/binary.js
+++ b/packages/pdfkit/src/binary.js
@@ -2,6 +2,12 @@
 Binary helpers — Uint8Array-native replacements for Node Buffer operations.
 */
 
+export const fromBinaryString = (str) => {
+  const out = new Uint8Array(str.length);
+  for (let i = 0; i < str.length; i++) out[i] = str.charCodeAt(i) & 0xff;
+  return out;
+};
+
 export const toBinaryString = (bytes) => {
   const chunkSize = 0x8000;
   let out = '';
@@ -12,15 +18,7 @@ export const toBinaryString = (bytes) => {
   return out;
 };
 
-export const fromBase64 = (b64) => {
-  const binary = atob(b64);
-  const len = binary.length;
-  const out = new Uint8Array(len);
-  for (let i = 0; i < len; i++) {
-    out[i] = binary.charCodeAt(i);
-  }
-  return out;
-};
+export const fromBase64 = (str) => fromBinaryString(atob(str));
 
 export const readUInt16BE = (bytes, offset = 0) =>
   ((bytes[offset] << 8) | bytes[offset + 1]) >>> 0;

--- a/packages/pdfkit/src/image.js
+++ b/packages/pdfkit/src/image.js
@@ -11,10 +11,10 @@ import PNG from './image/png';
 class PDFImage {
   static open(src, label) {
     let data;
-    if (Buffer.isBuffer(src)) {
+    if (src instanceof Uint8Array) {
       data = src;
     } else if (src instanceof ArrayBuffer) {
-      data = Buffer.from(new Uint8Array(src));
+      data = new Uint8Array(src);
     } else {
       const match = /^data:.+?;base64,(.*)$/.exec(src);
       if (match) {

--- a/packages/pdfkit/src/image/jpeg.js
+++ b/packages/pdfkit/src/image/jpeg.js
@@ -99,7 +99,7 @@ class JPEG {
     let marker;
     this.data = data;
     this.label = label;
-    if (this.data.readUInt16BE(0) !== 0xffd8) {
+    if (readUInt16BE(this.data, 0) !== 0xffd8) {
       throw 'SOI not found in JPEG';
     }
 
@@ -112,12 +112,12 @@ class JPEG {
       while (pos < this.data.length && this.data[pos] !== 0xff) pos++;
       if (pos >= this.data.length) break;
 
-      marker = this.data.readUInt16BE(pos);
+      marker = readUInt16BE(this.data, pos);
       pos += 2;
       if (MARKERS.includes(marker)) {
         break;
       }
-      pos += this.data.readUInt16BE(pos);
+      pos += readUInt16BE(this.data, pos);
     }
 
     if (!MARKERS.includes(marker)) {
@@ -126,10 +126,10 @@ class JPEG {
     pos += 2;
 
     this.bits = this.data[pos++];
-    this.height = this.data.readUInt16BE(pos);
+    this.height = readUInt16BE(this.data, pos);
     pos += 2;
 
-    this.width = this.data.readUInt16BE(pos);
+    this.width = readUInt16BE(this.data, pos);
     pos += 2;
 
     const channels = this.data[pos++];

--- a/packages/pdfkit/tests/binary.test.ts
+++ b/packages/pdfkit/tests/binary.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { fromBase64, fromBinaryString, toBinaryString } from '../src/binary.js';
+
+describe('binary helpers', () => {
+  it('converts a binary string to bytes', () => {
+    expect(fromBinaryString('\x00\x7f\x80\xff')).toEqual(
+      new Uint8Array([0x00, 0x7f, 0x80, 0xff]),
+    );
+  });
+
+  it('round-trips through toBinaryString', () => {
+    const bytes = new Uint8Array(256).map((_, i) => i);
+
+    expect(fromBinaryString(toBinaryString(bytes))).toEqual(bytes);
+  });
+
+  it('decodes base64 to the same bytes as Buffer', () => {
+    const b64 = Buffer.from('héllo pdfkit ✨').toString('base64');
+
+    expect(fromBase64(b64)).toEqual(new Uint8Array(Buffer.from(b64, 'base64')));
+  });
+});

--- a/packages/pdfkit/tests/image.test.ts
+++ b/packages/pdfkit/tests/image.test.ts
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import { describe, expect, it } from 'vitest';
+
+import PDFImage from '../src/image.js';
+import JPEG from '../src/image/jpeg.js';
+import PNG from '../src/image/png.js';
+
+// SOI + SOF0 (16x32, 8 bit, 3 channels). Kept under 20 bytes so the EXIF
+// parser bails out and orientation falls back to 1.
+const JPEG_BYTES = new Uint8Array([
+  0xff, 0xd8, 0xff, 0xc0, 0x00, 0x11, 0x08, 0x00, 0x10, 0x00, 0x20, 0x03,
+]);
+
+const PNG_BYTES = new Uint8Array(
+  fs.readFileSync(new URL('./assets/interlaced-rgb.png', import.meta.url)),
+);
+
+const toBase64 = (bytes: Uint8Array) => Buffer.from(bytes).toString('base64');
+
+describe('PDFImage.open', () => {
+  it('reads JPEG from a plain Uint8Array', () => {
+    const image = PDFImage.open(JPEG_BYTES, 'jpeg');
+
+    expect(image).toBeInstanceOf(JPEG);
+    expect(image.width).toBe(32);
+    expect(image.height).toBe(16);
+    expect(image.bits).toBe(8);
+    expect(image.colorSpace).toBe('DeviceRGB');
+    expect(image.orientation).toBe(1);
+  });
+
+  it('reads PNG from a plain Uint8Array', () => {
+    expect(PDFImage.open(PNG_BYTES, 'png')).toBeInstanceOf(PNG);
+  });
+
+  it('reads from a Buffer', () => {
+    expect(PDFImage.open(Buffer.from(JPEG_BYTES), 'jpeg')).toBeInstanceOf(JPEG);
+  });
+
+  it('reads from an ArrayBuffer', () => {
+    const image = PDFImage.open(JPEG_BYTES.slice().buffer, 'jpeg');
+
+    expect(image).toBeInstanceOf(JPEG);
+    expect(image.width).toBe(32);
+  });
+
+  it('reads from a base64 data URI', () => {
+    const jpeg = PDFImage.open(
+      `data:image/jpeg;base64,${toBase64(JPEG_BYTES)}`,
+      'jpeg',
+    );
+    const png = PDFImage.open(
+      `data:image/png;base64,${toBase64(PNG_BYTES)}`,
+      'png',
+    );
+
+    expect(jpeg).toBeInstanceOf(JPEG);
+    expect(jpeg.width).toBe(32);
+    expect(png).toBeInstanceOf(PNG);
+  });
+
+  it('throws on unknown formats', () => {
+    expect(() => PDFImage.open(new Uint8Array([1, 2, 3, 4]), 'nope')).toThrow(
+      'Unknown image format.',
+    );
+  });
+});


### PR DESCRIPTION
Extracted from #3397 (PR 1 & 3 of the plan, image half). Drops the remaining Node `Buffer` requirements from image parsing.

### Changes

- **`image.js`** — accepts any `Uint8Array` (a `Buffer` still is one), and stops copying `ArrayBuffer` input through `Buffer.from`. Plain `Uint8Array` sources now work instead of falling through to `fs.readFileSync`.
- **`image/jpeg.js`** — uses the `binary.js` `readUInt16BE` helper rather than the `Buffer.prototype` method, matching the EXIF parser already in that file.
- **`binary.js`** — adds `fromBinaryString`; `fromBase64` becomes a one-liner on top of it.

### Not included

`image/png.js` stays on `Buffer`. It feeds `zlib.deflateSync`, and the browser build aliases `zlib` to `browserify-zlib`, which throws on non-`Buffer` input — that was #3431. Those lines belong with the pako swap (PR 7 in the #3397 plan), not here.

### Tests

New `tests/image.test.ts` covers `PDFImage.open` for `Uint8Array`, `Buffer`, `ArrayBuffer`, base64 data URI, and unknown-format input; new `tests/binary.test.ts` covers the byte helpers against `Buffer` as the reference. Full `renderer`/`render`/`image` suites pass unchanged.