### PR TITLE
chore(examples): tighten drop cap and justify text in float example

### DIFF
--- a/packages/examples/vite/src/examples/float/index.tsx
+++ b/packages/examples/vite/src/examples/float/index.tsx
@@ -75,6 +75,7 @@ const styles = StyleSheet.create({
   text: {
     fontSize: 10,
     color: '#333333',
+    textAlign: 'justify',
   },
   image: {
     borderRadius: 4,
@@ -153,8 +154,15 @@ const FloatExample = () => (
       <View style={styles.card}>
         <Text style={styles.label}>float: left — drop cap</Text>
         <View style={{ minHeight: 58 }}>
-          <View style={{ float: 'left', marginRight: 6 }}>
-            <Text style={{ fontSize: 42, fontWeight: 700, color: BLUE }}>
+          <View style={{ float: 'left', marginRight: 6, marginTop: -10 }}>
+            <Text
+              style={{
+                fontSize: 42,
+                lineHeight: 1,
+                fontWeight: 700,
+                color: BLUE,
+              }}
+            >
               A
             </Text>
           </View>


### PR DESCRIPTION
Small visual tweaks to the float specimen:

- Justify the body text so the wrap edges against floats read cleanly.
- Set `lineHeight: 1` on the drop cap and pull it up with `marginTop: -10` so the "A" aligns with the first line instead of sitting low.

🤖 Generated with [Claude Code](https://claude.com/claude-code)