### PR TITLE
fix(mermaid): render inside Web Workers and honor the theme prop

### DIFF
--- a/.changeset/khaki-hoops-repeat.md
+++ b/.changeset/khaki-hoops-repeat.md
@@ -1,0 +1,7 @@
+---
+'@react-pdf/mermaid': patch
+---
+
+Fix rendering inside a Web Worker. elkjs read `self` without `document` as "I am the elk worker script", hijacked the host's `onmessage` and exported no layout engine, so the first diagram threw.
+
+Fix `theme` prop being ignored. Named themes are palettes in beautiful-mermaid, not a render option, so they are now expanded into colors before rendering.

--- a/.changeset/khaki-hoops-repeat.md
+++ b/.changeset/khaki-hoops-repeat.md
@@ -2,6 +2,6 @@
 '@react-pdf/mermaid': patch
 ---
 
-Fix rendering inside a Web Worker. elkjs read `self` without `document` as "I am the elk worker script", hijacked the host's `onmessage` and exported no layout engine, so the first diagram threw.
+Fix diagrams failing to render inside a Web Worker.
 
-Fix `theme` prop being ignored. Named themes are palettes in beautiful-mermaid, not a render option, so they are now expanded into colors before rendering.
+Fix the `theme` prop being ignored.

--- a/packages/mermaid/src/Mermaid.tsx
+++ b/packages/mermaid/src/Mermaid.tsx
@@ -1,6 +1,6 @@
 import { parseSvg } from '@react-pdf/svg';
 
-import { mermaidToSvg } from './render';
+import { mermaidToSvg, themeColors } from './render';
 import { preprocessSvg } from './preprocessSvg';
 import { mapSvgNode } from './mapSvg';
 import type { MermaidRenderOptions } from './render';
@@ -101,7 +101,7 @@ const Mermaid = ({
   theme,
   debug = false,
 }: MermaidProps) => {
-  const renderOptions: MermaidRenderOptions = {};
+  const renderOptions: MermaidRenderOptions = themeColors(theme);
 
   if (color) renderOptions.fg = color;
   if (bg) renderOptions.bg = bg;
@@ -111,19 +111,10 @@ const Mermaid = ({
   if (surface) renderOptions.surface = surface;
   if (border) renderOptions.border = border;
   if (transparent) renderOptions.transparent = transparent;
-  if (theme) renderOptions.theme = theme;
 
   const rawSvg = mermaidToSvg(children, renderOptions);
 
-  const svgString = preprocessSvg(rawSvg, {
-    fg: color,
-    bg,
-    accent,
-    line,
-    muted,
-    surface,
-    border,
-  });
+  const svgString = preprocessSvg(rawSvg, renderOptions);
 
   const svgTree = parseSvg(svgString);
 
@@ -135,7 +126,7 @@ const Mermaid = ({
   return mapSvgNode(svgTree, 'mermaid', {
     width: svgWidth ? Number(svgWidth) : undefined,
     height: svgHeight ? Number(svgHeight) : undefined,
-    color: color || 'black',
+    color: renderOptions.fg || 'black',
     debug,
   });
 };

--- a/packages/mermaid/src/render.ts
+++ b/packages/mermaid/src/render.ts
@@ -17,13 +17,11 @@ export function themeColors(theme?: string): MermaidRenderOptions {
 }
 
 /**
- * The layout engine behind mermaid, elkjs, reads its own globals to decide what
- * it is: `self` defined and no `document` means "I am the elk worker script", so
- * it hijacks `self.onmessage` and exports no in-process worker. Inside a Web
- * Worker that describes the host, not elk, and rendering throws — taking the
- * host's own message handling with it. A stub `document` sends elk down its
- * library branch, and an own writable `self` absorbs the restore beautiful-
- * mermaid does on the way out (a worker's `self` is getter-only).
+ * With `self` but no `document`, elkjs assumes it is running as its own worker
+ * script and takes over `onmessage` instead of laying out the diagram. A fake
+ * `document` keeps it in library mode. `self` is redefined as writable because
+ * beautiful-mermaid assigns to it on the way out, and in a real worker `self`
+ * is read-only.
  */
 function inWorkerScope<T>(fn: () => T): T {
   const scope = globalThis as { document?: unknown; self?: unknown };

--- a/packages/mermaid/src/render.ts
+++ b/packages/mermaid/src/render.ts
@@ -1,4 +1,4 @@
-import { renderMermaidSVG } from 'beautiful-mermaid';
+import { renderMermaidSVG, THEMES } from 'beautiful-mermaid';
 
 export interface MermaidRenderOptions {
   bg?: string;
@@ -9,12 +9,50 @@ export interface MermaidRenderOptions {
   surface?: string;
   border?: string;
   transparent?: boolean;
-  theme?: string;
+}
+
+/** Named themes are palettes, not a render option: expand them into colors. */
+export function themeColors(theme?: string): MermaidRenderOptions {
+  return theme ? { ...THEMES[theme] } : {};
+}
+
+/**
+ * The layout engine behind mermaid, elkjs, reads its own globals to decide what
+ * it is: `self` defined and no `document` means "I am the elk worker script", so
+ * it hijacks `self.onmessage` and exports no in-process worker. Inside a Web
+ * Worker that describes the host, not elk, and rendering throws — taking the
+ * host's own message handling with it. A stub `document` sends elk down its
+ * library branch, and an own writable `self` absorbs the restore beautiful-
+ * mermaid does on the way out (a worker's `self` is getter-only).
+ */
+function inWorkerScope<T>(fn: () => T): T {
+  const scope = globalThis as { document?: unknown; self?: unknown };
+  if (
+    typeof scope.document !== 'undefined' ||
+    typeof scope.self === 'undefined'
+  )
+    return fn();
+
+  const self = Object.getOwnPropertyDescriptor(scope, 'self');
+  scope.document = {};
+  Object.defineProperty(scope, 'self', {
+    value: scope,
+    writable: true,
+    configurable: true,
+  });
+
+  try {
+    return fn();
+  } finally {
+    delete scope.document;
+    if (self) Object.defineProperty(scope, 'self', self);
+    else delete scope.self;
+  }
 }
 
 export function mermaidToSvg(
   definition: string,
   options?: MermaidRenderOptions,
 ): string {
-  return renderMermaidSVG(definition, options as any);
+  return inWorkerScope(() => renderMermaidSVG(definition, options as any));
 }

--- a/packages/mermaid/tests/render.test.ts
+++ b/packages/mermaid/tests/render.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest';
+import { THEMES } from 'beautiful-mermaid';
+
+import { mermaidToSvg, themeColors } from '../src/render';
+
+const graph = 'graph LR\n  A --> B --> C';
+
+describe('themeColors', () => {
+  test('expands a named theme into its palette', () => {
+    expect(themeColors('nord')).toEqual(THEMES.nord);
+  });
+
+  test('is empty for no theme and for an unknown one', () => {
+    expect(themeColors()).toEqual({});
+    expect(themeColors('not-a-theme')).toEqual({});
+  });
+
+  test('hands back a copy, so overrides never leak into THEMES', () => {
+    const colors = themeColors('nord');
+    colors.fg = '#ff0000';
+
+    expect(THEMES.nord.fg).not.toBe('#ff0000');
+  });
+});
+
+// beautiful-mermaid takes colors, not a theme name: passing `theme` through
+// rendered every diagram in the default palette.
+describe('mermaidToSvg', () => {
+  test('paints the theme colors it is given', () => {
+    const svg = mermaidToSvg(graph, themeColors('nord'));
+
+    expect(svg).toContain(THEMES.nord.bg);
+    expect(svg).not.toBe(mermaidToSvg(graph, {}));
+  });
+});

--- a/packages/mermaid/tests/workerScope.test.ts
+++ b/packages/mermaid/tests/workerScope.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, expect, test } from 'vitest';
+
+import { mermaidToSvg } from '../src/render';
+
+const scope = globalThis as {
+  self?: unknown;
+  document?: unknown;
+  onmessage?: unknown;
+};
+
+/**
+ * A Web Worker is `self` without `document`, which is also how elkjs recognises
+ * its own worker script: it answers the host's messages and exports no layout
+ * engine, so the render throws. `self` there is a getter on the global's
+ * prototype — the detail that defeats beautiful-mermaid's own `delete self`
+ * guard — so the emulation puts it in the same place.
+ */
+const enterWorkerScope = () => {
+  Object.defineProperty(Object.getPrototypeOf(scope), 'self', {
+    get: () => scope,
+    configurable: true,
+  });
+};
+
+afterEach(() => {
+  delete (Object.getPrototypeOf(scope) as { self?: unknown }).self;
+  delete scope.self;
+});
+
+test('renders where `self` is a getter and `document` is not defined', () => {
+  enterWorkerScope();
+
+  expect(mermaidToSvg('graph LR\n  A --> B')).toContain('<svg');
+  expect(scope.onmessage).toBeUndefined();
+});
+
+test('leaves the scope as it found it', () => {
+  enterWorkerScope();
+
+  mermaidToSvg('graph LR\n  A --> B');
+
+  expect('document' in scope).toBe(false);
+  expect(Object.getOwnPropertyDescriptor(scope, 'self')).toBeUndefined();
+  expect(scope.self).toBe(scope);
+});


### PR DESCRIPTION
Two fixes to `@react-pdf/mermaid`, split out of the docs-site branch.

### Web Worker rendering

elkjs (the layout engine behind mermaid) decides what it is from globals: `self` defined and no `document` means "I am the elk worker script", so it hijacks `self.onmessage` and exports no in-process worker. Inside a Web Worker that describes the *host*, not elk, so the first diagram threw and took the host's message handling with it.

`inWorkerScope` stubs a `document` around the render call to send elk down its library branch, and defines an own writable `self` so the restore beautiful-mermaid does on the way out doesn't hit a worker's getter-only `self`. Both are torn down in a `finally`.

### `theme` prop

Named themes are palettes in beautiful-mermaid, not a render option, so passing `theme` did nothing. `themeColors` expands the name into colors before rendering, and those colors now also feed `preprocessSvg` and the fallback text color.

### Tests

`tests/workerScope.test.ts` simulates a worker global (no `document`, getter-only `self`) and asserts a diagram renders and the scope is restored. `tests/render.test.ts` covers theme expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)