### PR TITLE
refactor(pdfkit): align font/embedded with upstream

### DIFF
--- a/.changeset/align-embedded-font-upstream.md
+++ b/.changeset/align-embedded-font-upstream.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+Align embedded font with upstream: subset tags are now derived from the font id instead of `Math.random()`, so font objects are reproducible across runs; spaces in PostScript names are escaped; the ToUnicode CMap is written as `bfrange` instead of `bfchar`; and a `CIDSet` is emitted for PDF/A-1 and PDF/UA

--- a/packages/pdfkit/src/font/embedded.js
+++ b/packages/pdfkit/src/font/embedded.js
@@ -1,11 +1,7 @@
 import PDFFont from '../font';
 
-const toHex = function (...codePoints) {
-  const codes = Array.from(codePoints).map((code) =>
-    `0000${code.toString(16)}`.slice(-4)
-  );
-
-  return codes.join('');
+const toHex = function (num) {
+  return `0000${num.toString(16)}`.slice(-4);
 };
 
 class EmbeddedFont extends PDFFont {
@@ -61,9 +57,6 @@ class EmbeddedFont extends PDFFont {
 
   layout(text, features, onlyWidth) {
     // Skip the cache if any user defined features are applied
-    if (onlyWidth == null) {
-      onlyWidth = false;
-    }
     if (features) {
       return this.layoutRun(text, features);
     }
@@ -153,11 +146,11 @@ class EmbeddedFont extends PDFFont {
       flags |= 1 << 6;
     }
 
-    // generate a random tag (6 uppercase letters. 65 is the char code for 'A')
-    const tag = [0, 1, 2, 3, 4, 5]
-      .map(() => String.fromCharCode(Math.random() * 26 + 65))
+    // generate a tag (6 uppercase letters. 17 is the char code offset from '0' to 'A'. 73 will map to 'Z')
+    const tag = [1, 2, 3, 4, 5, 6]
+      .map((i) => String.fromCharCode((this.id.charCodeAt(i) || 73) + 17))
       .join('');
-    const name = tag + '+' + this.font.postscriptName;
+    const name = tag + '+' + this.font.postscriptName?.replaceAll(' ', '_');
 
     const { bbox } = this.font;
     const descriptor = this.document.ref({
@@ -182,6 +175,21 @@ class EmbeddedFont extends PDFFont {
       descriptor.data.FontFile3 = fontFile;
     } else {
       descriptor.data.FontFile2 = fontFile;
+    }
+
+    if (this.document.subset === 1) {
+      const maxCID = this.widths.length - 1;
+      const cidSet = new Uint8Array(Math.ceil((maxCID + 1) / 8));
+      for (let cid = 0; cid <= maxCID; cid++) {
+        if (this.widths[cid] != null) {
+          cidSet[Math.floor(cid / 8)] |= 0x80 >> cid % 8;
+        }
+      }
+
+      const cidSetRef = this.document.ref();
+      cidSetRef.end(cidSet);
+
+      descriptor.data.CIDSet = cidSetRef;
     }
 
     descriptor.end();
@@ -225,21 +233,11 @@ class EmbeddedFont extends PDFFont {
   // unicode characters represented by each glyph.
   toUnicodeCmap() {
     const cmap = this.document.ref();
-    let entries = [];
-    let unicodeMap =
-      '/CIDInit /ProcSet findresource begin\n12 dict begin\nbegincmap\n/CIDSystemInfo <<\n  /Registry (Adobe)\n  /Ordering (UCS)\n  /Supplement 0\n>> def\n/CMapName /Adobe-Identity-UCS def\n/CMapType 2 def\n1 begincodespacerange\n<0000><ffff>\nendcodespacerange';
 
-    for (let [index, codePoints] of this.unicode.entries()) {
+    const entries = [];
+    for (let codePoints of this.unicode) {
       const encoded = [];
-      if (entries.length >= 100) {
-        unicodeMap +=
-          '\n' +
-          entries.length +
-          ' beginbfchar\n' +
-          entries.join('\n') +
-          '\nendbfchar';
-        entries = [];
-      }
+
       // encode codePoints to utf16
       for (let value of codePoints) {
         if (value > 0xffff) {
@@ -247,22 +245,46 @@ class EmbeddedFont extends PDFFont {
           encoded.push(toHex(((value >>> 10) & 0x3ff) | 0xd800));
           value = 0xdc00 | (value & 0x3ff);
         }
+
         encoded.push(toHex(value));
       }
 
-      entries.push('<' + toHex(index) + '>' + '<' + encoded.join(' ') + '>');
+      entries.push(`<${encoded.join(' ')}>`);
     }
-    if (entries.length) {
-      unicodeMap +=
-        '\n' +
-        entries.length +
-        ' beginbfchar\n' +
-        entries.join('\n') +
-        '\nendbfchar\n';
+
+    const chunkSize = 256;
+    const chunks = Math.ceil(entries.length / chunkSize);
+    const ranges = [];
+    for (let i = 0; i < chunks; i++) {
+      const start = i * chunkSize;
+      const end = Math.min((i + 1) * chunkSize, entries.length);
+      ranges.push(
+        `<${toHex(start)}> <${toHex(end - 1)}> [${entries.slice(start, end).join(' ')}]`
+      );
     }
-    unicodeMap +=
-      'endcmap\nCMapName currentdict /CMap defineresource pop\nend\nend';
-    cmap.end(unicodeMap);
+
+    cmap.end(`\
+/CIDInit /ProcSet findresource begin
+12 dict begin
+begincmap
+/CIDSystemInfo <<
+  /Registry (Adobe)
+  /Ordering (UCS)
+  /Supplement 0
+>> def
+/CMapName /Adobe-Identity-UCS def
+/CMapType 2 def
+1 begincodespacerange
+<0000><ffff>
+endcodespacerange
+${ranges.length} beginbfrange
+${ranges.join('\n')}
+endbfrange
+endcmap
+CMapName currentdict /CMap defineresource pop
+end
+end\
+`);
 
     return cmap;
   }

--- a/packages/pdfkit/tests/font/embedded.test.ts
+++ b/packages/pdfkit/tests/font/embedded.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import PDFDocument from '../../src/document.node.js';
+
+const ROBOTO = new URL(
+  '../../../examples/vite/public/Roboto-Regular.ttf',
+  import.meta.url,
+).pathname;
+
+const render = (text: string, options = {}) =>
+  new Promise<string>((resolve) => {
+    const doc = new PDFDocument({ compress: false, ...options });
+    const decoder = new TextDecoder('latin1');
+    const chunks: string[] = [];
+
+    doc.on('data', (chunk) => chunks.push(decoder.decode(chunk)));
+    doc.on('end', () => resolve(chunks.join('')));
+
+    doc.font(ROBOTO).text(text);
+    doc.end();
+  });
+
+describe('embedded fonts', () => {
+  it('derives the subset tag from the font id', async () => {
+    const pdf = await render('Hello');
+
+    // 'F2' — the default Helvetica takes 'F1'
+    expect(pdf).toContain('/BaseFont /CZZZZZ+Roboto-Regular');
+  });
+
+  it('writes a ToUnicode cmap as bfranges', async () => {
+    const pdf = await render('AB');
+
+    expect(pdf).toContain('1 beginbfrange');
+    expect(pdf).toContain('<0000> <0002> [<0000> <0041> <0042>]');
+    expect(pdf).not.toContain('beginbfchar');
+  });
+
+  it('splits the cmap into 256-glyph bfranges', async () => {
+    const codePoints = (from: number, to: number) =>
+      Array.from({ length: to - from + 1 }, (_, i) =>
+        String.fromCodePoint(from + i),
+      ).join('');
+
+    const pdf = await render(
+      codePoints(0x21, 0x7e) +
+        codePoints(0xa1, 0xff) +
+        codePoints(0x100, 0x17f) +
+        codePoints(0x400, 0x45f),
+    );
+
+    const [, count, body] = pdf.match(
+      /(\d+) beginbfrange\n([\s\S]*?)\nendbfrange/,
+    )!;
+    const lines = body.split('\n');
+
+    expect(Number(count)).toBe(lines.length);
+    expect(lines.length).toBeGreaterThan(1);
+
+    // every range must declare exactly as many destinations as it spans
+    for (const line of lines) {
+      const [, from, to, dsts] = line.match(
+        /^<([0-9a-f]{4})> <([0-9a-f]{4})> \[(.*)\]$/,
+      )!;
+      expect(dsts.split(' ').length).toBe(
+        parseInt(to, 16) - parseInt(from, 16) + 1,
+      );
+    }
+  });
+
+  it('writes a CIDSet for PDF/A-1', async () => {
+    expect(await render('AB', { subset: 'PDF/A-1b' })).toContain('/CIDSet');
+    expect(await render('AB')).not.toContain('/CIDSet');
+  });
+});


### PR DESCRIPTION
Brings in the upstream `font/embedded.js` changes that don't regress this fork: the subset tag is derived from the font id instead of `Math.random()` (font objects are now reproducible across runs), spaces are escaped in PostScript names since they're invalid in a PDF name, the ToUnicode CMap is written as `bfrange` instead of chunked `bfchar`, and a `CIDSet` is emitted in the font descriptor for PDF/A-1 and PDF/UA — using `Uint8Array` rather than upstream's `Buffer`, per #3487.

Two upstream changes were deliberately not taken because they would regress us: the `'ltr'` argument to `font.layout()` stays, since without it fontkit reverses strings that textkit has already bidi-ordered (#2600), and the glyph/position arrays keep pushing in place rather than reallocating with `concat` per word. Upstream's `fontLayoutCache` option was skipped as nothing plumbs it through.

Verified that `pdftotext` still round-trips ligatures and accents through the new CMap, and that rendering the same document twice with a fixed `CreationDate` is now byte-identical (it wasn't before); the `/ID` trailer still varies run to run, but that's pre-existing and derives from `new Date()`, not from fonts. Adds tests covering the deterministic tag, the 256-glyph `bfrange` chunk boundaries, and the PDF/A-1-only `CIDSet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)