### PR TITLE
fix(examples): match bumped @react-pdf/tailwind version range

### DIFF
--- a/packages/examples/vite/package.json
+++ b/packages/examples/vite/package.json
@@ -17,7 +17,7 @@
     "@react-pdf/render": "^4.6.4",
     "@react-pdf/renderer": "^4.8.1",
     "@react-pdf/svgkit": "^0.0.0",
-    "@react-pdf/tailwind": "^0.0.0"
+    "@react-pdf/tailwind": "^0.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",


### PR DESCRIPTION
`1f73b94` bumped `packages/tailwind` to `0.1.0`, but the vite example still required `@react-pdf/tailwind: ^0.0.0`. Yarn stopped resolving it from the workspace, fell through to npm where the package isn't published, and `yarn --frozen-lockfile` failed on every CI and Release job on master. This widens the example's range to `^0.1.0`; verified locally with a clean frozen-lockfile install and full monorepo build, lockfile untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)