### PR TITLE
refactor(pdfkit): align font/afm WinAnsi table with upstream

### DIFF
--- a/.changeset/align-afm-winansi-upstream.md
+++ b/.changeset/align-afm-winansi-upstream.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+Align `font/afm.js` WinAnsi encoding table with upstream pdfkit, restoring `hyphen` at code point 0xAD as specified by the PDF spec

--- a/packages/pdfkit/src/font/afm.js
+++ b/packages/pdfkit/src/font/afm.js
@@ -77,7 +77,7 @@ oe            .notdef        zcaron         ydieresis
 space         exclamdown     cent           sterling
 currency      yen            brokenbar      section
 dieresis      copyright      ordfeminine    guillemotleft
-logicalnot    softhyphen     registered     macron
+logicalnot    hyphen         registered     macron
 degree        plusminus      twosuperior    threesuperior
 acute         mu             paragraph      periodcentered
 cedilla       onesuperior    ordmasculine   guillemotright

--- a/packages/pdfkit/tests/font/standard.test.ts
+++ b/packages/pdfkit/tests/font/standard.test.ts
@@ -4,13 +4,6 @@ import '../../src/document.node.js';
 import PDFFontFactory from '../../src/font_factory.js';
 
 describe('standard fonts', () => {
-  it('should resolve advanceWidth of soft hyphen to be zero', () => {
-    const SOFT_HYPHEN = '\u00AD';
-    const font = PDFFontFactory.open({}, 'Helvetica', 'Helvetica', 'foobar');
-
-    expect(font.encode(SOFT_HYPHEN)[1][0].advanceWidth).toBe(0);
-  });
-
   // Guards the generated AFM data against a bad regeneration: widths and the
   // delta-encoded kern pairs must still match the original Adobe metrics.
   it.each([


### PR DESCRIPTION
## Summary

`packages/pdfkit/src/font/afm.js` is now **byte-identical to upstream pdfkit** (`origin/master` @ `0b8812a`). With `standard.js`, `standard_fonts.js` and `generated/*` already in sync, `embedded.js` is the only remaining divergence in `font/`.

The fork had exactly one line of drift, from #3188: WinAnsi `0xAD` mapped to `softhyphen` instead of `hyphen`, so it would miss `glyphWidths` and `widthOfGlyph` would return `0` rather than Helvetica's `333` — making soft hyphens weightless for line breaking.

That was the wrong place for it:

- Per the PDF spec (Annex D), `0xAD` **is** `hyphen` in WinAnsiEncoding. Upstream is correct here.
- `encodeText` emits the `0xAD` byte regardless of what we name the glyph, so viewers paint a hyphen either way. The rename only desynced measurement from what's actually drawn.

## Why nothing regresses

The zero-width behaviour #3188 wanted was belt-and-braces at the pdfkit layer. Both mechanisms that actually carry it live in react-pdf code and are untouched:

- `packages/textkit/src/layout/wrapWords.ts:62` strips `U+00AD` before glyphs are built, so pdfkit never sees a soft hyphen in the render pipeline.
- `packages/font/src/standard-font.ts:117` forces `advanceWidth = 0` for `U+00AD`. Its comment ("Upstream pdfkit maps them to `hyphen` in AFM data, so we override here") is accurate again.

`packages/font/tests/standard-fonts.test.ts:270` still asserts the zero advance width end-to-end, so the guarantee is covered at the layer that owns it. The fork-specific assertion in `packages/pdfkit/tests/font/standard.test.ts` is removed; the AFM-metrics regression test stays.

The only caller of pdfkit's text stack outside the fork is `packages/render/src/primitives/renderDebug.ts:160`, which is debug-only, prints `` `${width} x ${height}` ``, and passes `{ width: Infinity }` — unreachable either way.

## Consequence

Third parties importing `@react-pdf/pdfkit` standalone and using `widthOfString`/`line_wrapper` get upstream's behaviour back: a soft hyphen measures 333 in Helvetica and draws as a visible hyphen. That's upstream's own bug to fix — `lib/line_wrapper.js:114` `canFit` double-counts, and upstream never strips mid-line soft hyphens — and fixing it there is the prerequisite for ever taking the zero-width semantics upstream.

## Test plan

- [x] Full suite green: 218 files, 2263 tests, including layout/renderer visual snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)