### PR TITLE
perf(textkit): merge flattened run attributes lazily

### DIFF
--- a/.changeset/lazy-flatten-merge.md
+++ b/.changeset/lazy-flatten-merge.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/textkit': patch
+---
+
+perf: merge run attributes lazily in flatten, only when a segment is emitted

--- a/packages/textkit/src/run/flatten.ts
+++ b/packages/textkit/src/run/flatten.ts
@@ -74,17 +74,19 @@ const flattenRegularRuns = (runs: Run[]) => {
   const points = generatePoints(runs);
 
   let start = -1;
-  let attrs = {};
-  const stack = [];
+  const stack: Attributes[] = [];
 
   for (let i = 0; i < points.length; i += 1) {
     const [type, offset, attributes] = points[i];
 
+    // Merging the active attributes only when a segment is emitted avoids
+    // rebuilding them on every point, most wastefully when several runs
+    // end at the same offset and no segment follows.
     if (start !== -1 && start < offset) {
       res.push({
         start,
         end: offset,
-        attributes: attrs,
+        attributes: Object.assign({}, ...stack),
         stringIndices: [],
         glyphIndices: [],
         glyphs: [],
@@ -94,16 +96,9 @@ const flattenRegularRuns = (runs: Run[]) => {
 
     if (type === 'start') {
       stack.push(attributes);
-      attrs = Object.assign({}, attrs, attributes);
     } else {
-      attrs = {};
-
       for (let j = 0; j < stack.length; j += 1) {
-        if (stack[j] === attributes) {
-          stack.splice(j--, 1);
-        } else {
-          attrs = Object.assign({}, attrs, stack[j]);
-        }
+        if (stack[j] === attributes) stack.splice(j--, 1);
       }
     }
 


### PR DESCRIPTION
Follow-up to #3523. `flattenRegularRuns` was the top remaining textkit hotspot (7.7% of a text-heavy render profile) because it eagerly rebuilt the merged attribute object at every sweep event — on each run-end it re-merged the whole remaining stack, and when several runs end at the same offset (every single-style paragraph) those rebuilt objects were discarded without ever being emitted. Since the maintained value is always `merge(stack)`, this computes the merge once per emitted segment instead, preserving exact semantics including duplicate-reference removal and empty-stack gap segments. The function drops from 7.7% to 1.8% of the profile (~5% end-to-end on a 60-page document) with byte-identical PDF output; textkit (817), layout (493), and renderer (112, incl. visual snapshots) suites pass. Includes a patch changeset for `@react-pdf/textkit`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)