### PR TITLE
fix(pdfkit): encrypt strings inside name trees

### DIFF
--- a/.changeset/encrypt-name-trees.md
+++ b/.changeset/encrypt-name-trees.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/pdfkit': patch
+---
+
+Encrypt strings inside name trees, fixing broken internal links and unreadable attachments in password-protected documents

--- a/packages/pdfkit/src/object.js
+++ b/packages/pdfkit/src/object.js
@@ -101,9 +101,12 @@ class PDFObject {
       // Byte arrays are converted to PDF hex strings
     } else if (object instanceof Uint8Array) {
       return `<${bytesToHex(object)}>`;
+    } else if (object instanceof PDFTree) {
+      // Name trees hold PDF strings as keys, which have to be encrypted like
+      // any other string in the document
+      return object.toString(encryptFn);
     } else if (
       object instanceof PDFAbstractReference ||
-      object instanceof PDFTree ||
       object instanceof SpotColor
     ) {
       return object.toString();

--- a/packages/pdfkit/src/tree.js
+++ b/packages/pdfkit/src/tree.js
@@ -19,7 +19,7 @@ class PDFTree {
     return this._items[key];
   }
 
-  toString() {
+  toString(encryptFn = null) {
     // Needs to be sorted by key
     const sortedKeys = Object.keys(this._items).sort((a, b) =>
       this._compareKeys(a, b),
@@ -30,14 +30,15 @@ class PDFTree {
       const first = sortedKeys[0],
         last = sortedKeys[sortedKeys.length - 1];
       out.push(
-        `  /Limits ${PDFObject.convert([this._dataForKey(first), this._dataForKey(last)])}`,
+        `  /Limits ${PDFObject.convert([this._dataForKey(first), this._dataForKey(last)], encryptFn)}`,
       );
     }
     out.push(`  /${this._keysName()} [`);
     for (let key of sortedKeys) {
       out.push(
-        `    ${PDFObject.convert(this._dataForKey(key))} ${PDFObject.convert(
+        `    ${PDFObject.convert(this._dataForKey(key), encryptFn)} ${PDFObject.convert(
           this._items[key],
+          encryptFn,
         )}`,
       );
     }

--- a/packages/pdfkit/tests/tree.test.ts
+++ b/packages/pdfkit/tests/tree.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import { fromBinaryString, toBinaryString } from '../src/binary.js';
+import PDFDocument from '../src/document.node.js';
+import PDFNameTree from '../src/name_tree.js';
+import PDFNumberTree from '../src/number_tree.js';
+import PDFObject from '../src/object.js';
+
+// Stand-in for a real cipher: uppercasing keeps the expected output readable
+// while still showing that every string went through it individually
+const encryptFn = (bytes: Uint8Array) =>
+  fromBinaryString(toBinaryString(bytes).toUpperCase());
+
+describe.each([
+  [
+    'name tree',
+    {
+      Tree: PDFNameTree,
+      keys: ['a', 'b'],
+      plain: `<<
+  /Limits [(a) (b)]
+  /Names [
+    (a) (one)
+    (b) (two)
+]
+>>`,
+      // the keys are PDF strings, so they get encrypted just like the values
+      encrypted: `<<
+  /Limits [(A) (B)]
+  /Names [
+    (A) (ONE)
+    (B) (TWO)
+]
+>>`,
+    },
+  ],
+  [
+    'number tree',
+    {
+      Tree: PDFNumberTree,
+      keys: [1, 2],
+      plain: `<<
+  /Limits [1 2]
+  /Nums [
+    1 (one)
+    2 (two)
+]
+>>`,
+      // the keys are numbers rather than strings, so they stay as they are
+      encrypted: `<<
+  /Limits [1 2]
+  /Nums [
+    1 (ONE)
+    2 (TWO)
+]
+>>`,
+    },
+  ],
+])('%s', (_treeName, { Tree, keys, plain, encrypted }) => {
+  const tree = () => {
+    const result = new Tree();
+    result.add(keys[0], new String('one'));
+    result.add(keys[1], new String('two'));
+    return result;
+  };
+
+  it('is written in plain text without an encryption function', () => {
+    expect(PDFObject.convert(tree())).toEqual(plain);
+  });
+
+  it('is encrypted with an encryption function', () => {
+    expect(PDFObject.convert(tree(), encryptFn)).toEqual(encrypted);
+  });
+});
+
+describe('name trees in a document', () => {
+  const names = ['(heading)', '(data.txt)', 'app.alert'];
+
+  const writeDocument = (options = {}) => {
+    const chunks: Uint8Array[] = [];
+    const doc = new PDFDocument(options);
+
+    doc.on('data', (chunk: Uint8Array) => chunks.push(chunk));
+
+    doc.text('link', { destination: 'heading' });
+    doc.file(new Uint8Array([1, 2, 3]), { name: 'data.txt' });
+    doc.addNamedJavaScript('hello', 'app.alert("hi")');
+    doc.end();
+
+    return new Promise<string>((resolve, reject) => {
+      doc.on('end', () => resolve(chunks.map(toBinaryString).join('')));
+      doc.on('error', reject);
+    });
+  };
+
+  it.each(names)('writes %s in plain text when not encrypted', async (name) => {
+    await expect(writeDocument()).resolves.toContain(name);
+  });
+
+  describe.each([
+    ['RC4', '1.3'],
+    ['AES-128', '1.6'],
+    ['AES-256', '1.7ext3'],
+  ])('encrypted with %s', (_algorithm, pdfVersion) => {
+    it.each(names)('never writes %s', async (name) => {
+      await expect(
+        writeDocument({ pdfVersion, userPassword: 'pw' }),
+      ).resolves.not.toContain(name);
+    });
+  });
+});


### PR DESCRIPTION
Since encryption landed in #3344, setting `userPassword` on a `<Document>` silently breaks two things:

- **internal links.** `<Link src="#chapter-2">` to a node with `id="chapter-2"` no longer navigates. Firefox's viewer logs `goToDestination: "null" is not a valid destination array, for dest="chapter-2"`.
- **attachments.** `ctx.file()` embeds the file, but its name comes back as garbage, so it cannot be looked up.

Both are the same bug, inherited from upstream pdfkit (https://github.com/foliojs/pdfkit/issues/1513). I've ran into this while trying to add password support to my own project that uses react-pdf: https://github.com/klimeryk/recalendar.js/commit/f62f765f19283dd41a2a56f483f015160b2f280c.

I've submitted this patch and it got merged upstream already: https://github.com/foliojs/pdfkit/pull/1773 🙇 

### Cause

Strings inside name trees are written **unencrypted** in an otherwise encrypted document. Readers decrypt them like every other string, get garbage, and the lookup fails.

[`PDFObject.convert()` discards the cipher for every `PDFTree`](https://github.com/diegomura/react-pdf/blob/482d7cd600ffa28c60b5db46e7eb1466398feb7b/packages/pdfkit/src/object.js#L106), so [`PDFTree.toString()`](https://github.com/diegomura/react-pdf/blob/482d7cd600ffa28c60b5db46e7eb1466398feb7b/packages/pdfkit/src/tree.js#L22) has nothing to pass on when it serialises `/Limits`, the keys and the values — and name tree keys [are PDF strings](https://github.com/diegomura/react-pdf/blob/482d7cd600ffa28c60b5db46e7eb1466398feb7b/packages/pdfkit/src/name_tree.js#L16).

In an encrypted document, the strings inside name trees are written **unencrypted**. Readers decrypt them like every other string, get garbage, and the lookup fails. Anything that relies on a name tree is broken:

- internal links to named destinations go nowhere
- attachments cannot be found by name
- named JavaScript never runs - and both its name and its body leak in plain text out of an encrypted document

### Reproduction

```js
import { getDocument } from 'pdfjs-dist/legacy/build/pdf.mjs';

const doc = new PDFDocument({ userPassword: 'secret' });
const chunks = [];
doc.on('data', (c) => chunks.push(c));
doc.on('end', async () => {
  const pdf = await getDocument({ data: Buffer.concat(chunks), password: 'secret' }).promise;
  console.log(await pdf.getDestination('heading'));
  console.log(Object.keys(await pdf.getAttachments()));
});

doc.text('go', { destination: 'heading' });
doc.file(new Uint8Array([1, 2, 3]), { name: 'data.txt' });
doc.end();
```

| | destination | attachment |
| --- | --- | --- |
| before | `null` | `[ 'v*\x8E(äì\x91ı' ]` |
| after | `[ { num: 12, gen: 0 }, { name: 'XYZ' }, 72, 720, null ]` | `[ 'data.txt' ]` |

Without a password both cases already printed the correct values.

## Tests

`packages/pdfkit/tests/tree.test.ts`:

- a tree is serialised in plain text without a cipher (regression guard) and fully encrypted with one, parametrized over `PDFNameTree` and `PDFNumberTree` (whose keys are integers, so only its values are encrypted)
- a document with a named destination, an attachment and a named script contains `(heading)`, `(data.txt)` and `app.alert` when unencrypted, and none of them when encrypted — checked across RC4, AES-128 and AES-256

The eleven encryption cases fail on `master` and pass with this change.