### PR TITLE
perf(textkit): improve Knuth-Plass line breaking performance

### DIFF
--- a/.changeset/tidy-lines-break.md
+++ b/.changeset/tidy-lines-break.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/textkit': patch
+---
+
+Improve Knuth-Plass line breaking performance for long paragraphs.

--- a/packages/textkit/src/engines/linebreaker/knuthPlass.ts
+++ b/packages/textkit/src/engines/linebreaker/knuthPlass.ts
@@ -276,11 +276,13 @@ const linebreak = (
 
         // Stop iterating through active nodes to insert new candidate active nodes in the active list
         // before moving on to the active nodes for the next line.
-        // TODO: The Knuth and Plass paper suggests a conditional for currentLine < j0. This means paragraphs
-        // with identical line lengths will not be sorted by line number. Find out if that is a desirable outcome.
-        // For now I left this out, as it only adds minimal overhead to the algorithm and keeping the active node
-        // list sorted has a higher priority.
-        if (active !== null && active.data.line >= currentLine) {
+        // Line numbers are equivalent once the last distinct line length is reached.
+        // Grouping them allows dominated candidates to be discarded together.
+        if (
+          active !== null &&
+          active.data.line >= currentLine &&
+          currentLine < lineLengths.length
+        ) {
           break;
         }
       }

--- a/packages/textkit/tests/engines/linebreaker.test.ts
+++ b/packages/textkit/tests/engines/linebreaker.test.ts
@@ -10,6 +10,36 @@ const width = 50;
 describe('linebreaker', () => {
   const linebreaker = linebreakerFactory({});
 
+  const createAttributedString = (
+    align: 'left' | 'right' | 'center' | 'justify',
+    syllables: string[],
+  ) => {
+    const string = syllables.join('');
+    const indices = Array.from({ length: string.length }, (_, index) => index);
+
+    return {
+      string,
+      syllables,
+      runs: [
+        {
+          start: 0,
+          end: string.length,
+          attributes: { align, font: [font] },
+          stringIndices: indices,
+          glyphIndices: indices,
+          positions: Array.from(string, (character) => ({
+            xAdvance: character === ' ' ? 3 : 6,
+            yAdvance: 0,
+            xOffset: 0,
+            yOffset: 0,
+            advanceWidth: character === ' ' ? 3 : 6,
+          })),
+          glyphs: [],
+        },
+      ],
+    };
+  };
+
   test('should break lines and adds hyphens only where indicated', () => {
     const attributedString = {
       string: 'Potentieel broeikasgasemissierapport',
@@ -294,6 +324,83 @@ describe('linebreaker', () => {
       'broeikasgas-',
       'emissie-',
       'rapport',
+    ]);
+  });
+
+  test('should preserve breaks with constant line widths', () => {
+    const syllables =
+      'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu'
+        .split(/([ ]+)/u)
+        .filter(Boolean);
+    const attributedString = createAttributedString('left', syllables);
+
+    const result = linebreaker(attributedString, [72]);
+
+    expect(result.map((line) => line.string)).toEqual([
+      'alpha beta ',
+      'gamma delta ',
+      'epsilon zeta ',
+      'eta theta ',
+      'iota kappa ',
+      'lambda mu',
+    ]);
+  });
+
+  test('should preserve breaks with variable line widths', () => {
+    const syllables =
+      'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu'
+        .split(/([ ]+)/u)
+        .filter(Boolean);
+    const attributedString = createAttributedString('left', syllables);
+
+    const result = linebreaker(attributedString, [54, 90, 72]);
+
+    expect(result.map((line) => line.string)).toEqual([
+      'alpha ',
+      'beta gamma delta ',
+      'epsilon zeta ',
+      'eta theta ',
+      'iota kappa ',
+      'lambda mu',
+    ]);
+  });
+
+  test('should preserve hyphenation with variable line widths', () => {
+    const attributedString = createAttributedString('justify', [
+      'extra',
+      'ordi',
+      'nary',
+      ' ',
+      'typo',
+      'graphy',
+      ' ',
+      'preser',
+      'vation',
+      ' ',
+      'matters',
+    ]);
+
+    const result = linebreaker(attributedString, [54, 90, 72]);
+
+    expect(result.map((line) => line.string)).toEqual([
+      'extra-',
+      'ordinary ',
+      'typography ',
+      'preser-',
+      'vation ',
+      'matters',
+    ]);
+  });
+
+  test('should preserve the best-fit fallback for an oversized word', () => {
+    const attributedString = createAttributedString('left', [
+      'supercalifragilisticexpialidocious',
+    ]);
+
+    const result = linebreaker(attributedString, [24]);
+
+    expect(result.map((line) => line.string)).toEqual([
+      'supercalifragilisticexpialidocious',
     ]);
   });
 });


### PR DESCRIPTION
This improves textkit's Knuth-Plass performance for long paragraphs without changing line-breaking behavior.

The Knuth-Plass paper treats line numbers as equivalent once the line widths become identical. The current implementation keeps separating them, so newly inserted candidates are reconsidered at the same breakpoint and the active-node search grows approximately quadratically on the measured corpus.

Changes:

- group equivalent line-number candidates after the last distinct available width
- keep distinct candidates while variable line widths still apply
- add regression fixtures for alignments, variable widths, hyphenation, and best-fit fallback

Measured on an Apple arm64 Mac with Node 24.17.0, using isolated processes, two warmups, and seven measured runs:

```text
500 words:  5.43ms ->  1.54ms wall, 114MB -> 111MB maxRSS
1k words:  15.62ms ->  4.17ms wall, 123MB -> 115MB maxRSS
2k words:  50.72ms ->  4.44ms wall, 222MB -> 118MB maxRSS
4k words: 183.62ms -> 12.76ms wall, 334MB -> 124MB maxRSS
8k words: 749.56ms -> 19.23ms wall, 693MB -> 141MB maxRSS
```

At 8,000 words, candidate evaluations fell from ~36.6M to ~852k and active-node creation fell from ~1.49M to ~34.8k. Candidate evaluations changed from approximately quadratic growth (empirical exponent 2.01) to approximately linear growth (1.04) across the measured matrix.

Breakpoint hashes match at every benchmark size. A separate 192-case baseline/optimized matrix also matches across constant and variable widths, tolerances, hyphenation settings and penalties, and failure cases.

Validation:

- `yarn workspace @react-pdf/textkit test --run`: 794 tests passed
- `yarn workspace @react-pdf/textkit typecheck`: passed
- `yarn workspace @react-pdf/textkit build`: passed
- changed-file ESLint and Prettier: passed
- full suite: 2,276 tests passed; four unrelated pdfkit font tests could not resolve their fixture because the checkout path contains spaces
- root typecheck still has existing `@react-pdf/render` bookmark and SVG type errors; textkit typecheck passes
