### PR TITLE
docs: normalize package README structure

### DIFF
--- a/packages/layout/README.md
+++ b/packages/layout/README.md
@@ -3,3 +3,25 @@
 </p>
 
 # @react-pdf/layout
+
+Layout engine for react-pdf. Takes the document element tree produced by the reconciler and resolves it into an absolutely positioned page tree: it parses styles, measures text with textkit, computes flexbox layout with Yoga, resolves images and SVG, and paginates content into fixed-size pages ready for rendering.
+
+## Installation
+
+```bash
+yarn add @react-pdf/layout
+```
+
+## Usage
+
+```js
+import layout from '@react-pdf/layout';
+
+const layoutTree = await layout(documentTree, fontStore);
+```
+
+The default export is an async function that composes the individual resolution steps (styles, inheritance, page sizes, Yoga layout, text layout, pagination, and so on) over a document root node and returns the fully resolved tree consumed by `@react-pdf/render`.
+
+## License
+
+MIT

--- a/packages/math/README.md
+++ b/packages/math/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://user-images.githubusercontent.com/5600341/27505816-c8bc37aa-587f-11e7-9a86-08a2d081a8b9.png" height="280px">
+</p>
+
 # @react-pdf/math
 
 Render LaTeX math expressions in [react-pdf](https://github.com/diegomura/react-pdf) documents.
@@ -7,15 +11,13 @@ Uses [MathJax](https://www.mathjax.org/) to convert LaTeX into SVG paths, then m
 ## Installation
 
 ```bash
-npm install @react-pdf/math
-# or
 yarn add @react-pdf/math
 ```
 
 Peer dependencies:
 
 ```bash
-npm install @react-pdf/renderer react
+yarn add @react-pdf/renderer react
 ```
 
 ## Usage

--- a/packages/reconciler/README.md
+++ b/packages/reconciler/README.md
@@ -3,3 +3,30 @@
 </p>
 
 # @react-pdf/reconciler
+
+React fiber reconciler for react-pdf. Turns React elements into the internal element tree consumed by the layout engine. Detects the installed React version at runtime and picks a compatible reconciler build, supporting React 18 and earlier, React 19, and React 19.2+.
+
+## Installation
+
+```bash
+yarn add @react-pdf/reconciler
+```
+
+## Usage
+
+```js
+import createRenderer from '@react-pdf/reconciler';
+
+const renderer = createRenderer({
+  appendChild,
+  createInstance,
+  createTextInstance,
+  // ...remaining host config callbacks
+});
+```
+
+The factory receives the host config callbacks that build and mutate the element tree, and returns a `react-reconciler` instance.
+
+## License
+
+MIT

--- a/packages/render/README.md
+++ b/packages/render/README.md
@@ -6,9 +6,9 @@
 
 > React-pdf render engine
 
-## How to install
+## Installation
 
-```sh
+```bash
 yarn add @react-pdf/render
 ```
 
@@ -142,4 +142,4 @@ ctx.pipe(stream);
 
 ## License
 
-MIT © [Diego Muracciole](http://github.com/diegomura)
+MIT

--- a/packages/svg/README.md
+++ b/packages/svg/README.md
@@ -1,23 +1,5 @@
 <p align="center">
   <img src="https://user-images.githubusercontent.com/5600341/27505816-c8bc37aa-587f-11e7-9a86-08a2d081a8b9.png" height="280px">
-  <p align="center">React renderer for creating PDF files on the browser and server<p>
-  <p align="center">
-    <a href="https://www.npmjs.com/package/@react-pdf/renderer">
-      <img src="https://img.shields.io/npm/v/@react-pdf/renderer?style=flat&colorA=000000&colorB=000000" />
-    </a>
-     <a href="https://opencollective.com/react-pdf">
-      <img src="https://img.shields.io/opencollective/all/react-pdf?style=flat&colorA=000000&colorB=000000" />
-    </a>
-    <a href="https://github.com/diegomura/react-pdf/blob/master/LICENSE">
-      <img src="https://img.shields.io/github/license/diegomura/react-pdf?style=flat&colorA=000000&colorB=000000" />
-    </a>
-    <a href="https://blockchain.com/btc/address/bc1qj223udztpmt5dck46dw0yap08yum63ht56h90v">
-      <img src="https://img.shields.io/badge/BTC-f5f5f5?style=flat&colorA=000000&colorB=000000" />
-    </a>
-     <a href="https://blockchain.com/eth/address/0x4e1DB76bA0858BbCAa4DD804418D0D9EcF77B1cC">
-      <img src="https://img.shields.io/badge/ETH-f5f5f5?style=flat&colorA=000000&colorB=000000" />
-    </a>
-  </p>
 </p>
 
 # @react-pdf/svg
@@ -29,8 +11,6 @@ Parses SVG markup into a tree of nodes compatible with react-pdf's SVG primitive
 ## Installation
 
 ```bash
-npm install @react-pdf/svg
-# or
 yarn add @react-pdf/svg
 ```
 

--- a/packages/types/README.md
+++ b/packages/types/README.md
@@ -6,12 +6,12 @@
 
 > React-pdf TypeScript definitions
 
-## How to install
+## Installation
 
-```sh
+```bash
 yarn add @react-pdf/types
 ```
 
 ## License
 
-MIT © [Diego Muracciole](http://github.com/diegomura)
+MIT


### PR DESCRIPTION
Brings all 16 package READMEs onto the same schema: logo header, `# @react-pdf/<name>` title, description, `## Installation` with a yarn block, and an `MIT` license footer. Replaces the renderer badge block mistakenly copied into `svg`, adds the missing logo header to `math`, and fleshes out the `layout`/`reconciler` stubs with a description, install, and usage section. Also renames "How to install" to "Installation" in `render`/`types` and normalizes their license lines. The flagship `renderer` README is intentionally left with its own layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)