### PR TITLE
chore: bump @react-pdf/pdfkit to a major release

### DIFF
--- a/.changeset/generated-afm-font-data.md
+++ b/.changeset/generated-afm-font-data.md
@@ -1,5 +1,5 @@
 ---
-'@react-pdf/pdfkit': minor
+'@react-pdf/pdfkit': major
 '@react-pdf/font': patch
 ---
 


### PR DESCRIPTION
Changes the `@react-pdf/pdfkit` bump in `.changeset/generated-afm-font-data.md` from `minor` to `major`.

Splitting the node and browser entry points (#3474) is a breaking change for anyone importing `@react-pdf/pdfkit` directly, so `5.2.0` understates it. With this, pdfkit releases as `6.0.0` and changesets rewrites the `^5.x` ranges in font/render/renderer.

Once merged, the release PR (#3399) regenerates itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)