### PR TITLE
feat(layout): mark split fragments with a required wasSplit flag

### DIFF
--- a/.changeset/brave-donuts-tell.md
+++ b/.changeset/brave-donuts-tell.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/layout': minor
+---
+
+Mark pagination split fragments with a required `wasSplit` flag on node types

--- a/packages/layout/src/node/splitBox.ts
+++ b/packages/layout/src/node/splitBox.ts
@@ -16,12 +16,14 @@ const splitBox = (node: SafeNode, height: number): [SafeNode, SafeNode] => {
     ...node,
     box: { ...node.box, height, ...ZERO_BOTTOM_BOX },
     style: { ...node.style, height, ...ZERO_BOTTOM_STYLE },
+    wasSplit: true,
   } as SafeNode;
 
   const next = {
     ...node,
     box: { ...node.box, top: 0, height: nextHeight, ...ZERO_TOP_BOX },
     style: { ...node.style, height: nextHeight, ...ZERO_TOP_STYLE },
+    wasSplit: true,
   } as SafeNode;
 
   return [current, next];

--- a/packages/layout/src/steps/resolveStyles.ts
+++ b/packages/layout/src/steps/resolveStyles.ts
@@ -42,11 +42,16 @@ const resolveNodeStyles =
   (node: Node): SafeNode => {
     const style = computeStyle(container, node);
 
-    if (!node.children) return Object.assign({}, node, { style }) as SafeNode;
+    // Split fragments re-enter through page relayout; keep their mark.
+    const wasSplit = (node as SafeNode).wasSplit ?? false;
+
+    if (!node.children) {
+      return Object.assign({}, node, { style, wasSplit }) as SafeNode;
+    }
 
     const children = node.children.map(resolveNodeStyles(container));
 
-    return Object.assign({}, node, { style, children }) as SafeNode;
+    return Object.assign({}, node, { style, wasSplit, children }) as SafeNode;
   };
 
 /**
@@ -74,11 +79,18 @@ export const resolvePageStyles = (page: PageNode) => {
  * @returns Document root with resolved styles
  */
 const resolveStyles = (root: DocumentNode): SafeDocumentNode => {
-  if (!root.children) return root as SafeDocumentNode;
+  if (!root.children) {
+    return Object.assign({}, root, {
+      wasSplit: false,
+    }) as unknown as SafeDocumentNode;
+  }
 
   const children = root.children.map(resolvePageStyles);
 
-  return Object.assign({}, root, { children }) as SafeDocumentNode;
+  return Object.assign({}, root, {
+    wasSplit: false,
+    children,
+  }) as SafeDocumentNode;
 };
 
 export default resolveStyles;

--- a/packages/layout/src/steps/resolveSvg.ts
+++ b/packages/layout/src/steps/resolveSvg.ts
@@ -194,6 +194,7 @@ const wrapBetweenTspan = (node: SafeTextInstanceNode): SafeTspanNode => ({
   type: P.Tspan,
   props: {},
   style: {},
+  wasSplit: false,
   children: [node],
 });
 
@@ -432,6 +433,7 @@ function convertToSvgNode(imageNode: SafeImageNode): SafeSvgNode {
     box: imageNode.box,
     origin: imageNode.origin,
     yogaNode: imageNode.yogaNode,
+    wasSplit: false,
     children: image.data.children.map(convertParsedNode),
   };
 }

--- a/packages/layout/src/text/splitText.ts
+++ b/packages/layout/src/text/splitText.ts
@@ -53,6 +53,7 @@ const splitText = (node: SafeTextNode, height: number) => {
       borderBottomRightRadius: 0,
     },
     lines: node.lines.slice(0, slicedLineIndex),
+    wasSplit: true,
   });
 
   const next: SafeTextNode = Object.assign({}, node, {
@@ -71,6 +72,7 @@ const splitText = (node: SafeTextNode, height: number) => {
       borderTopRightRadius: 0,
     },
     lines: node.lines.slice(slicedLineIndex),
+    wasSplit: true,
   });
 
   return [current, next];

--- a/packages/layout/src/types/canvas.ts
+++ b/packages/layout/src/types/canvas.ts
@@ -25,4 +25,5 @@ export type CanvasNode = {
 
 export type SafeCanvasNode = Omit<CanvasNode, 'style'> & {
   style: SafeStyle;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/checkbox.ts
+++ b/packages/layout/src/types/checkbox.ts
@@ -25,4 +25,5 @@ export type CheckboxNode = {
 
 export type SafeCheckboxNode = Omit<CheckboxNode, 'style'> & {
   style: SafeStyle;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/circle.ts
+++ b/packages/layout/src/types/circle.ts
@@ -34,4 +34,5 @@ export type CircleNode = {
 export type SafeCircleNode = Omit<CircleNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafeCircleProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/clip-path.ts
+++ b/packages/layout/src/types/clip-path.ts
@@ -31,6 +31,7 @@ export type ClipPathNode = {
 };
 
 export type SafeClipPathNode = Omit<ClipPathNode, 'children'> & {
+  wasSplit: boolean;
   children?: (
     | SafeLineNode
     | SafePolylineNode

--- a/packages/layout/src/types/defs.ts
+++ b/packages/layout/src/types/defs.ts
@@ -22,6 +22,7 @@ export type DefsNode = {
 export type Defs = Record<string, DefsNode['children'][number]>;
 
 export type SafeDefsNode = Omit<DefsNode, 'children'> & {
+  wasSplit: boolean;
   children?: (
     | SafeClipPathNode
     | SafeLinearGradientNode

--- a/packages/layout/src/types/document.ts
+++ b/packages/layout/src/types/document.ts
@@ -69,5 +69,6 @@ export type DocumentNode = {
 
 export type SafeDocumentNode = Omit<DocumentNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children: SafePageNode[];
 };

--- a/packages/layout/src/types/ellipse.ts
+++ b/packages/layout/src/types/ellipse.ts
@@ -35,4 +35,5 @@ export type EllipseNode = {
 export type SafeEllipseNode = Omit<EllipseNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafeEllipseProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/field-set.ts
+++ b/packages/layout/src/types/field-set.ts
@@ -23,5 +23,6 @@ export type FieldSetNode = {
 
 export type SafeFieldSetNode = Omit<FieldSetNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: (SafeTextNode | SafeViewNode | SafeTextInputNode)[];
 };

--- a/packages/layout/src/types/g.ts
+++ b/packages/layout/src/types/g.ts
@@ -49,6 +49,7 @@ export type GNode = {
 export type SafeGNode = Omit<GNode, 'style' | 'props' | 'children'> & {
   style: SafeStyle;
   props: SafeGProps;
+  wasSplit: boolean;
   children?: (
     | SafeLineNode
     | SafePolylineNode

--- a/packages/layout/src/types/image-background.ts
+++ b/packages/layout/src/types/image-background.ts
@@ -67,6 +67,7 @@ export type SafeImageBackgroundNode = Omit<
   'style' | 'children'
 > & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: (
     | SafeViewNode
     | SafeImageNode

--- a/packages/layout/src/types/image.ts
+++ b/packages/layout/src/types/image.ts
@@ -77,4 +77,5 @@ export type ImageNode = {
 
 export type SafeImageNode = Omit<ImageNode, 'style'> & {
   style: SafeStyle;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/line.ts
+++ b/packages/layout/src/types/line.ts
@@ -35,4 +35,5 @@ export type LineNode = {
 export type SafeLineNode = Omit<LineNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafeLineProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/linear-gradient.ts
+++ b/packages/layout/src/types/linear-gradient.ts
@@ -39,5 +39,6 @@ export type SafeLinearGradientNode = Omit<
   'props' | 'children'
 > & {
   props: SafeLinearGradientProps;
+  wasSplit: boolean;
   children?: SafeStopNode[];
 };

--- a/packages/layout/src/types/link.ts
+++ b/packages/layout/src/types/link.ts
@@ -33,6 +33,7 @@ export type LinkNode = {
 
 export type SafeLinkNode = Omit<LinkNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: (
     | SafeViewNode
     | SafeImageNode

--- a/packages/layout/src/types/marker.ts
+++ b/packages/layout/src/types/marker.ts
@@ -55,6 +55,7 @@ export type MarkerNode = {
 
 export type SafeMarkerNode = Omit<MarkerNode, 'props' | 'children'> & {
   props: SafeMarkerProps;
+  wasSplit: boolean;
   children?: (
     | SafeLineNode
     | SafePolylineNode

--- a/packages/layout/src/types/note.ts
+++ b/packages/layout/src/types/note.ts
@@ -16,5 +16,6 @@ export type NoteNode = {
 
 export type SafeNoteNode = Omit<NoteNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: SafeTextInstanceNode[];
 };

--- a/packages/layout/src/types/page.ts
+++ b/packages/layout/src/types/page.ts
@@ -122,6 +122,7 @@ export type PageNode = {
 
 export type SafePageNode = Omit<PageNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: (
     | SafeViewNode
     | SafeImageNode

--- a/packages/layout/src/types/path.ts
+++ b/packages/layout/src/types/path.ts
@@ -29,4 +29,5 @@ export type PathNode = {
 export type SafePathNode = Omit<PathNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafePathProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/polygon.ts
+++ b/packages/layout/src/types/polygon.ts
@@ -29,4 +29,5 @@ export type PolygonNode = {
 export type SafePolygonNode = Omit<PolygonNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafePolygonProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/polyline.ts
+++ b/packages/layout/src/types/polyline.ts
@@ -29,4 +29,5 @@ export type PolylineNode = {
 export type SafePolylineNode = Omit<PolylineNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafePolylineProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/radial-gradient.ts
+++ b/packages/layout/src/types/radial-gradient.ts
@@ -44,5 +44,6 @@ export type SafeRadialGradientNode = Omit<
   'props' | 'children'
 > & {
   props: SafeRadialGradientProps;
+  wasSplit: boolean;
   children?: SafeStopNode[];
 };

--- a/packages/layout/src/types/rect.ts
+++ b/packages/layout/src/types/rect.ts
@@ -39,4 +39,5 @@ export type RectNode = {
 export type SafeRectNode = Omit<RectNode, 'style' | 'props'> & {
   style: SafeStyle;
   props: SafeRectProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/select.ts
+++ b/packages/layout/src/types/select.ts
@@ -24,6 +24,7 @@ export type SelectNode = {
 
 export type SafeSelectNode = Omit<SelectNode, 'style'> & {
   style: SafeStyle;
+  wasSplit: boolean;
 };
 
 export type ListNode = {
@@ -38,4 +39,5 @@ export type ListNode = {
 
 export type SafeListNode = Omit<ListNode, 'style'> & {
   style: SafeStyle;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/stop.ts
+++ b/packages/layout/src/types/stop.ts
@@ -24,4 +24,5 @@ export type StopNode = {
 
 export type SafeStopNode = Omit<StopNode, 'props'> & {
   props: StopSafeProps;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/svg.ts
+++ b/packages/layout/src/types/svg.ts
@@ -84,6 +84,7 @@ export type SvgNode = {
 export type SafeSvgNode = Omit<SvgNode, 'style' | 'props' | 'children'> & {
   style: SafeStyle;
   props: SvgSafeProps;
+  wasSplit: boolean;
   children?: (
     | SafeLineNode
     | SafePolylineNode

--- a/packages/layout/src/types/text-input.ts
+++ b/packages/layout/src/types/text-input.ts
@@ -58,4 +58,5 @@ export type TextInputNode = {
 
 export type SafeTextInputNode = Omit<TextInputNode, 'style'> & {
   style: SafeStyle;
+  wasSplit: boolean;
 };

--- a/packages/layout/src/types/text-instance.ts
+++ b/packages/layout/src/types/text-instance.ts
@@ -11,4 +11,4 @@ export type TextInstanceNode = {
   value: string;
 };
 
-export type SafeTextInstanceNode = TextInstanceNode;
+export type SafeTextInstanceNode = TextInstanceNode & { wasSplit: boolean };

--- a/packages/layout/src/types/text.ts
+++ b/packages/layout/src/types/text.ts
@@ -56,6 +56,7 @@ export type TextNode = {
 
 export type SafeTextNode = Omit<TextNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: (
     | SafeTextNode
     | SafeTextInstanceNode

--- a/packages/layout/src/types/tspan.ts
+++ b/packages/layout/src/types/tspan.ts
@@ -32,5 +32,6 @@ export type TspanNode = {
 export type SafeTspanNode = Omit<TspanNode, 'style' | 'props' | 'children'> & {
   style: SafeStyle;
   props: SafeTspanProps;
+  wasSplit: boolean;
   children?: SafeTextInstanceNode[];
 };

--- a/packages/layout/src/types/view.ts
+++ b/packages/layout/src/types/view.ts
@@ -52,6 +52,7 @@ export type ViewNode = {
 
 export type SafeViewNode = Omit<ViewNode, 'style' | 'children'> & {
   style: SafeStyle;
+  wasSplit: boolean;
   children?: (
     | SafeViewNode
     | SafeImageNode

--- a/packages/layout/tests/steps/__snapshots__/resolveStyles.test.ts.snap
+++ b/packages/layout/tests/steps/__snapshots__/resolveStyles.test.ts.snap
@@ -20,15 +20,18 @@ exports[`layout resolveStyles > Should overide default link styles 1`] = `
             "textDecoration": "none",
           },
           "type": "LINK",
+          "wasSplit": false,
         },
       ],
       "props": {},
       "style": {},
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -52,15 +55,18 @@ exports[`layout resolveStyles > Should overide default link styles with array 1`
             "textDecoration": "none",
           },
           "type": "LINK",
+          "wasSplit": false,
         },
       ],
       "props": {},
       "style": {},
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -84,15 +90,18 @@ exports[`layout resolveStyles > Should resolve default link styles 1`] = `
             "textDecoration": "underline",
           },
           "type": "LINK",
+          "wasSplit": false,
         },
       ],
       "props": {},
       "style": {},
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -131,15 +140,18 @@ exports[`layout resolveStyles > Should resolve nested node styles 1`] = `
             "paddingTop": 28.34645669291339,
           },
           "type": "VIEW",
+          "wasSplit": false,
         },
       ],
       "props": {},
       "style": {},
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -178,15 +190,18 @@ exports[`layout resolveStyles > Should resolve nested node styles array 1`] = `
             "paddingTop": 28.34645669291339,
           },
           "type": "VIEW",
+          "wasSplit": false,
         },
       ],
       "props": {},
       "style": {},
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -209,6 +224,7 @@ exports[`layout resolveStyles > Should resolve nested node styles media queries 
             "backgroundColor": "green",
           },
           "type": "VIEW",
+          "wasSplit": false,
         },
         {
           "props": {},
@@ -216,15 +232,18 @@ exports[`layout resolveStyles > Should resolve nested node styles media queries 
             "backgroundColor": "red",
           },
           "type": "VIEW",
+          "wasSplit": false,
         },
       ],
       "props": {},
       "style": {},
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -239,6 +258,7 @@ exports[`layout resolveStyles > Should resolve nested node styles media queries 
             "backgroundColor": "green",
           },
           "type": "VIEW",
+          "wasSplit": false,
         },
         {
           "props": {},
@@ -246,6 +266,7 @@ exports[`layout resolveStyles > Should resolve nested node styles media queries 
             "backgroundColor": "red",
           },
           "type": "VIEW",
+          "wasSplit": false,
         },
       ],
       "props": {},
@@ -254,10 +275,12 @@ exports[`layout resolveStyles > Should resolve nested node styles media queries 
         "width": 100,
       },
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -286,10 +309,12 @@ exports[`layout resolveStyles > Should resolve page styles 1`] = `
         "paddingTop": 28.34645669291339,
       },
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -318,10 +343,12 @@ exports[`layout resolveStyles > Should resolve page styles array 1`] = `
         "paddingTop": 28.34645669291339,
       },
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;
 
@@ -340,6 +367,7 @@ exports[`layout resolveStyles > Should resolve several pages styles 1`] = `
         "paddingTop": 28.34645669291339,
       },
       "type": "PAGE",
+      "wasSplit": false,
     },
     {
       "props": {},
@@ -360,9 +388,11 @@ exports[`layout resolveStyles > Should resolve several pages styles 1`] = `
         "fontWeight": 700,
       },
       "type": "PAGE",
+      "wasSplit": false,
     },
   ],
   "props": {},
   "type": "DOCUMENT",
+  "wasSplit": false,
 }
 `;

--- a/packages/layout/tests/steps/resolveSvg.test.ts
+++ b/packages/layout/tests/steps/resolveSvg.test.ts
@@ -14,6 +14,7 @@ describe('layout resolveSvg', () => {
   describe('resolve xlinks', () => {
     test('should replace xlinkHref with the correct node', () => {
       const node: SafeSvgNode = {
+        wasSplit: false,
         type: 'SVG',
         props: {},
         style: {},
@@ -57,6 +58,7 @@ describe('layout resolveSvg', () => {
 
     test('should not replace xlinkHref if node does not exist', () => {
       const node: SafeSvgNode = {
+        wasSplit: false,
         type: 'SVG',
         props: {},
         style: {},
@@ -165,6 +167,7 @@ describe('layout resolveSvg', () => {
 
     test('Should not modify non-SVG ImageNodes', () => {
       const imageNode: SafeImageNode = {
+        wasSplit: false,
         type: P.Image,
         props: { src: 'test.png' },
         style: {},
@@ -195,6 +198,7 @@ describe('layout resolveSvg', () => {
       const svgImage = createMockSvgImage();
       const imageNode = createMockImageNode(svgImage);
       const viewNode: SafeNode = {
+        wasSplit: false,
         type: P.View,
         props: {},
         style: {},
@@ -213,6 +217,7 @@ describe('layout resolveSvg', () => {
       const svgImage = createMockSvgImage();
       const svgImageNode = createMockImageNode(svgImage);
       const pngImageNode: SafeImageNode = {
+        wasSplit: false,
         type: P.Image,
         props: { src: 'test.png' },
         style: {},
@@ -235,6 +240,7 @@ describe('layout resolveSvg', () => {
     test('Should use SVG dimensions when style dimensions not specified', () => {
       const svgImage = createMockSvgImage();
       const imageNode: SafeImageNode = {
+        wasSplit: false,
         type: P.Image,
         props: { src: 'test.svg' },
         style: {},

--- a/packages/layout/tests/text/heightAtLineIndex.test.ts
+++ b/packages/layout/tests/text/heightAtLineIndex.test.ts
@@ -8,7 +8,12 @@ const TEST_LINES = Array(10).fill(TEST_LINE);
 
 describe('text heightAtLineIndex', () => {
   test('Should return 0 if no lines present', () => {
-    const node: SafeTextNode = { type: 'TEXT', props: {}, style: {} };
+    const node: SafeTextNode = {
+      type: 'TEXT',
+      props: {},
+      style: {},
+      wasSplit: false,
+    };
     const result = heightAtLineIndex(node, 5);
 
     expect(result).toBe(0);
@@ -16,6 +21,7 @@ describe('text heightAtLineIndex', () => {
 
   test('Should return correct height for first line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -29,6 +35,7 @@ describe('text heightAtLineIndex', () => {
 
   test('Should return correct height for intermediate line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -42,6 +49,7 @@ describe('text heightAtLineIndex', () => {
 
   test('Should return correct height for last line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -55,6 +63,7 @@ describe('text heightAtLineIndex', () => {
 
   test('Should return correct height for overflow line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},

--- a/packages/layout/tests/text/lineIndexAtHeight.test.ts
+++ b/packages/layout/tests/text/lineIndexAtHeight.test.ts
@@ -8,7 +8,12 @@ const TEST_LINES = Array(10).fill(TEST_LINE);
 
 describe('text lineIndexAtHeight', () => {
   test('Should return 0 if no lines present', () => {
-    const node: SafeTextNode = { type: 'TEXT', props: {}, style: {} };
+    const node: SafeTextNode = {
+      type: 'TEXT',
+      props: {},
+      style: {},
+      wasSplit: false,
+    };
     const result = lineIndexAtHeight(node, 5);
 
     expect(result).toBe(0);
@@ -16,6 +21,7 @@ describe('text lineIndexAtHeight', () => {
 
   test('Should return 0 for height lower than first line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -29,6 +35,7 @@ describe('text lineIndexAtHeight', () => {
 
   test('Should return 1 for height higher than first line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -42,6 +49,7 @@ describe('text lineIndexAtHeight', () => {
 
   test('Should return correct line index for intermediate line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -55,6 +63,7 @@ describe('text lineIndexAtHeight', () => {
 
   test('Should return penultimate line index for height lower than last line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -68,6 +77,7 @@ describe('text lineIndexAtHeight', () => {
 
   test('Should return correct line index for last line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},
@@ -81,6 +91,7 @@ describe('text lineIndexAtHeight', () => {
 
   test('Should return correct line index for height higher than last line', () => {
     const node: SafeTextNode = {
+      wasSplit: false,
       type: 'TEXT',
       props: {},
       style: {},


### PR DESCRIPTION
Extracted from #3286 so the float work can build on it.

When pagination splits a node, both fragments now carry `wasSplit: true` (stamped by `splitText` and `splitBox`). Style resolution seeds `wasSplit: false` on every node at the `Node → SafeNode` boundary and preserves an existing mark when fragments re-enter page relayout, so the field is required on the safe node types rather than optional.

This gives downstream steps a durable way to tell a pagination fragment from a whole node. The float implementation (#3286) uses it to keep split text fragments from being re-wrapped — a fragment's sliced `lines` are the only record of which content belongs on its page, so re-running text layout on one would regenerate the full text.

Marking currently covers leaf splits (text and childless boxes); container fragments rebuilt by the new engine's `fromPage` are not marked, and can be if a consumer needs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)