### PR TITLE
fix(render): checkbox rendering crashes with upstream pdfkit (initDeflate)

### DIFF
--- a/.changeset/forms-initdeflate-fix.md
+++ b/.changeset/forms-initdeflate-fix.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/render': patch
+---
+
+Fix `appearance.initDeflate is not a function` when rendering checkboxes with upstream pdfkit

--- a/packages/render/src/utils/parseFormOptions.ts
+++ b/packages/render/src/utils/parseFormOptions.ts
@@ -75,8 +75,6 @@ const getAppearance = (
     },
   });
 
-  appearance.initDeflate();
-
   appearance.write(
     `/Tx BMC\nq\n/ZaDi ${height * 0.8} Tf\nBT\n${width * 0.45} ${
       height / 4

--- a/packages/render/tests/primitives/renderForm.test.ts
+++ b/packages/render/tests/primitives/renderForm.test.ts
@@ -82,7 +82,6 @@ describe('primitive renderCheckbox', () => {
     const ctx = createCTX();
     ctx._acroform = { fonts: {} };
     ctx.ref = vi.fn(() => ({
-      initDeflate: vi.fn(),
       write: vi.fn(),
       end: vi.fn(),
     }));


### PR DESCRIPTION
## Summary

Rendering a `Checkbox` (e.g. the forms example) crashes with `appearance.initDeflate is not a function` since the swap to upstream pdfkit (#3509). `initDeflate` was a streaming-deflate API that only existed in the `@react-pdf/pdfkit` fork — upstream's `PDFReference` compresses stream content automatically in `finalize()`, so the call is simply removed along with its test mock. Verified end-to-end: the forms document renders without error and checked-checkbox appearance streams draw correctly; all render package tests pass. Includes a patch changeset for `@react-pdf/render`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)