### PR TITLE
perf(textkit/font): drop omit('font') pass, trim Knuth-Plass, cache AFM lookups

### DIFF
--- a/.changeset/proud-donuts-argue.md
+++ b/.changeset/proud-donuts-argue.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/textkit': patch
+'@react-pdf/font': patch
+---
+
+perf: drop the omit('font') preprocessing pass, skip attachment purging when no attachment is set, reduce allocations in the Knuth-Plass main loop, and cache standard font AFM glyph-name lookups

--- a/packages/font/src/standard-font.ts
+++ b/packages/font/src/standard-font.ts
@@ -69,6 +69,7 @@ const openStandardFont = (src: string) => {
 class StandardFont implements Font {
   name: string;
   src: any;
+  glyphNames = new Map<number, string>();
   fullName: string;
   familyName: string;
   subfamilyName: string;
@@ -155,12 +156,23 @@ class StandardFont implements Font {
     return glyph;
   }
 
+  glyphName(id: number) {
+    let name = this.glyphNames.get(id);
+
+    if (name === undefined) {
+      name = this.src.font.characterToGlyph(id) as string;
+      this.glyphNames.set(id, name);
+    }
+
+    return name;
+  }
+
   getGlyph(id: number): fontkit.Glyph {
     return {
       id,
       codePoints: [id],
       isLigature: false,
-      name: this.src.font.characterToGlyph(id),
+      name: this.glyphName(id),
       _font: this.src,
       // @ts-expect-error assign proper value
       advanceWidth: undefined,
@@ -168,7 +180,7 @@ class StandardFont implements Font {
   }
 
   hasGlyphForCodePoint(codePoint: number) {
-    return this.src.font.characterToGlyph(codePoint) !== '.notdef';
+    return this.glyphName(codePoint) !== '.notdef';
   }
 
   // Based on empirical observation

--- a/packages/textkit/src/engines/linebreaker/knuthPlass.ts
+++ b/packages/textkit/src/engines/linebreaker/knuthPlass.ts
@@ -166,6 +166,15 @@ const linebreak = (
     new LinkedList.Node(breakpoint(0, 0, 0, 0, undefined, null)),
   );
 
+  // Candidates for each fitness class, reset per active-node group. Reused
+  // across iterations to avoid allocating in the algorithm's hottest loop.
+  const candidates = [
+    { active: undefined, demerits: Infinity },
+    { active: undefined, demerits: Infinity },
+    { active: undefined, demerits: Infinity },
+    { active: undefined, demerits: Infinity },
+  ];
+
   // The main loop of the algorithm
   function mainLoop(node: Node, index: number, nodes: Node[]) {
     let active = activeNodes.first();
@@ -177,13 +186,10 @@ const linebreak = (
     while (active !== null) {
       let currentLine = 0;
 
-      // Candidates fo each fitness class
-      const candidates = [
-        { active: undefined, demerits: Infinity },
-        { active: undefined, demerits: Infinity },
-        { active: undefined, demerits: Infinity },
-        { active: undefined, demerits: Infinity },
-      ];
+      for (let i = 0; i < candidates.length; i += 1) {
+        candidates[i].active = undefined;
+        candidates[i].demerits = Infinity;
+      }
 
       // Iterate through the linked list of active nodes to find new potential active nodes and deactivate current active nodes.
       while (active !== null) {
@@ -213,26 +219,21 @@ const linebreak = (
         // If the ratio is within the valid range of -1 <= ratio <= tolerance calculate the
         // total demerits and record a candidate active node.
         if (ratio >= -1 && ratio <= options.tolerance) {
-          const badness = 100 * Math.pow(Math.abs(ratio), 3);
+          const absRatio = Math.abs(ratio);
+          const badness = 100 * absRatio * absRatio * absRatio;
+          const lineDemerits = options.demerits.line + badness;
 
-          let demerits = 0;
+          let demerits = lineDemerits * lineDemerits;
 
           // Positive penalty
           if (node.type === 'penalty' && node.penalty >= 0) {
-            demerits =
-              Math.pow(options.demerits.line + badness, 2) +
-              Math.pow(node.penalty, 2);
+            demerits += node.penalty * node.penalty;
             // Negative penalty but not a forced break
           } else if (
             node.type === 'penalty' &&
             node.penalty !== -linebreak.infinity
           ) {
-            demerits =
-              Math.pow(options.demerits.line + badness, 2) -
-              Math.pow(node.penalty, 2);
-            // All other cases
-          } else {
-            demerits = Math.pow(options.demerits.line + badness, 2);
+            demerits -= node.penalty * node.penalty;
           }
 
           if (
@@ -268,7 +269,8 @@ const linebreak = (
 
           // Only store the best candidate for each fitness class
           if (demerits < candidates[currentClass].demerits) {
-            candidates[currentClass] = { active, demerits };
+            candidates[currentClass].active = active;
+            candidates[currentClass].demerits = demerits;
           }
         }
 
@@ -317,27 +319,22 @@ const linebreak = (
     }
   }
 
-  nodes.forEach((node, index, nodes) => {
+  for (let index = 0; index < nodes.length; index += 1) {
+    const node = nodes[index];
+
     if (node.type === 'box') {
       sum.width += node.width;
-      return;
-    }
-
-    if (node.type === 'glue') {
+    } else if (node.type === 'glue') {
       const precedesBox = index > 0 && nodes[index - 1].type === 'box';
       if (precedesBox) mainLoop(node, index, nodes);
 
       sum.width += node.width;
       sum.stretch += node.stretch;
       sum.shrink += node.shrink;
-
-      return;
-    }
-
-    if (node.type === 'penalty' && node.penalty !== linebreak.infinity) {
+    } else if (node.type === 'penalty' && node.penalty !== linebreak.infinity) {
       mainLoop(node, index, nodes);
     }
-  });
+  }
 
   return findBestBreakpoints(activeNodes);
 };

--- a/packages/textkit/src/layout/layoutParagraph.ts
+++ b/packages/textkit/src/layout/layoutParagraph.ts
@@ -23,7 +23,11 @@ const purgeAttachments = (line: AttributedString) => {
 
   if (!shouldPurge) return line;
 
-  const runs = line.runs.map((run) => omit('attachment', run));
+  // applyDefaultStyles materializes `attachment: null` on every run, so only
+  // pay for the omit copy when an attachment is actually set.
+  const runs = line.runs.map((run) =>
+    run.attributes?.attachment ? omit('attachment', run) : run,
+  );
 
   return Object.assign({}, line, { runs });
 };

--- a/packages/textkit/src/layout/preprocessRuns.ts
+++ b/packages/textkit/src/layout/preprocessRuns.ts
@@ -1,20 +1,9 @@
 import { isNil } from '@react-pdf/fns';
 
-import omit from '../run/omit';
 import flatten from '../run/flatten';
 import empty from '../attributedString/empty';
 import { AttributedString } from '../types';
 import type { Engines } from '../engines';
-
-/**
- *
- * @param attributedString
- * @returns Attributed string without font
- */
-const omitFont = (attributedString: AttributedString): AttributedString => {
-  const runs = attributedString.runs.map((run) => omit('font', run));
-  return Object.assign({}, attributedString, { runs });
-};
 
 type ProcessRunsEngines = Pick<
   Engines,
@@ -37,15 +26,14 @@ const preprocessRuns = (engines: ProcessRunsEngines) => {
     const { string } = attributedString;
     const { fontSubstitution, scriptItemizer, bidi } = engines;
 
-    const { runs: omittedFontRuns } = omitFont(attributedString);
     const { runs: itemizationRuns } = scriptItemizer()(attributedString);
     const { runs: substitutedRuns } = fontSubstitution()(attributedString);
     const { runs: bidiRuns } = bidi()(attributedString);
 
-    const runs = bidiRuns
-      .concat(substitutedRuns)
+    const runs = attributedString.runs
+      .concat(bidiRuns)
       .concat(itemizationRuns)
-      .concat(omittedFontRuns);
+      .concat(substitutedRuns);
 
     return { string, runs: flatten(runs) } as AttributedString;
   };


### PR DESCRIPTION
Third round of text-stack perf work after #3523/#3524 (supersedes #3526, which can be closed). `preprocessRuns` no longer strips `font` from every base run: reordering the flatten concat so substitution runs merge last gives the resolved font the same precedence with zero copies, and removes `omit`'s per-run `delete`, which pushed attribute objects into V8 dictionary mode and taxed every downstream read. `purgeAttachments` now skips its per-line run copy when no attachment is set, and the Knuth-Plass main loop reuses candidate slots, swaps `Math.pow` for multiplication, and drives the node scan with a plain loop (~45% faster). `StandardFont` caches AFM glyph-name lookups, which `fontSubstitution` was hitting once per code point of the document. Net: 60-page text benchmark warm median 379 → 320 ms (min 351 → 303 ms), byte-identical output, all suites green (textkit+font 868, layout 493, renderer 112 incl. visual snapshots); includes a patch changeset for both packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)