### PR TITLE
feat(site): add sitemap, robots and OG image, take @react-pdf/ui from npm

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -49,15 +49,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
 
-      # The site takes @react-pdf/ui as `file:../../packages/ui`, and yarn packs
-      # it at install time from its `files` list, so lib/ has to exist first.
-      # Drops away once the package is published and this becomes a version range.
-      - name: Build @react-pdf/ui
-        working-directory: .
-        run: |
-          yarn install --frozen-lockfile
-          yarn --cwd packages/ui run build
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/apps/site/app/layout.tsx
+++ b/apps/site/app/layout.tsx
@@ -15,12 +15,22 @@ const mono = Geist_Mono({
 });
 
 export const metadata = {
+  metadataBase: new URL('https://react-pdf.org'),
   title: {
     template: '%s | react-pdf',
     default: 'react-pdf — PDFs, made with React',
   },
   description:
     'React renderer for creating PDF files on the browser and server.',
+  openGraph: {
+    type: 'website',
+    url: '/',
+    siteName: 'react-pdf',
+    title: 'react-pdf — PDFs, made with React',
+    description:
+      'React renderer for creating PDF files on the browser and server.',
+  },
+  twitter: { card: 'summary_large_image' },
   icons: {
     icon: [
       { url: '/favicon.ico', sizes: 'any' },

--- a/apps/site/app/opengraph-image.tsx
+++ b/apps/site/app/opengraph-image.tsx
@@ -1,0 +1,80 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { ImageResponse } from 'next/og';
+
+export const alt = 'react-pdf — PDFs, made with React';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+/**
+ * Geist reaches the site through next/font, which hands back a class name
+ * rather than bytes, and Satori needs bytes. Roboto is already in public/fonts
+ * for the docs examples.
+ */
+const font = (file: string) =>
+  readFileSync(join(process.cwd(), 'public/fonts', file));
+
+/** The hero's right-hand shard cluster, cropped out of its 1440x544 viewBox. */
+const SHARDS = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="1094 0 346 544">
+  <polygon points="1440,0 1198,0 1440,330" fill="rgba(242,35,0,0.32)"/>
+  <polygon points="1440,0 1310,0 1440,120" fill="rgba(141,22,2,0.30)"/>
+  <polygon points="1268,0 1198,0 1440,330 1440,392" fill="rgba(141,22,2,0.30)"/>
+  <polygon points="1198,0 1156,0 1416,412 1440,392" fill="rgba(255,255,255,0.78)"/>
+  <polygon points="1156,0 1120,0 1392,470 1416,412" fill="rgba(201,138,94,0.20)"/>
+  <polygon points="1120,0 1094,0 1370,544 1392,470" fill="rgba(255,255,255,0.78)"/>
+</svg>`;
+
+export default async function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+          padding: '0 88px',
+          background: 'hsl(36, 14%, 98%)',
+          color: 'hsl(0, 0%, 24.3%)',
+          fontFamily: 'Roboto',
+        }}
+      >
+        <img
+          src={`data:image/svg+xml;base64,${Buffer.from(SHARDS).toString('base64')}`}
+          width={400}
+          height={630}
+          style={{ position: 'absolute', top: 0, right: 0 }}
+        />
+        <div
+          style={{ display: 'flex', fontSize: 76, letterSpacing: '-0.03em' }}
+        >
+          <span style={{ fontWeight: 700 }}>PDFs,</span>
+          <span style={{ color: 'hsl(0, 0%, 43.1%)', margin: '0 18px' }}>
+            made with
+          </span>
+          <span style={{ fontWeight: 700, color: 'hsl(8.7, 100%, 45.5%)' }}>
+            React
+          </span>
+        </div>
+        <div
+          style={{
+            marginTop: 24,
+            fontSize: 30,
+            color: 'hsl(0, 0%, 43.1%)',
+            maxWidth: 540,
+          }}
+        >
+          React renderer for creating PDF files on the browser and server.
+        </div>
+      </div>
+    ),
+    {
+      ...size,
+      fonts: [
+        { name: 'Roboto', data: font('Roboto-Regular.ttf'), weight: 400 },
+        { name: 'Roboto', data: font('Roboto-Bold.ttf'), weight: 700 },
+      ],
+    },
+  );
+}

--- a/apps/site/app/robots.ts
+++ b/apps/site/app/robots.ts
@@ -1,0 +1,8 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: '*', allow: '/' },
+    sitemap: 'https://react-pdf.org/sitemap.xml',
+  };
+}

--- a/apps/site/app/sitemap.ts
+++ b/apps/site/app/sitemap.ts
@@ -1,0 +1,20 @@
+import type { MetadataRoute } from 'next';
+import { blogSource } from '@/lib/blog-source';
+import { latestPages } from '@/lib/llm-text';
+
+const SITE = 'https://react-pdf.org';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = [
+    '/',
+    '/playground',
+    '/blog',
+    '/changelog',
+    // only the latest docs: v1–v3 are still served, but listing them puts four
+    // pages in the index competing for every query
+    ...latestPages().map((page) => page.url),
+    ...blogSource.getPages().map((page) => page.url),
+  ];
+
+  return routes.map((route) => ({ url: new URL(route, SITE).href }));
+}

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -20,7 +20,7 @@
     "@react-pdf/math": "^5.0.1",
     "@react-pdf/mermaid": "^5.0.1",
     "@react-pdf/renderer": "^4.8.0",
-    "@react-pdf/ui": "file:../../packages/ui",
+    "@react-pdf/ui": "^0.1.0",
     "@uiw/react-codemirror": "^4.25.11",
     "codemirror": "^6.0.2",
     "fumadocs-core": "^16.15.1",

--- a/apps/site/vercel.json
+++ b/apps/site/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- . ../../packages"
+  "ignoreCommand": "git diff --quiet HEAD^ HEAD -- ."
 }

--- a/apps/site/yarn.lock
+++ b/apps/site/yarn.lock
@@ -1178,8 +1178,10 @@
     "@react-pdf/primitives" "^4.4.0"
     "@react-pdf/stylesheet" "^6.3.1"
 
-"@react-pdf/ui@file:../../packages/ui":
+"@react-pdf/ui@^0.1.0":
   version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@react-pdf/ui/-/ui-0.1.0.tgz#a9361e7d995bfdfa5bbae543eae98a4b7da69486"
+  integrity sha512-DFpUIIpn2VTIzYzFx78l8YtbkHpTNdyz/ZxHrkQAPM4zb4pvfkcYH4siwwGtv7DZtXq7i+kH8xgHJX+NGDEkLg==
   dependencies:
     jotai "^2.12.5"
     jotai-effect "^2.0.4"


### PR DESCRIPTION
Launch prep for pointing react-pdf.org at the new site. Adds `app/sitemap.ts` (latest docs only — listing v1–v3 too would put four versions of every page in the index competing for the same queries), `app/robots.ts`, and an `app/opengraph-image.tsx` built with `next/og` from the hero's own wordmark and shard graphic, plus the `metadataBase`/`openGraph`/`twitter` metadata that wires it up.

Now that `@react-pdf/ui` is on npm, the site takes it as a version range instead of `file:../../packages/ui`. That removes the CI step that installed and built the whole monorepo just so yarn had a `lib/` to pack, lets Vercel build with its default install command, and narrows `vercel.json`'s ignore check to `apps/site`.

Verified with a production build: all routes prerender, the published `@react-pdf/ui` tarball is byte-identical to a local build of master, and `/`, `/playground`, `/docs/v4`, `/changelog`, `/sitemap.xml` and `/opengraph-image` all serve 200 under `next start`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)