### PR TITLE
refactor(pdfkit): align annotations, attachments and spotcolor with upstream

### DIFF
--- a/.changeset/align-annotations-attachments-upstream.md
+++ b/.changeset/align-annotations-attachments-upstream.md
@@ -1,0 +1,9 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+refactor(pdfkit): align annotations.js, attachments.js and spotcolor.js with upstream
+
+Spot color names are now escaped as PDF Name objects, so names containing
+spaces or delimiters (e.g. `PANTONE 123 C`) no longer emit a malformed
+Separation color space.

--- a/packages/pdfkit/src/mixins/annotations.js
+++ b/packages/pdfkit/src/mixins/annotations.js
@@ -2,38 +2,32 @@ import PDFAnnotationReference from '../structure_annotation';
 
 export default {
   annotate(x, y, w, h, options) {
-    options.Type = 'Annot';
-    options.Rect = this._convertRect(x, y, w, h);
-    options.Border = [0, 0, 0];
+    const { structParent, color, ...annotations } = options;
+    annotations.Type = 'Annot';
+    annotations.Rect = this._convertRect(x, y, w, h);
+    annotations.Border = [0, 0, 0];
 
-    if (options.Subtype === 'Link' && typeof options.F === 'undefined') {
-      options.F = 1 << 2; // Print Annotation Flag
+    if (
+      annotations.Subtype === 'Link' &&
+      typeof annotations.F === 'undefined'
+    ) {
+      annotations.F = 1 << 2; // Print Annotation Flag
     }
 
-    if (options.Subtype !== 'Link') {
-      if (options.C == null) {
-        options.C = this._normalizeColor(options.color || [0, 0, 0]);
+    if (annotations.Subtype !== 'Link') {
+      if (annotations.C == null) {
+        annotations.C = this._normalizeColor(color || [0, 0, 0]);
       }
-    } // convert colors
-    delete options.color;
-
-    if (typeof options.Dest === 'string') {
-      options.Dest = new String(options.Dest);
     }
 
-    const structParent = options.structParent;
-    delete options.structParent;
-
-    // Capitalize keys
-    for (let key in options) {
-      const val = options[key];
-      options[key[0].toUpperCase() + key.slice(1)] = val;
+    if (typeof annotations.Dest === 'string') {
+      annotations.Dest = new String(annotations.Dest);
     }
 
-    const ref = this.ref(options);
+    const ref = this.ref(annotations);
     this.page.annotations.push(ref);
 
-    if (structParent && typeof structParent.add === 'function') {
+    if (typeof structParent?.add === 'function') {
       const annotRef = new PDFAnnotationReference(ref);
       structParent.add(annotRef);
     }
@@ -42,125 +36,146 @@ export default {
     return this;
   },
 
-  note(x, y, w, h, contents, options = {}) {
-    options.Subtype = 'Text';
-    options.Contents = new String(contents);
-    if (options.Name == null) {
-      options.Name = 'Comment';
+  note(x, y, w, h, contents, options) {
+    const annotationOptions = {
+      ...options,
+      Subtype: 'Text',
+      Contents: new String(contents),
+    };
+    if (annotationOptions.Name == null) {
+      annotationOptions.Name = 'Comment';
     }
-    if (options.color == null) {
-      options.color = [243, 223, 92];
+    if (annotationOptions.color == null) {
+      annotationOptions.color = [243, 223, 92];
     }
-    return this.annotate(x, y, w, h, options);
+
+    return this.annotate(x, y, w, h, annotationOptions);
   },
 
-  goTo(x, y, w, h, name, options = {}) {
-    options.Subtype = 'Link';
-    options.A = this.ref({
-      S: 'GoTo',
-      D: new String(name),
-    });
-    options.A.end();
-    return this.annotate(x, y, w, h, options);
+  goTo(x, y, w, h, name, options) {
+    const annotateOptions = {
+      ...options,
+      Subtype: 'Link',
+      A: this.ref({ S: 'GoTo', D: new String(name) }),
+    };
+    annotateOptions.A.end();
+    return this.annotate(x, y, w, h, annotateOptions);
   },
 
-  link(x, y, w, h, url, options = {}) {
-    options.Subtype = 'Link';
+  link(x, y, w, h, url, options) {
+    const annotateOptions = { ...options, Subtype: 'Link' };
 
     if (typeof url === 'number') {
       // Link to a page in the document (the page must already exist)
       const pages = this._root.data.Pages.data;
       if (url >= 0 && url < pages.Kids.length) {
-        options.A = this.ref({
+        annotateOptions.A = this.ref({
           S: 'GoTo',
           D: [pages.Kids[url], 'XYZ', null, null, null],
         });
-        options.A.end();
+        annotateOptions.A.end();
       } else {
         throw new Error(`The document has no page ${url}`);
       }
     } else {
       // Link to an external url
-      options.A = this.ref({
+      annotateOptions.A = this.ref({
         S: 'URI',
         URI: new String(url),
       });
-      options.A.end();
+      annotateOptions.A.end();
     }
 
-    if (options.structParent && !options.Contents) {
-      options.Contents = new String('');
+    if (annotateOptions.structParent && !annotateOptions.Contents) {
+      annotateOptions.Contents = new String('');
     }
 
-    return this.annotate(x, y, w, h, options);
+    return this.annotate(x, y, w, h, annotateOptions);
   },
 
-  _markup(x, y, w, h, options = {}) {
+  _markup(x, y, w, h, options) {
     const [x1, y1, x2, y2] = this._convertRect(x, y, w, h);
-    options.QuadPoints = [x1, y2, x2, y2, x1, y1, x2, y1];
-    options.Contents = new String();
-    return this.annotate(x, y, w, h, options);
+    return this.annotate(x, y, w, h, {
+      ...options,
+      QuadPoints: [x1, y2, x2, y2, x1, y1, x2, y1],
+      Contents: new String(),
+    });
   },
 
-  highlight(x, y, w, h, options = {}) {
-    options.Subtype = 'Highlight';
-    if (options.color == null) {
-      options.color = [241, 238, 148];
+  highlight(x, y, w, h, options) {
+    const annotationOptions = { ...options, Subtype: 'Highlight' };
+    if (annotationOptions.color == null) {
+      annotationOptions.color = [241, 238, 148];
     }
-    return this._markup(x, y, w, h, options);
+    return this._markup(x, y, w, h, annotationOptions);
   },
 
-  underline(x, y, w, h, options = {}) {
-    options.Subtype = 'Underline';
-    return this._markup(x, y, w, h, options);
+  underline(x, y, w, h, options) {
+    const annotationOptions = { ...options, Subtype: 'Underline' };
+    return this._markup(x, y, w, h, annotationOptions);
   },
 
-  strike(x, y, w, h, options = {}) {
-    options.Subtype = 'StrikeOut';
-    return this._markup(x, y, w, h, options);
+  strike(x, y, w, h, options) {
+    const annotationOptions = { ...options, Subtype: 'StrikeOut' };
+    return this._markup(x, y, w, h, annotationOptions);
   },
 
-  lineAnnotation(x1, y1, x2, y2, options = {}) {
-    options.Subtype = 'Line';
-    options.Contents = new String();
-    options.L = [x1, this.page.height - y1, x2, this.page.height - y2];
-    return this.annotate(x1, y1, x2, y2, options);
+  lineAnnotation(x1, y1, x2, y2, options) {
+    const annotationOptions = {
+      ...options,
+      Subtype: 'Line',
+      Contents: new String(),
+      L: [x1, this.page.height - y1, x2, this.page.height - y2],
+    };
+    return this.annotate(x1, y1, x2, y2, annotationOptions);
   },
 
-  rectAnnotation(x, y, w, h, options = {}) {
-    options.Subtype = 'Square';
-    options.Contents = new String();
-    return this.annotate(x, y, w, h, options);
+  rectAnnotation(x, y, w, h, options) {
+    const annotationOptions = {
+      ...options,
+      Subtype: 'Square',
+      Contents: new String(),
+    };
+    return this.annotate(x, y, w, h, annotationOptions);
   },
 
-  ellipseAnnotation(x, y, w, h, options = {}) {
-    options.Subtype = 'Circle';
-    options.Contents = new String();
-    return this.annotate(x, y, w, h, options);
+  ellipseAnnotation(x, y, w, h, options) {
+    const annotationOptions = {
+      ...options,
+      Subtype: 'Circle',
+      Contents: new String(),
+    };
+    return this.annotate(x, y, w, h, annotationOptions);
   },
 
-  textAnnotation(x, y, w, h, text, options = {}) {
-    options.Subtype = 'FreeText';
-    options.Contents = new String(text);
-    options.DA = new String();
-    return this.annotate(x, y, w, h, options);
+  textAnnotation(x, y, w, h, text, options) {
+    const annotationOptions = {
+      ...options,
+      Subtype: 'FreeText',
+      Contents: new String(text),
+      DA: new String(),
+    };
+    return this.annotate(x, y, w, h, annotationOptions);
   },
 
-  fileAnnotation(x, y, w, h, file = {}, options = {}) {
+  fileAnnotation(x, y, w, h, file = {}, options) {
     // create hidden file
     const filespec = this.file(file.src, Object.assign({ hidden: true }, file));
 
-    options.Subtype = 'FileAttachment';
-    options.FS = filespec;
+    const annotationOptions = {
+      ...options,
+      Subtype: 'FileAttachment',
+      FS: filespec,
+    };
 
     // add description from filespec unless description (Contents) has already been set
-    if (options.Contents) {
-      options.Contents = new String(options.Contents);
+    if (annotationOptions.Contents) {
+      annotationOptions.Contents = new String(annotationOptions.Contents);
     } else if (filespec.data.Desc) {
-      options.Contents = filespec.data.Desc;
+      annotationOptions.Contents = new String(filespec.data.Desc);
     }
 
-    return this.annotate(x, y, w, h, options);
+    return this.annotate(x, y, w, h, annotationOptions);
   },
 
   _convertRect(x1, y1, w, h) {

--- a/packages/pdfkit/src/mixins/attachments.js
+++ b/packages/pdfkit/src/mixins/attachments.js
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import { md5Hex } from '../crypto/md5';
+import { escapeName } from '../object.js';
 
 export default {
   /**
@@ -36,7 +37,7 @@ export default {
       const match = /^data:(.*?);base64,(.*)$/.exec(src);
       if (match) {
         if (match[1]) {
-          refBody.Subtype = match[1].replace('/', '#2F');
+          refBody.Subtype = escapeName(match[1]);
         }
         data = Buffer.from(match[2], 'base64');
       } else {
@@ -61,7 +62,7 @@ export default {
     }
     // add optional subtype
     if (options.type) {
-      refBody.Subtype = options.type.replace('/', '#2F');
+      refBody.Subtype = escapeName(options.type);
     }
 
     // add checksum and size information

--- a/packages/pdfkit/src/object.js
+++ b/packages/pdfkit/src/object.js
@@ -8,6 +8,28 @@ import PDFNameTree from './name_tree';
 
 const pad = (str, length) => (Array(length + 1).join('0') + str).slice(-length);
 
+// PDF Name objects must escape delimiter characters and whitespace. We keep
+// non-ASCII characters unescaped for backward compatibility in existing output.
+const isSafeCharCode = (code) => {
+  if (code > 0x7f) return true; // keep non-ASCII characters as-is
+
+  return (
+    code > 0x20 && // exclude NUL/control chars + space (0x00-0x20)
+    code !== 0x7f && // exclude DEL
+    code !== 0x23 && // # (escape marker)
+    code !== 0x25 && // % (comment introducer)
+    code !== 0x28 && // ( (literal string delimiter)
+    code !== 0x29 && // ) (literal string delimiter)
+    code !== 0x2f && // / (name object delimiter)
+    code !== 0x3c && // < (hex string delimiter)
+    code !== 0x3e && // > (hex string delimiter)
+    code !== 0x5b && // [ (array start)
+    code !== 0x5d && // ] (array end)
+    code !== 0x7b && // { (dictionary start)
+    code !== 0x7d // } (dictionary end)
+  );
+};
+
 const escapableRe = /[\n\r\t\b\f()\\]/g;
 const escapable = {
   '\n': '\\n',
@@ -18,6 +40,21 @@ const escapable = {
   '\\': '\\\\',
   '(': '\\(',
   ')': '\\)'
+};
+
+export const escapeName = function (name) {
+  let escapedName = '';
+
+  for (const char of name) {
+    const code = char.charCodeAt(0);
+    if (isSafeCharCode(code)) {
+      escapedName += char;
+    } else {
+      escapedName += `#${code.toString(16).toUpperCase().padStart(2, '0')}`;
+    }
+  }
+
+  return escapedName;
 };
 
 // Convert little endian UTF-16 to big endian

--- a/packages/pdfkit/src/spotcolor.js
+++ b/packages/pdfkit/src/spotcolor.js
@@ -1,3 +1,5 @@
+import { escapeName } from './object.js';
+
 export default class SpotColor {
   constructor(doc, name, C, M, Y, K) {
     this.id = 'CS' + Object.keys(doc.spotColors).length;
@@ -5,7 +7,7 @@ export default class SpotColor {
     this.values = [C, M, Y, K];
     this.ref = doc.ref([
       'Separation',
-      this.name,
+      escapeName(this.name),
       'DeviceCMYK',
       {
         Range: [0, 1, 0, 1, 0, 1, 0, 1],

--- a/packages/pdfkit/tests/spotcolor.test.ts
+++ b/packages/pdfkit/tests/spotcolor.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import PDFDocument from '../src/document.js';
+
+const separationName = (doc, name) =>
+  String(doc.spotColors[name].ref.data[1]);
+
+describe('spot colors', () => {
+  it('escapes names that are not valid PDF names', () => {
+    const doc = new PDFDocument({ compress: false });
+
+    doc.addSpotColor('Plain', 0, 100, 100, 0);
+    doc.addSpotColor('PANTONE 123 C', 0, 20, 100, 0);
+    doc.addSpotColor('Weird/Name#(1)', 10, 20, 30, 40);
+
+    expect(separationName(doc, 'Plain')).toBe('Plain');
+    expect(separationName(doc, 'PANTONE 123 C')).toBe('PANTONE#20123#20C');
+    expect(separationName(doc, 'Weird/Name#(1)')).toBe(
+      'Weird#2FName#23#281#29',
+    );
+  });
+
+  it('resolves colors by their unescaped name', () => {
+    const doc = new PDFDocument({ compress: false });
+    doc.addSpotColor('PANTONE 123 C', 0, 20, 100, 0);
+
+    const color = doc._normalizeColor('PANTONE 123 C');
+
+    expect(color).toBe(doc.spotColors['PANTONE 123 C']);
+    expect(color.id).toBe('CS0');
+  });
+});


### PR DESCRIPTION
Replaces `mixins/annotations.js`, `mixins/attachments.js` and `spotcolor.js` with foliojs/pdfkit master, byte-identical; `escapeName` is ported into `object.js` as an additive export since the latter two import it. `annotate()` stops mutating the caller's options object and drops the capitalize-every-key loop, which is what removed the junk `/FontSize` entry form widgets used to carry.

Aligning `spotcolor.js` is also a fix — spot color names went into the Separation array raw, so `PANTONE 123 C` emitted `/PANTONE 123 C`, three tokens rather than one name; lookup is unaffected since it's keyed by the unescaped name. `mixins/acroform.js` is deliberately left alone: upstream ffc17b6 stopped passing unmapped options into the field dictionary, and `@react-pdf/render` relies on that for Checkbox appearance streams (`AP`/`AS`) and TextInput `maxLength` (`MaxLen`), which have no documented equivalent and can't be patched on afterwards because `annotate()` ends the ref.

Verified by diffing generated PDFs before and after across every annotation type, `file()`, and a form document (Note, both Link kinds, FieldSet, TextInput, Checkboxes, Select, List): output is byte-identical apart from the random `/ID` and the dropped `/FontSize`. Part of #2613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)