### PR TITLE
refactor(pdfkit): align object.js, outline.js and reference.js with upstream

### DIFF
--- a/.changeset/align-object-outline-reference-upstream.md
+++ b/.changeset/align-object-outline-reference-upstream.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+Align `object.js`, `outline.js` and `reference.js` with upstream pdfkit, fixing `PDFNumberTree` being serialized as a plain dictionary

--- a/packages/pdfkit/src/object.js
+++ b/packages/pdfkit/src/object.js
@@ -3,8 +3,9 @@ PDFObject - converts JavaScript types into their corresponding PDF types.
 By Devon Govett
 */
 
-import PDFReference from './reference';
-import PDFNameTree from './name_tree';
+import PDFAbstractReference from './abstract_reference';
+import PDFTree from './tree';
+import SpotColor from './spotcolor';
 
 const pad = (str, length) => (Array(length + 1).join('0') + str).slice(-length);
 
@@ -39,7 +40,7 @@ const escapable = {
   '\f': '\\f',
   '\\': '\\\\',
   '(': '\\(',
-  ')': '\\)'
+  ')': '\\)',
 };
 
 export const escapeName = function (name) {
@@ -78,10 +79,9 @@ class PDFObject {
     // String literals are converted to the PDF name type
     if (typeof object === 'string') {
       return `/${object}`;
-    }
 
-    // String objects are converted to PDF strings (UTF-16)
-    if (object instanceof String) {
+      // String objects are converted to PDF strings (UTF-16)
+    } else if (object instanceof String) {
       let string = object;
       // Detect if this is a unicode string
       let isUnicode = false;
@@ -113,17 +113,15 @@ class PDFObject {
       return `(${string})`;
 
       // Buffers are converted to PDF hex strings
-    }
-
-    if (Buffer.isBuffer(object)) {
+    } else if (Buffer.isBuffer(object)) {
       return `<${object.toString('hex')}>`;
-    }
-
-    if (object instanceof PDFReference || object instanceof PDFNameTree) {
+    } else if (
+      object instanceof PDFAbstractReference ||
+      object instanceof PDFTree ||
+      object instanceof SpotColor
+    ) {
       return object.toString();
-    }
-
-    if (object instanceof Date) {
+    } else if (object instanceof Date) {
       let string =
         `D:${pad(object.getUTCFullYear(), 4)}` +
         pad(object.getUTCMonth() + 1, 2) +
@@ -136,20 +134,18 @@ class PDFObject {
       // Encrypt the string when necessary
       if (encryptFn) {
         string = encryptFn(Buffer.from(string, 'ascii')).toString('binary');
+
+        // Escape characters as required by the spec
         string = string.replace(escapableRe, (c) => escapable[c]);
       }
 
       return `(${string})`;
-    }
-
-    if (Array.isArray(object)) {
-      const items = Array.from(object)
+    } else if (Array.isArray(object)) {
+      const items = object
         .map((e) => PDFObject.convert(e, encryptFn))
         .join(' ');
       return `[${items}]`;
-    }
-
-    if ({}.toString.call(object) === '[object Object]') {
+    } else if ({}.toString.call(object) === '[object Object]') {
       const out = ['<<'];
       for (let key in object) {
         const val = object[key];
@@ -158,13 +154,11 @@ class PDFObject {
 
       out.push('>>');
       return out.join('\n');
-    }
-
-    if (typeof object === 'number') {
+    } else if (typeof object === 'number') {
       return PDFObject.number(object);
+    } else {
+      return `${object}`;
     }
-
-    return `${object}`;
   }
 
   static number(n) {

--- a/packages/pdfkit/src/outline.js
+++ b/packages/pdfkit/src/outline.js
@@ -1,13 +1,11 @@
-/* Custom fork start */
 const DEFAULT_OPTIONS = {
   top: 0,
   left: 0,
   zoom: 0,
-  fit: false,
+  fit: true, // Default to Fit for backward compatibility
   pageNumber: null,
-  expanded: false
+  expanded: false,
 };
-/* Custom fork end */
 
 class PDFOutline {
   constructor(document, parent, title, dest, options = DEFAULT_OPTIONS) {
@@ -16,7 +14,6 @@ class PDFOutline {
     this.outlineData = {};
 
     if (dest !== null) {
-      /* Custom fork start */
       const destWidth = dest.data.MediaBox[2];
       const destHeight = dest.data.MediaBox[3];
       const top = destHeight - (options.top || 0);
@@ -26,7 +23,6 @@ class PDFOutline {
       this.outlineData['Dest'] = options.fit
         ? [dest, 'Fit']
         : [dest, 'XYZ', left, top, zoom];
-      /* Custom fork end */
     }
 
     if (parent !== null) {
@@ -42,21 +38,18 @@ class PDFOutline {
   }
 
   addItem(title, options = DEFAULT_OPTIONS) {
-    /* Custom fork start */
     const pages = this.document._root.data.Pages.data.Kids;
-
     const dest =
-      options.pageNumber !== null
+      options.pageNumber != null
         ? pages[options.pageNumber]
         : this.document.page.dictionary;
-    /* Custom fork end */
 
     const result = new PDFOutline(
       this.document,
       this.dictionary,
       title,
       dest,
-      options
+      options,
     );
     this.children.push(result);
 

--- a/packages/pdfkit/src/reference.js
+++ b/packages/pdfkit/src/reference.js
@@ -4,41 +4,22 @@ By Devon Govett
 */
 
 import zlib from 'zlib';
-import stream from 'stream';
+import PDFAbstractReference from './abstract_reference';
 import PDFObject from './object';
 
-class PDFReference extends stream.Writable {
-  constructor(document, id, data) {
-    super({ decodeStrings: false });
-
-    this.finalize = this.finalize.bind(this);
+class PDFReference extends PDFAbstractReference {
+  constructor(document, id, data = {}) {
+    super();
     this.document = document;
     this.id = id;
-    if (data == null) {
-      data = {};
-    }
     this.data = data;
-
     this.gen = 0;
-    this.deflate = null;
     this.compress = this.document.compress && !this.data.Filter;
     this.uncompressedLength = 0;
-    this.chunks = [];
+    this.buffer = [];
   }
 
-  initDeflate() {
-    this.data.Filter = 'FlateDecode';
-
-    this.deflate = zlib.createDeflate();
-    this.deflate.on('data', (chunk) => {
-      this.chunks.push(chunk);
-      return (this.data.Length += chunk.length);
-    });
-
-    return this.deflate.on('end', this.finalize);
-  }
-
-  _write(chunk, encoding, callback) {
+  write(chunk) {
     if (!(chunk instanceof Uint8Array)) {
       chunk = Buffer.from(chunk + '\n', 'binary');
     }
@@ -47,28 +28,18 @@ class PDFReference extends stream.Writable {
     if (this.data.Length == null) {
       this.data.Length = 0;
     }
-
+    this.buffer.push(chunk);
+    this.data.Length += chunk.length;
     if (this.compress) {
-      if (!this.deflate) {
-        this.initDeflate();
-      }
-      this.deflate.write(chunk);
-    } else {
-      this.chunks.push(chunk);
-      this.data.Length += chunk.length;
+      this.data.Filter = 'FlateDecode';
     }
-
-    return callback();
   }
 
-  end() {
-    super.end(...arguments);
-
-    if (this.deflate) {
-      return this.deflate.end();
+  end(chunk) {
+    if (chunk) {
+      this.write(chunk);
     }
-
-    return this.finalize();
+    this.finalize();
   }
 
   finalize() {
@@ -78,29 +49,33 @@ class PDFReference extends stream.Writable {
       ? this.document._security.getEncryptFn(this.id, this.gen)
       : null;
 
-    if (this.chunks.length) {
-      let buffer = Buffer.concat(this.chunks);
-
-      if (encryptFn) {
-        buffer = encryptFn(buffer);
+    if (this.buffer.length) {
+      this.buffer = Buffer.concat(this.buffer);
+      if (this.compress) {
+        this.buffer = zlib.deflateSync(this.buffer);
       }
 
-      this.data.Length = buffer.length;
-      this.document._write(`${this.id} ${this.gen} obj`);
-      this.document._write(PDFObject.convert(this.data, encryptFn));
+      if (encryptFn) {
+        this.buffer = encryptFn(this.buffer);
+      }
+
+      this.data.Length = this.buffer.length;
+    }
+
+    this.document._write(`${this.id} ${this.gen} obj`);
+    this.document._write(PDFObject.convert(this.data, encryptFn));
+
+    if (this.buffer.length) {
       this.document._write('stream');
-      this.document._write(buffer);
-      this.chunks.length = 0;
+      this.document._write(this.buffer);
+
+      this.buffer = []; // free up memory
       this.document._write('\nendstream');
-    } else {
-      this.document._write(`${this.id} ${this.gen} obj`);
-      this.document._write(PDFObject.convert(this.data, encryptFn));
     }
 
     this.document._write('endobj');
-    return this.document._refEnd(this);
+    this.document._refEnd(this);
   }
-
   toString() {
     return `${this.id} ${this.gen} R`;
   }


### PR DESCRIPTION
Replaces all three files with foliojs/pdfkit master, byte-identical.

`reference.js` was the outlier — the fork still carried the pre-ES6 `stream.Writable` version with an async `zlib.createDeflate`, while upstream has buffered chunks and deflated synchronously in `finalize()` since 2017; nothing pipes into a ref or listens on it, `document.js` was already identical to upstream, and `browserify-zlib` exports `deflateSync` for the browser build, so the only observable change is that compressed objects are now emitted in call order rather than deferred to the end of the file (verified pixel-identical output before/after).

`object.js` is coupled to that (its `instanceof PDFAbstractReference` check only works once `PDFReference` extends it) and fixes a real bug: the old chain matched `instanceof PDFNameTree`, but `PDFNumberTree` extends `PDFTree`, so it fell through to the `[object Object]` branch and tagged PDFs emitted `/ParentTree << /_items << /0 [10 0 R] >> /limits true >>` instead of `/ParentTree << /Nums [ 0 [10 0 R] ] >>`.

`outline.js` had already been upstreamed, custom fork markers and all; what was left is `DEFAULT_OPTIONS.fit` and `pageNumber != null` vs `!== null`, neither of which reaches react-pdf since `addBookmarks` always passes an explicit options object with a numeric `pageNumber`.

Full test suite passes (2261 tests, 218 files), including the renderer visual snapshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)