### PR TITLE
feat(textkit): ellipse and polygon exclusion shapes for text wrapping

### DIFF
--- a/.changeset/shiny-shapes-flow.md
+++ b/.changeset/shiny-shapes-flow.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/textkit': major
+'@react-pdf/layout': patch
+---
+
+Support ellipse and polygon exclusion shapes for text wrapping, groundwork for CSS `shape-outside`. Breaking: the `Container.excludeRects` prop is renamed to `exclusions` and now accepts `ExclusionShape[]` (rect, ellipse, or polygon, each with an optional `extend` side)

--- a/packages/layout/src/steps/resolveFloats.ts
+++ b/packages/layout/src/steps/resolveFloats.ts
@@ -112,7 +112,7 @@ const applyClearOffset = (node: SafeNode, offset: number): SafeNode => {
 };
 
 /**
- * Attach exclusion geometry to a text node for excludeRects generation.
+ * Attach exclusion geometry to a text node for text wrapping.
  * Skip if no floats or if text was split during pagination.
  */
 const attachExclusions = (

--- a/packages/layout/src/text/layoutText.ts
+++ b/packages/layout/src/text/layoutText.ts
@@ -30,10 +30,10 @@ const getMaxLines = (node) => node.style?.maxLines;
 const getTextOverflow = (node) => node.style?.textOverflow;
 
 /**
- * Generate exclude rects from node exclusions for textkit,
+ * Generate exclusion shapes from node exclusions for textkit,
  * in coordinates relative to the text container.
  */
-const getExcludeRects = (node: SafeTextNode): Rect[] | undefined => {
+const getExclusions = (node: SafeTextNode): Rect[] | undefined => {
   const exclusions = node.exclusions;
 
   if (!exclusions || exclusions.length === 0) return undefined;
@@ -67,7 +67,7 @@ const getContainer = (width: number, height: number, node: SafeTextNode) => {
     maxLines,
     height: height || Infinity,
     truncateMode: textOverflow,
-    excludeRects: getExcludeRects(node),
+    exclusions: getExclusions(node),
   };
 };
 

--- a/packages/textkit/src/layout/generateLineRects.ts
+++ b/packages/textkit/src/layout/generateLineRects.ts
@@ -1,30 +1,32 @@
-import intersects from '../rect/intersects';
+import bandInterval from '../shape/bandInterval';
+import shapeMaxY from '../shape/maxY';
 import partition from '../rect/partition';
-import { Container, Rect } from '../types';
+import { Container, ExclusionShape, Rect } from '../types';
 
-const getLineFragment = (lineRect: Rect, excludeRect: Rect): Rect[] => {
-  if (!intersects(excludeRect, lineRect)) return [lineRect];
-
-  const eStart = excludeRect.x;
-  const eEnd = excludeRect.x + excludeRect.width;
-  const lStart = lineRect.x;
-  const lEnd = lineRect.x + lineRect.width;
-
-  const a = Object.assign({}, lineRect, { width: eStart - lStart });
-  const b = Object.assign({}, lineRect, { x: eEnd, width: lEnd - eEnd });
-
-  return [a, b].filter((r) => r.width > 0);
-};
-
-const getLineFragments = (rect: Rect, excludeRects: Rect[]) => {
+const getLineFragments = (rect: Rect, shapes: ExclusionShape[]) => {
   let fragments = [rect];
 
-  for (let i = 0; i < excludeRects.length; i += 1) {
-    const excludeRect = excludeRects[i];
+  for (let i = 0; i < shapes.length; i += 1) {
+    const shape = shapes[i];
+    const interval = bandInterval(shape, rect.y, rect.y + rect.height);
 
-    fragments = fragments.reduce((acc, fragment) => {
-      const pieces = getLineFragment(fragment, excludeRect);
-      return acc.concat(pieces);
+    if (!interval) continue;
+
+    // extend stretches the exclusion to the line edge on the float side,
+    // so text never lands between a floated shape and its own margin edge
+    const x0 = shape.extend === 'left' ? -Infinity : interval.x0;
+    const x1 = shape.extend === 'right' ? Infinity : interval.x1;
+
+    fragments = fragments.reduce((acc: Rect[], fragment) => {
+      const fStart = fragment.x;
+      const fEnd = fragment.x + fragment.width;
+
+      if (x1 <= fStart || x0 >= fEnd) return acc.concat(fragment);
+
+      const a = Object.assign({}, fragment, { width: x0 - fStart });
+      const b = Object.assign({}, fragment, { x: x1, width: fEnd - x1 });
+
+      return acc.concat([a, b].filter((r) => r.width > 0));
     }, []);
   }
 
@@ -32,18 +34,18 @@ const getLineFragments = (rect: Rect, excludeRects: Rect[]) => {
 };
 
 const generateLineRects = (container: Container, height: number) => {
-  const { excludeRects, ...rect } = container;
+  const { exclusions, ...rect } = container;
 
-  if (!excludeRects) return [rect];
+  if (!exclusions || exclusions.length === 0) return [rect];
 
   const lineRects: Rect[] = [];
-  const maxY = Math.max(...excludeRects.map((r) => r.y + r.height));
+  const maxY = Math.max(...exclusions.map(shapeMaxY));
 
   let currentRect = rect;
 
   while (currentRect.y < maxY) {
     const [lineRect, rest] = partition(currentRect, height);
-    const lineRectFragments = getLineFragments(lineRect, excludeRects);
+    const lineRectFragments = getLineFragments(lineRect, exclusions);
 
     currentRect = rest;
     lineRects.push(...lineRectFragments);

--- a/packages/textkit/src/shape/bandInterval.ts
+++ b/packages/textkit/src/shape/bandInterval.ts
@@ -1,0 +1,84 @@
+import { Coordinate, ExclusionShape } from '../types';
+
+export type Interval = { x0: number; x1: number };
+
+const ellipseInterval = (
+  cx: number,
+  cy: number,
+  rx: number,
+  ry: number,
+  y0: number,
+  y1: number,
+): Interval | null => {
+  if (y1 <= cy - ry || y0 >= cy + ry) return null;
+
+  // The ellipse is widest at the band y closest to its center
+  const y = Math.min(Math.max(cy, y0), y1);
+  const t = ry === 0 ? 0 : (y - cy) / ry;
+  const halfWidth = rx * Math.sqrt(1 - t * t);
+
+  return { x0: cx - halfWidth, x1: cx + halfWidth };
+};
+
+const polygonInterval = (
+  points: Coordinate[],
+  y0: number,
+  y1: number,
+): Interval | null => {
+  const xs: number[] = [];
+
+  for (let i = 0; i < points.length; i += 1) {
+    const a = points[i];
+    const b = points[(i + 1) % points.length];
+
+    if (a.y >= y0 && a.y <= y1) xs.push(a.x);
+
+    const crossings = [y0, y1];
+
+    for (let j = 0; j < crossings.length; j += 1) {
+      const y = crossings[j];
+      if ((a.y < y && b.y > y) || (a.y > y && b.y < y)) {
+        xs.push(a.x + ((y - a.y) / (b.y - a.y)) * (b.x - a.x));
+      }
+    }
+  }
+
+  if (xs.length === 0) return null;
+
+  return { x0: Math.min(...xs), x1: Math.max(...xs) };
+};
+
+/**
+ * Horizontal extent a shape occupies within the y band [y0, y1].
+ * Conservative for polygons: concavities inside a band are filled,
+ * matching line-granularity flow in browsers.
+ *
+ * @param shape - Exclusion shape
+ * @param y0 - Band top
+ * @param y1 - Band bottom
+ * @returns Occupied x interval, or null if the shape misses the band
+ */
+const bandInterval = (
+  shape: ExclusionShape,
+  y0: number,
+  y1: number,
+): Interval | null => {
+  let interval: Interval | null;
+
+  if (shape.type === 'ellipse') {
+    interval = ellipseInterval(shape.cx, shape.cy, shape.rx, shape.ry, y0, y1);
+  } else if (shape.type === 'polygon') {
+    interval = polygonInterval(shape.points, y0, y1);
+  } else {
+    interval =
+      y1 <= shape.y || y0 >= shape.y + shape.height
+        ? null
+        : { x0: shape.x, x1: shape.x + shape.width };
+  }
+
+  if (!interval || interval.x1 - interval.x0 <= 0) return null;
+
+  return interval;
+};
+
+export default bandInterval;

--- a/packages/textkit/src/shape/maxY.ts
+++ b/packages/textkit/src/shape/maxY.ts
@@ -1,0 +1,23 @@
+import { ExclusionShape } from '../types';
+
+/**
+ * Returns max shape Y coordinate
+ *
+ * @param shape - Exclusion shape
+ * @returns Y coordinate
+ */
+const maxY = (shape: ExclusionShape) => {
+  if (shape.type === 'ellipse') return shape.cy + shape.ry;
+
+  if (shape.type === 'polygon') {
+    let max = -Infinity;
+    for (let i = 0; i < shape.points.length; i += 1) {
+      max = Math.max(max, shape.points[i].y);
+    }
+    return max;
+  }
+
+  return shape.y + shape.height;
+};
+
+export default maxY;

--- a/packages/textkit/src/types.ts
+++ b/packages/textkit/src/types.ts
@@ -14,10 +14,35 @@ export type Rect = {
   height: number;
 };
 
+export type ExclusionRect = Rect & {
+  type?: 'rect';
+  extend?: 'left' | 'right';
+};
+
+export type ExclusionEllipse = {
+  type: 'ellipse';
+  extend?: 'left' | 'right';
+  cx: number;
+  cy: number;
+  rx: number;
+  ry: number;
+};
+
+export type ExclusionPolygon = {
+  type: 'polygon';
+  extend?: 'left' | 'right';
+  points: Coordinate[];
+};
+
+export type ExclusionShape =
+  | ExclusionRect
+  | ExclusionEllipse
+  | ExclusionPolygon;
+
 export type Container = Rect & {
   truncateMode?: 'ellipsis';
   maxLines?: number;
-  excludeRects?: Rect[];
+  exclusions?: ExclusionShape[];
 };
 
 export type Glyph = FontkitGlyph;

--- a/packages/textkit/tests/layout/generateLineRects.test.ts
+++ b/packages/textkit/tests/layout/generateLineRects.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from 'vitest';
+
+import generateLineRects from '../../src/layout/generateLineRects';
+
+const container = { x: 0, y: 0, width: 100, height: 100 };
+
+describe('generateLineRects', () => {
+  test('should return container when no exclusions', () => {
+    expect(generateLineRects(container, 10)).toEqual([container]);
+    expect(generateLineRects({ ...container, exclusions: [] }, 10)).toEqual([
+      container,
+    ]);
+  });
+
+  test('should split lines around rect exclusion', () => {
+    const exclusions = [{ x: 40, y: 0, width: 20, height: 10 }];
+    const rects = generateLineRects({ ...container, exclusions }, 10);
+
+    expect(rects).toEqual([
+      { x: 0, y: 0, width: 40, height: 10 },
+      { x: 60, y: 0, width: 40, height: 10 },
+      { x: 0, y: 10, width: 100, height: 90 },
+    ]);
+  });
+
+  test('should extend rect exclusion to the left line edge', () => {
+    const exclusions = [
+      { x: 40, y: 0, width: 20, height: 10, extend: 'left' as const },
+    ];
+    const rects = generateLineRects({ ...container, exclusions }, 10);
+
+    expect(rects).toEqual([
+      { x: 60, y: 0, width: 40, height: 10 },
+      { x: 0, y: 10, width: 100, height: 90 },
+    ]);
+  });
+
+  test('should extend rect exclusion to the right line edge', () => {
+    const exclusions = [
+      { x: 40, y: 0, width: 20, height: 10, extend: 'right' as const },
+    ];
+    const rects = generateLineRects({ ...container, exclusions }, 10);
+
+    expect(rects).toEqual([
+      { x: 0, y: 0, width: 40, height: 10 },
+      { x: 0, y: 10, width: 100, height: 90 },
+    ]);
+  });
+
+  test('should widen lines following ellipse contour', () => {
+    const exclusions = [
+      { type: 'ellipse' as const, cx: 0, cy: 20, rx: 40, ry: 20 },
+    ];
+    const rects = generateLineRects({ ...container, exclusions }, 10);
+
+    expect(rects.length).toBe(5);
+
+    // bands touching the center y get the full rx, outer bands are narrower
+    const edgeHalfWidth = 40 * Math.sqrt(0.75);
+
+    expect(rects[0].x).toBeCloseTo(edgeHalfWidth);
+    expect(rects[0].width).toBeCloseTo(100 - edgeHalfWidth);
+    expect(rects[1].x).toBeCloseTo(40);
+    expect(rects[1].width).toBeCloseTo(60);
+    expect(rects[2].x).toBeCloseTo(40);
+    expect(rects[3].x).toBeCloseTo(edgeHalfWidth);
+
+    expect(rects[4]).toEqual({ x: 0, y: 40, width: 100, height: 60 });
+  });
+
+  test('should flow text around polygon exclusion', () => {
+    const exclusions = [
+      {
+        type: 'polygon' as const,
+        points: [
+          { x: 100, y: 0 },
+          { x: 100, y: 30 },
+          { x: 70, y: 0 },
+        ],
+        extend: 'right' as const,
+      },
+    ];
+    const rects = generateLineRects({ ...container, exclusions }, 10);
+
+    expect(rects).toEqual([
+      { x: 0, y: 0, width: 70, height: 10 },
+      { x: 0, y: 10, width: 80, height: 10 },
+      { x: 0, y: 20, width: 90, height: 10 },
+      { x: 0, y: 30, width: 100, height: 70 },
+    ]);
+  });
+});

--- a/packages/textkit/tests/layout/layoutParagraph.test.ts
+++ b/packages/textkit/tests/layout/layoutParagraph.test.ts
@@ -9,7 +9,7 @@ describe('layoutParagraph', () => {
     const layout = layoutParagraph({ linebreaker }!);
 
     const container = {
-      excludeRects: [],
+      exclusions: [],
       x: 2,
       y: 4,
       width: 20,

--- a/packages/textkit/tests/shape/bandInterval.test.ts
+++ b/packages/textkit/tests/shape/bandInterval.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from 'vitest';
+
+import bandInterval from '../../src/shape/bandInterval';
+import { ExclusionShape } from '../../src/types';
+
+describe('shape bandInterval operator', () => {
+  test('should return rect extent when band overlaps', () => {
+    const shape: ExclusionShape = { x: 10, y: 20, width: 30, height: 40 };
+
+    expect(bandInterval(shape, 30, 40)).toEqual({ x0: 10, x1: 40 });
+  });
+
+  test('should treat untyped shape as rect', () => {
+    const shape: ExclusionShape = {
+      type: 'rect',
+      x: 10,
+      y: 20,
+      width: 30,
+      height: 40,
+    };
+
+    expect(bandInterval(shape, 30, 40)).toEqual({ x0: 10, x1: 40 });
+  });
+
+  test('should return null when band is above rect', () => {
+    const shape: ExclusionShape = { x: 10, y: 20, width: 30, height: 40 };
+
+    expect(bandInterval(shape, 0, 20)).toBeNull();
+  });
+
+  test('should return null when band is below rect', () => {
+    const shape: ExclusionShape = { x: 10, y: 20, width: 30, height: 40 };
+
+    expect(bandInterval(shape, 60, 80)).toBeNull();
+  });
+
+  test('should return full ellipse width when band contains center', () => {
+    const shape: ExclusionShape = {
+      type: 'ellipse',
+      cx: 50,
+      cy: 50,
+      rx: 20,
+      ry: 10,
+    };
+
+    expect(bandInterval(shape, 45, 55)).toEqual({ x0: 30, x1: 70 });
+  });
+
+  test('should narrow ellipse interval away from center', () => {
+    const shape: ExclusionShape = {
+      type: 'ellipse',
+      cx: 50,
+      cy: 50,
+      rx: 20,
+      ry: 10,
+    };
+
+    // widest band y is 55, half height below center
+    const interval = bandInterval(shape, 55, 65);
+    const halfWidth = 20 * Math.sqrt(1 - 0.5 ** 2);
+
+    expect(interval.x0).toBeCloseTo(50 - halfWidth);
+    expect(interval.x1).toBeCloseTo(50 + halfWidth);
+  });
+
+  test('should return null when band misses ellipse', () => {
+    const shape: ExclusionShape = {
+      type: 'ellipse',
+      cx: 50,
+      cy: 50,
+      rx: 20,
+      ry: 10,
+    };
+
+    expect(bandInterval(shape, 0, 40)).toBeNull();
+    expect(bandInterval(shape, 60, 100)).toBeNull();
+  });
+
+  test('should return null for tangent ellipse band', () => {
+    const shape: ExclusionShape = {
+      type: 'ellipse',
+      cx: 50,
+      cy: 50,
+      rx: 20,
+      ry: 10,
+    };
+
+    expect(bandInterval(shape, 30, 40)).toBeNull();
+  });
+
+  test('should return triangle extent within band', () => {
+    const shape: ExclusionShape = {
+      type: 'polygon',
+      points: [
+        { x: 50, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ],
+    };
+
+    // triangle is widest at the band bottom y=50, where edges sit at x=25 and x=75
+    expect(bandInterval(shape, 40, 50)).toEqual({ x0: 25, x1: 75 });
+  });
+
+  test('should include polygon vertices inside band', () => {
+    const shape: ExclusionShape = {
+      type: 'polygon',
+      points: [
+        { x: 50, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ],
+    };
+
+    expect(bandInterval(shape, 90, 110)).toEqual({ x0: 0, x1: 100 });
+  });
+
+  test('should return null when band misses polygon', () => {
+    const shape: ExclusionShape = {
+      type: 'polygon',
+      points: [
+        { x: 50, y: 0 },
+        { x: 100, y: 100 },
+        { x: 0, y: 100 },
+      ],
+    };
+
+    expect(bandInterval(shape, 110, 120)).toBeNull();
+  });
+
+  test('should span band crossing polygon entirely', () => {
+    const shape: ExclusionShape = {
+      type: 'polygon',
+      points: [
+        { x: 40, y: 20 },
+        { x: 60, y: 20 },
+        { x: 60, y: 80 },
+        { x: 40, y: 80 },
+      ],
+    };
+
+    expect(bandInterval(shape, 40, 50)).toEqual({ x0: 40, x1: 60 });
+  });
+});


### PR DESCRIPTION
## Summary

Generalizes textkit's line exclusion support from rects to shapes, as groundwork for CSS `shape-outside`. Text now follows ellipse and polygon contours line by line.

- **Breaking**: `Container.excludeRects` → `Container.exclusions`, typed `ExclusionShape[]` — a union of rect (`type` optional), ellipse (`cx/cy/rx/ry`; circles are `rx === ry`), and polygon (`points`)
- New `shape/bandInterval.ts`: for a horizontal line band `[y0, y1]`, returns the x-interval the shape occupies (ellipse evaluated at its widest y within the band; polygon via vertices in band + edge crossings)
- Optional `extend: 'left' | 'right'` per shape stretches the exclusion to the line edge on the float side, so text never flows between a floated shape and its own margin edge
- `generateLineRects` algorithm unchanged — it now subtracts band intervals instead of raw rect edges
- Layout updated to pass the renamed prop; behavior identical for existing rect floats

## Follow-up (separate PR)

Wire `shape-outside` through stylesheet/layout: parse `circle()`/`ellipse()`/`inset()`/`polygon()`, resolve percentages against the float margin box, set `extend` from float side, `shape-margin`.

## Test plan

- New unit tests: `tests/shape/bandInterval.test.ts` (12), `tests/layout/generateLineRects.test.ts` (6)
- textkit 813/813, layout 481/481, renderer 108/108 including all float visual snapshots (pixel-identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)