### PR TITLE
chore(examples): load vite config in vite dev server

### DIFF
--- a/packages/examples/vite/package.json
+++ b/packages/examples/vite/package.json
@@ -7,8 +7,8 @@
   "homepage": "https://github.com/diegomura/react-pdf#readme",
   "repository": "git@github.com:diegomura/react-pdf.git",
   "scripts": {
-    "dev": "vite ./src --open",
-    "build:site": "vite build ./src"
+    "dev": "vite --open",
+    "build:site": "vite build"
   },
   "dependencies": {
     "@react-pdf/math": "^4.0.0",

--- a/packages/examples/vite/vite.config.js
+++ b/packages/examples/vite/vite.config.js
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  root: 'src',
   plugins: [react()],
 });


### PR DESCRIPTION
## What

`packages/examples/vite` ran the dev server as `vite ./src`, which sets the Vite root to `src/`. Vite only looks for `vite.config.js` **inside the root** — it never walks up to the package directory. So the config was silently ignored:

```
vite:config no config file found.
```

`@vitejs/plugin-react` therefore never loaded, meaning no Fast Refresh while working on examples.

## Change

Move `root: 'src'` into the config and drop the path argument from the scripts. Verified the plugin now loads (`vite:react-babel`, `vite:react-refresh` in the resolved plugin list) with the root unchanged, and `vite build` still emits to the same place.

## Note

Examples default-export `{ id, name, Document }` rather than a component, so Fast Refresh still bails with `Could not Fast Refresh` and falls back to a full page reload. That's a separate cleanup across 29 files, not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)