### PR TITLE
feat: add conformance Document prop for PDF/A output

### DIFF
--- a/.changeset/tall-lions-hammer.md
+++ b/.changeset/tall-lions-hammer.md
@@ -1,0 +1,9 @@
+---
+'@react-pdf/types': minor
+'@react-pdf/layout': minor
+'@react-pdf/renderer': minor
+---
+
+feat: add `conformance` Document prop for PDF/A output
+
+Produces PDF/A-1/2/3 (b-level) output with XMP conformance metadata and an sRGB OutputIntent. `pdfVersion` defaults to what the chosen level requires. Fonts must be registered (not the built-in standard 14) to fully validate.

--- a/packages/layout/src/types/document.ts
+++ b/packages/layout/src/types/document.ts
@@ -6,6 +6,14 @@ import { SafeStyle, StyleProp } from '@react-pdf/stylesheet';
 
 export type PDFVersion = '1.3' | '1.4' | '1.5' | '1.6' | '1.7' | '1.7ext3';
 
+export type PDFConformance =
+  | 'PDF/A-1'
+  | 'PDF/A-1b'
+  | 'PDF/A-2'
+  | 'PDF/A-2b'
+  | 'PDF/A-3'
+  | 'PDF/A-3b';
+
 export type PageLayout =
   | 'singlePage'
   | 'oneColumn'
@@ -48,6 +56,7 @@ export type DocumentProps = {
   creationDate?: Date;
   modificationDate?: Date;
   pdfVersion?: PDFVersion;
+  conformance?: PDFConformance;
   pageMode?: PageMode;
   pageLayout?: PageLayout;
   ownerPassword?: string;

--- a/packages/renderer/index.d.ts
+++ b/packages/renderer/index.d.ts
@@ -7,6 +7,7 @@ import {
   PageSize,
   FontStore,
   PDFVersion,
+  PDFConformance,
   Orientation,
   SourceObject,
   SrcSet,
@@ -55,6 +56,7 @@ declare namespace ReactPDF {
     creationDate?: Date;
     modificationDate?: Date;
     pdfVersion?: PDFVersion;
+    conformance?: PDFConformance;
     pageMode?: PageMode;
     pageLayout?: PageLayout;
     ownerPassword?: string;

--- a/packages/renderer/src/index.js
+++ b/packages/renderer/src/index.js
@@ -39,6 +39,7 @@ const pdf = (initialValue) => {
     const props = container.document.props || {};
     const {
       pdfVersion,
+      conformance,
       language,
       pageLayout,
       pageMode,
@@ -55,9 +56,17 @@ const pdf = (initialValue) => {
       permissions,
     } = props;
 
+    // PDF/A-1 requires PDF 1.4; PDF/A-2/3 require PDF 1.7. pdfkit defaults
+    // to 1.3, which skips writing the metadata that marks the file as PDF/A.
+    const conformancePdfVersion = conformance?.startsWith('PDF/A-1')
+      ? '1.4'
+      : '1.7';
+
     const ctx = new PDFDocument({
       compress,
-      pdfVersion,
+      subset: conformance,
+      pdfVersion:
+        pdfVersion || (conformance ? conformancePdfVersion : undefined),
       lang: language,
       displayTitle: true,
       autoFirstPage: false,

--- a/packages/renderer/tests/conformance.test.jsx
+++ b/packages/renderer/tests/conformance.test.jsx
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+
+import ReactPDF from '../src/node';
+
+const { Document, Page, View } = ReactPDF;
+
+const TestDocument = ({ conformance }) => (
+  <Document conformance={conformance}>
+    <Page>
+      <View style={{ width: 20, height: 20, backgroundColor: 'red' }} />
+    </Page>
+  </Document>
+);
+
+describe('conformance', () => {
+  test('should render PDF/A-1b document as PDF 1.4 with conformance metadata', async () => {
+    const document = await ReactPDF.renderToString(
+      <TestDocument conformance="PDF/A-1b" />,
+    );
+
+    expect(document.indexOf('%PDF-1.4')).toBe(0);
+    expect(document).toContain('<pdfaid:part>1</pdfaid:part>');
+    expect(document).toContain('<pdfaid:conformance>B</pdfaid:conformance>');
+    expect(document).toContain('/OutputIntents');
+  });
+
+  test('should render PDF/A-2b document as PDF 1.7 with conformance metadata', async () => {
+    const document = await ReactPDF.renderToString(
+      <TestDocument conformance="PDF/A-2b" />,
+    );
+
+    expect(document.indexOf('%PDF-1.7')).toBe(0);
+    expect(document).toContain('<pdfaid:part>2</pdfaid:part>');
+    expect(document).toContain('<pdfaid:conformance>B</pdfaid:conformance>');
+  });
+
+  test('should respect explicit pdfVersion over conformance default', async () => {
+    const document = await ReactPDF.renderToString(
+      <Document conformance="PDF/A-3b" pdfVersion="1.6">
+        <Page>
+          <View style={{ width: 20, height: 20 }} />
+        </Page>
+      </Document>,
+    );
+
+    expect(document.indexOf('%PDF-1.6')).toBe(0);
+    expect(document).toContain('<pdfaid:part>3</pdfaid:part>');
+  });
+});

--- a/packages/types/pdf.d.ts
+++ b/packages/types/pdf.d.ts
@@ -1,1 +1,9 @@
 export type PDFVersion = '1.3' | '1.4' | '1.5' | '1.6' | '1.7' | '1.7ext3';
+
+export type PDFConformance =
+  | 'PDF/A-1'
+  | 'PDF/A-1b'
+  | 'PDF/A-2'
+  | 'PDF/A-2b'
+  | 'PDF/A-3'
+  | 'PDF/A-3b';


### PR DESCRIPTION
Adds a `conformance` prop to `<Document />` that passes through to upstream pdfkit's subset machinery, producing PDF/A-1/2/3 (b-level) output with XMP conformance metadata and an sRGB OutputIntent. When `pdfVersion` is not set explicitly, it defaults to what the chosen level requires (1.4 for PDF/A-1, 1.7 for PDF/A-2/3) — pdfkit's 1.3 default would otherwise silently drop the metadata that marks the file as PDF/A. Only b levels are exposed for now; a levels and PDF/UA need tagged output, so the `PDFConformance` union extends once that lands. Note that fully validating PDF/A requires registered (embedded) fonts, not the built-in standard 14. Includes tests and a changeset.

Closes #1520
Refs #3179, #2924

🤖 Generated with [Claude Code](https://claude.com/claude-code)