### PR TITLE
feat(pdfkit): use fflate instead of zlib in the browser build

### DIFF
--- a/.changeset/pdfkit-browser-fflate.md
+++ b/.changeset/pdfkit-browser-fflate.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+Use fflate instead of browserify-zlib and pako in the browser build

--- a/packages/pdfkit/package.json
+++ b/packages/pdfkit/package.json
@@ -49,13 +49,12 @@
   ],
   "dependencies": {
     "@babel/runtime": "^7.20.13",
-    "browserify-zlib": "^0.2.0",
     "@noble/ciphers": "^1.0.0",
     "@noble/hashes": "^1.6.0",
+    "fflate": "^0.8.2",
     "fontkit": "^2.0.2",
     "js-md5": "^0.8.3",
     "linebreak": "^1.1.0",
-    "pako": "^1.0.11",
     "png-js": "^2.0.0",
     "vite-compatible-readable-stream": "^3.6.1"
   }

--- a/packages/pdfkit/rollup.config.js
+++ b/packages/pdfkit/rollup.config.js
@@ -33,11 +33,8 @@ const babelConfig = () => ({
 
 const getExternal = ({ browser }) => [
   ...Object.keys(pkg.dependencies).filter(
-    (dep) =>
-      !browser ||
-      !['vite-compatible-readable-stream', 'browserify-zlib'].includes(dep)
+    (dep) => !browser || dep !== 'vite-compatible-readable-stream'
   ),
-  /\/node_modules\/pako\//,
   /@babel\/runtime/,
   'js-md5',
   '@noble/hashes/sha256',
@@ -51,17 +48,7 @@ const getPlugins = ({ browser }) => [
         ignore(['fs']),
         alias({
           entries: [
-            // See https://github.com/browserify/browserify-zlib/pull/45
-            {
-              find: 'pako/lib/zlib/zstream',
-              replacement: 'pako/lib/zlib/zstream.js'
-            },
-            {
-              find: 'pako/lib/zlib/constants',
-              replacement: 'pako/lib/zlib/constants.js'
-            },
-            { find: 'stream', replacement: 'vite-compatible-readable-stream' },
-            { find: 'zlib', replacement: 'browserify-zlib' }
+            { find: 'stream', replacement: 'vite-compatible-readable-stream' }
           ]
         }),
         commonjs(),
@@ -84,7 +71,8 @@ const serverConfig = {
   input: 'src/document.node.js',
   output: { format: 'es', file: 'lib/pdfkit.js' },
   external: getExternal({ browser: false }),
-  plugins: getPlugins({ browser: false })
+  plugins: getPlugins({ browser: false }),
+  treeshake: { moduleSideEffects: 'no-external' }
 };
 
 const browserConfig = {

--- a/packages/pdfkit/src/document.js
+++ b/packages/pdfkit/src/document.js
@@ -264,7 +264,7 @@ class PDFDocument extends stream.Readable {
   // do nothing, but this method is required by node
 
   _write(data) {
-    if (!Buffer.isBuffer(data)) {
+    if (!(data instanceof Uint8Array)) {
       data = Buffer.from(data + '\n', 'binary');
     }
 

--- a/packages/pdfkit/src/image/png.js
+++ b/packages/pdfkit/src/image/png.js
@@ -1,4 +1,4 @@
-import zlib from 'zlib';
+import zlib from '../zlib';
 import PNG from 'png-js';
 
 class PNGImage {
@@ -161,7 +161,7 @@ class PNGImage {
 
       // For interlaced images, re-encode the decoded pixel data
       if (isInterlaced) {
-        this.imgData = zlib.deflateSync(Buffer.from(pixels));
+        this.imgData = zlib.deflateSync(pixels);
       }
 
       this.alphaChannel = zlib.deflateSync(alphaChannel);
@@ -171,8 +171,7 @@ class PNGImage {
 
   decodeData() {
     this.image.decodePixels((pixels) => {
-      const data = Buffer.isBuffer(pixels) ? pixels : Buffer.from(pixels);
-      this.imgData = zlib.deflateSync(data);
+      this.imgData = zlib.deflateSync(pixels);
       this.finalize();
     });
   }

--- a/packages/pdfkit/src/reference.js
+++ b/packages/pdfkit/src/reference.js
@@ -3,7 +3,7 @@ PDFReference - represents a reference to another object in the PDF object heirar
 By Devon Govett
 */
 
-import zlib from 'zlib';
+import zlib from './zlib';
 import PDFAbstractReference from './abstract_reference';
 import PDFObject from './object';
 

--- a/packages/pdfkit/src/zlib.js
+++ b/packages/pdfkit/src/zlib.js
@@ -1,0 +1,7 @@
+import zlib from 'zlib';
+import { zlibSync } from 'fflate';
+
+export default {
+  deflateSync: (data) =>
+    BROWSER ? Buffer.from(zlibSync(data)) : zlib.deflateSync(data),
+};

--- a/packages/pdfkit/tests/image/png.test.ts
+++ b/packages/pdfkit/tests/image/png.test.ts
@@ -1,12 +1,7 @@
 import fs from 'fs';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('zlib', async () => {
-  const zlib = await import('browserify-zlib');
-  return { ...zlib, default: zlib.default };
-});
-
-const { default: PNGImage } = await import('../../src/image/png.js');
+import PNGImage from '../../src/image/png.js';
 
 const fixtureUrl = new URL('../assets/interlaced-rgb.png', import.meta.url);
 
@@ -31,7 +26,13 @@ const createDocument = () => {
 };
 
 describe('PNG images', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('deflates decoded interlaced RGB pixels as a Buffer in browser zlib builds', () => {
+    vi.stubGlobal('BROWSER', true);
+
     // 8x8 RGB PNG generated with Adam7 interlace, filter type 0 rows, no alpha, and no tRNS chunk.
     const image = new PNGImage(fs.readFileSync(fixtureUrl), 'interlaced-rgb');
 

--- a/packages/pdfkit/vitest.config.js
+++ b/packages/pdfkit/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['vitest.setup.js'],
+  },
+});

--- a/packages/pdfkit/vitest.setup.js
+++ b/packages/pdfkit/vitest.setup.js
@@ -1,0 +1,1 @@
+global.BROWSER = false;

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -58,7 +58,6 @@
   "devDependencies": {
     "@size-limit/preset-big-lib": "^11.0.1",
     "assert": "^2.0.0",
-    "browserify-zlib": "^0.2.0",
     "buffer": "^6.0.3",
     "process": "^0.11.10",
     "size-limit": "^11.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3623,13 +3623,6 @@ brotli@^1.3.2:
   dependencies:
     base64-js "^1.1.2"
 
-browserify-zlib@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/browserify-zlib/-/browserify-zlib-0.2.0.tgz#2869459d9aa3be245fe8fe2ca1f46e2e7f54d73f"
-  integrity sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==
-  dependencies:
-    pako "~1.0.5"
-
 browserslist@^4.21.5, browserslist@^4.22.2:
   version "4.23.3"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.23.3.tgz#debb029d3c93ebc97ffbc8d9cbb03403e227c800"
@@ -8232,11 +8225,6 @@ pako@^0.2.5:
   version "0.2.9"
   resolved "https://registry.yarnpkg.com/pako/-/pako-0.2.9.tgz#f3f7522f4ef782348da8161bad9ecfd51bf83a75"
   integrity sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=
-
-pako@^1.0.11, pako@~1.0.5:
-  version "1.0.11"
-  resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.11.tgz#6c9599d340d54dfd3946380252a35705a6b992bf"
-  integrity sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==
 
 parent-module@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Applies [foliojs/pdfkit#1760](https://github.com/foliojs/pdfkit/pull/1760) to our fork. The browser build no longer imports Node's `zlib`, so consumers don't need a bundler polyfill for it, and `browserify-zlib` and `pako` (plus their alias workarounds in the rollup config) are gone from the dependency tree.

Both `deflateSync` call sites now go through `src/zlib.js`, which picks fflate's `zlibSync` or native `zlib` off the `BROWSER` constant, so each bundle keeps only one compressor after tree-shaking — verified in the built output. fflate returns a plain `Uint8Array`, which the bundled `Buffer` polyfill's `concat` rejects, so the browser branch wraps it in `Buffer.from`; `PDFDocument._write` also takes upstream's `instanceof Uint8Array` check.

Tests: the existing PNG test now flips `BROWSER` with `vi.stubGlobal` instead of mocking the `zlib` module (which needed a vitest setup file defining `BROWSER` for the package). Full suite passes, and the browser bundle was checked end to end by rendering text plus an interlaced PNG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)