### PR TITLE
test(pdfkit): import node document entry in spotcolor tests

### DIFF
--- a/packages/pdfkit/tests/spotcolor.test.ts
+++ b/packages/pdfkit/tests/spotcolor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import PDFDocument from '../src/document.js';
+import PDFDocument from '../src/document.node.js';
 
 const separationName = (doc, name) =>
   String(doc.spotColors[name].ref.data[1]);


### PR DESCRIPTION
Fixes CI on master, which has been red since #3476.

`tests/spotcolor.test.ts` imported `../src/document.js`, the shared entry that no longer registers the standard fonts since the node/browser split in #3474, so `new PDFDocument()` threw `Standard font "Helvetica" is not registered`. Importing `document.node.js` instead matches what `tests/font/standard.test.ts` already does. Verified locally: 2 failures before, 7/7 pdfkit tests pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)