### PR TITLE
refactor(pdfkit): sync image/jpeg with upstream pdfkit

### DIFF
--- a/packages/pdfkit/src/image/jpeg.js
+++ b/packages/pdfkit/src/image/jpeg.js
@@ -99,7 +99,7 @@ class JPEG {
     let marker;
     this.data = data;
     this.label = label;
-    if (this.data.readUInt16BE(0) !== 0xffd8) {
+    if (readUInt16BE(this.data, 0) !== 0xffd8) {
       throw 'SOI not found in JPEG';
     }
 
@@ -112,12 +112,12 @@ class JPEG {
       while (pos < this.data.length && this.data[pos] !== 0xff) pos++;
       if (pos >= this.data.length) break;
 
-      marker = this.data.readUInt16BE(pos);
+      marker = readUInt16BE(this.data, pos);
       pos += 2;
       if (MARKERS.includes(marker)) {
         break;
       }
-      pos += this.data.readUInt16BE(pos);
+      pos += readUInt16BE(this.data, pos);
     }
 
     if (!MARKERS.includes(marker)) {
@@ -126,13 +126,13 @@ class JPEG {
     pos += 2;
 
     this.bits = this.data[pos++];
-    this.height = this.data.readUInt16BE(pos);
+    this.height = readUInt16BE(this.data, pos);
     pos += 2;
 
-    this.width = this.data.readUInt16BE(pos);
+    this.width = readUInt16BE(this.data, pos);
     pos += 2;
 
-    const channels = this.data[pos++];
+    const channels = this.data[pos];
     this.colorSpace = COLOR_SPACE_MAP[channels];
 
     this.obj = null;


### PR DESCRIPTION
Makes `packages/pdfkit/src/image/jpeg.js` byte-identical to [foliojs/pdfkit `lib/image/jpeg.js`](https://github.com/foliojs/pdfkit/blob/master/lib/image/jpeg.js), so future upstream syncs of this file are a clean copy.

The only drift was six lines using Buffer methods (`this.data.readUInt16BE(pos)`) where upstream uses the `../binary` helper (`readUInt16BE(this.data, pos)`), plus a no-op `pos++` on the channels read. `binary.js` was already identical, so nothing else needed to change. Behavior is unchanged, and the helper form additionally works on a plain `Uint8Array` rather than requiring a `Buffer`.

pdfkit, image, render, and renderer (visual regression) test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)