### PR TITLE
feat(site): add Tailwind docs page and playground example

### DIFF
--- a/.changeset/tailwind-playground-module.md
+++ b/.changeset/tailwind-playground-module.md
@@ -1,0 +1,5 @@
+---
+'@react-pdf/ui': patch
+---
+
+Allow playground code to import `@react-pdf/tailwind`, loaded lazily like the other optional packages

--- a/apps/site/content/docs/v4/meta.json
+++ b/apps/site/content/docs/v4/meta.json
@@ -24,6 +24,7 @@
     "styling",
     "floats",
     "fonts",
+    "tailwind",
     "---SVG---",
     "svg/svg",
     "svg/line",

--- a/apps/site/content/docs/v4/tailwind.mdx
+++ b/apps/site/content/docs/v4/tailwind.mdx
@@ -1,0 +1,120 @@
+---
+title: 'Tailwind'
+---
+
+The `@react-pdf/tailwind` package converts a compatible subset of the Tailwind CSS class syntax into style objects that react-pdf understands.
+
+## Installation
+
+```bash
+npm install @react-pdf/tailwind
+```
+
+## Usage
+
+```jsx
+import { Document, Page, Text, View } from '@react-pdf/renderer';
+import { createTw } from '@react-pdf/tailwind';
+
+// Apply your own styles on top of Tailwind defaults
+const tw = createTw({
+  fontFamily: {
+    sans: ['Papyrus'],
+  },
+  colors: {
+    custom: '#bada55',
+  },
+});
+
+const MyDocument = () => (
+  <Document>
+    <Page size="A4" style={tw('p-12 font-sans')}>
+      <View style={tw('p-20 bg-gray-100')}>
+        <Text style={tw('text-custom text-3xl')}>Section #1</Text>
+      </View>
+      <View style={tw('mt-12 px-8 rotate-2')}>
+        <Text style={tw('text-amber-600 text-2xl')}>Section #2</Text>
+      </View>
+    </Page>
+  </Document>
+);
+```
+
+<Example name="tailwind" />
+
+The returned `tw` function takes a space-separated class string and returns a react-pdf `Style` object. Unknown classes are skipped with a console warning, emitted once per distinct class.
+
+## createTw
+
+`createTw(config, options)` builds the `tw` function. `config` is a theme object merged into Tailwind's `defaultTheme`, following the Tailwind v4 theme shape — see [Tailwind's default theme](https://github.com/tailwindlabs/tailwindcss/blob/main/packages/tailwindcss/src/compat/default-theme.ts) for reference.
+
+```js
+const tw = createTw(
+  {
+    fontFamily: {
+      sans: ['Papyrus'],
+    },
+    spacing: {
+      verybig: '999rem',
+    },
+    colors: {
+      custom: '#bada55',
+    },
+  },
+  {
+    // Base font size in points. Defaults to 12.
+    ptPerRem: 12,
+  },
+);
+```
+
+Scales merge one level deep, so overriding a single key keeps the rest of the default scale — `spacing: { 4: '2rem' }` changes `p-4` while leaving `p-8` alone, and `colors: { gray: { 500: '#fff' } }` leaves the other grays intact. Replace a whole scale by overriding it with a non-object value.
+
+`fontFamily` is the exception: it comes from your config alone, neither merging with Tailwind's defaults nor falling back to them. react-pdf can only draw [fonts you have registered](/docs/v4/fonts), and Tailwind's stacks name web families like `-apple-system`, so resolving `font-sans` against them would throw at render time. Register a font, map it in the config, and `font-<key>` works; without a config, `font-sans` / `font-serif` / `font-mono` warn as unsupported while `font-bold` and friends still resolve.
+
+## Color opacity
+
+`bg-red-500/50` and friends work anywhere a color does — `bg-`, `text-`, `border-`, `decoration-` — including black, white, custom and arbitrary colors:
+
+```js
+tw('bg-red-500/50'); // { backgroundColor: '#ef444480' }
+tw('text-black/25'); // { color: '#00000040' }
+tw('bg-[#bada55]/60'); // { backgroundColor: '#bada5599' }
+```
+
+A bare suffix is a percentage; a bracketed one is `0`–`1` unless it carries a `%`, so `/[0.55]` and `/[55%]` agree. `transparent`, `currentColor` and `inherit` name no channel to modulate and reject the suffix.
+
+## Variants
+
+Breakpoint and orientation variants become react-pdf media queries, which resolve against the **page box** rather than a viewport:
+
+```js
+tw('p-2 lg:p-4 landscape:p-6');
+// {
+//   padding: 6,
+//   '@media min-width: 768': { padding: 12 },
+//   '@media orientation: landscape': { padding: 18 },
+// }
+```
+
+| Variant                        | Becomes                 |
+| ------------------------------ | ----------------------- |
+| `sm:` `md:` `lg:` `xl:` `2xl:` | `@media min-width: N`   |
+| `max-sm:` … `max-2xl:`         | `@media max-width: N`   |
+| `min-[600px]:` `max-[40rem]:`  | the width you give it   |
+| `portrait:` `landscape:`       | `@media orientation: …` |
+| stacked, e.g. `lg:portrait:`   | both, joined with `and` |
+
+Tailwind v4 states its breakpoints in rem, so at the default `1rem = 12pt` they land at page scale: `sm` is 480pt, `md` 576pt, `lg` 768pt, `xl` 960pt. An A4 page is 595pt wide upright and 842pt on its side, so `md` matches portrait and `lg` matches landscape. Set `screens` in the config to choose your own.
+
+State variants — `hover:`, `focus:`, `dark:`, `group-*`, `peer-*` — describe something a printed page never enters, and are reported as unsupported rather than applied. Applying them would bake the hover style into the output.
+
+## Notes
+
+- Supports the CSS properties that make sense in a PDF context and are supported by react-pdf — see [valid CSS properties](/docs/v4/styling#valid-css-properties).
+- Uses `pt` as the internal unit ([valid units](/docs/v4/styling#valid-units)), with `1rem = 12pt` by default. Change it with `ptPerRem`.
+- react-pdf uses [Yoga](https://yogalayout.dev/) for layout, so some defaults differ from the web — `flex-direction` defaults to `column`, for example. Add `flex-row` where you need it.
+- Line heights are emitted unitless, since react-pdf only supports unitless `lineHeight`.
+- `aspect-auto` and `line-clamp-none` warn as unsupported. react-pdf has no style value meaning "no aspect ratio" or "no clamp" — leaving the utility off is the reset.
+- Intrinsic sizing (`w-fit`, `h-min`, `max-w-max`, …), `max-w-none` / `max-h-none`, and lengths in units react-pdf can't parse (`max-w-prose` is `65ch`) warn as unsupported. Yoga has no equivalent, and passing the value through would throw while laying out the document.
+- `float-*` and `clear-*` map to react-pdf's [float support](/docs/v4/floats), which is newer and has rough edges: setting `lineHeight` on floated content breaks text wrap, and parents don't grow to contain their floats.

--- a/apps/site/lib/examples/index.ts
+++ b/apps/site/lib/examples/index.ts
@@ -39,6 +39,7 @@ import shape_outside from './shape-outside';
 import styles from './styles';
 import svg from './svg';
 import svgtext from './svgtext';
+import tailwind from './tailwind';
 import text from './text';
 import textinput from './textinput';
 
@@ -84,6 +85,7 @@ export const examples: Record<string, string> = {
   styles: styles,
   svg: svg,
   svgtext: svgtext,
+  tailwind: tailwind,
   text: text,
   textinput: textinput,
 };
@@ -98,7 +100,7 @@ const RULES: [string, RegExp][] = [
   ['Text & fonts', /text|font|hyphenation|emoji/],
   ['Layout & pagination', /page|break|orphans|widows|fixed|float|shape|wrap/],
   ['Images', /image/],
-  ['Advanced', /math|resume|knobs/],
+  ['Advanced', /math|resume|knobs|tailwind/],
 ];
 
 const FALLBACK = 'Essentials';

--- a/apps/site/lib/examples/tailwind.ts
+++ b/apps/site/lib/examples/tailwind.ts
@@ -1,0 +1,91 @@
+const tailwind = `import { createTw } from '@react-pdf/tailwind';
+
+// Tailwind's default font stacks name web families, so map the ones you use to
+// fonts react-pdf can draw
+const tw = createTw({
+  fontFamily: {
+    sans: ['Helvetica'],
+  },
+  colors: {
+    brand: '#4f46e5',
+  },
+});
+
+const Row = ({ item, qty, price, muted }) => (
+  <View style={tw(\`flex-row py-2 border-b \${muted ? 'border-gray-100' : 'border-gray-200'}\`)}>
+    <Text style={tw('flex-1 text-[10px] text-gray-800')}>{item}</Text>
+    <Text style={tw('w-16 text-[10px] text-right text-gray-500')}>{qty}</Text>
+    <Text style={tw('w-20 text-[10px] text-right text-gray-800')}>{price}</Text>
+  </View>
+);
+
+const doc = (
+  <Document>
+    <Page size="A4" style={tw('bg-white font-sans p-10 landscape:p-16')}>
+      <View style={tw('flex-row justify-between items-start pb-6 border-b-2 border-brand')}>
+        <View>
+          <Text style={tw('text-2xl font-bold text-gray-900')}>Invoice</Text>
+          <Text style={tw('mt-1 text-[10px] text-gray-400')}>#2026-0042</Text>
+        </View>
+        <View style={tw('items-end')}>
+          <Text style={tw('text-[10px] text-gray-500')}>Issued 28 Aug 2026</Text>
+          <Text style={tw('mt-1 text-[10px] text-gray-500')}>Due 27 Sep 2026</Text>
+        </View>
+      </View>
+
+      <View style={tw('flex-row gap-4 mt-6')}>
+        <View style={tw('flex-1 rounded-lg bg-brand/5 p-4')}>
+          <Text style={tw('text-[8px] uppercase tracking-wide text-brand')}>Billed to</Text>
+          <Text style={tw('mt-2 text-xs text-gray-900')}>Acme Corporation</Text>
+          <Text style={tw('mt-1 text-[10px] leading-normal text-gray-500')}>
+            120 Fifth Avenue{'\\n'}New York, NY 10011
+          </Text>
+        </View>
+        <View style={tw('flex-1 rounded-lg bg-gray-50 p-4')}>
+          <Text style={tw('text-[8px] uppercase tracking-wide text-gray-400')}>From</Text>
+          <Text style={tw('mt-2 text-xs text-gray-900')}>react-pdf studio</Text>
+          <Text style={tw('mt-1 text-[10px] leading-normal text-gray-500')}>
+            Rendered with @react-pdf/tailwind
+          </Text>
+        </View>
+      </View>
+
+      <View style={tw('mt-8')}>
+        <View style={tw('flex-row border-b border-gray-300 pb-2')}>
+          <Text style={tw('flex-1 text-[8px] uppercase tracking-wide text-gray-400')}>Description</Text>
+          <Text style={tw('w-16 text-[8px] uppercase tracking-wide text-right text-gray-400')}>Qty</Text>
+          <Text style={tw('w-20 text-[8px] uppercase tracking-wide text-right text-gray-400')}>Amount</Text>
+        </View>
+        <Row item="Design system audit" qty="1" price="$2,400.00" />
+        <Row item="Component library" qty="12" price="$4,800.00" muted />
+        <Row item="PDF templates" qty="6" price="$1,800.00" />
+        <Row item="Support retainer" qty="3" price="$900.00" muted />
+      </View>
+
+      <View style={tw('mt-6 flex-row justify-end')}>
+        <View style={tw('w-52')}>
+          <View style={tw('flex-row justify-between')}>
+            <Text style={tw('text-[10px] text-gray-500')}>Subtotal</Text>
+            <Text style={tw('text-[10px] text-gray-800')}>$9,900.00</Text>
+          </View>
+          <View style={tw('mt-1 flex-row justify-between')}>
+            <Text style={tw('text-[10px] text-gray-500')}>Tax (8.875%)</Text>
+            <Text style={tw('text-[10px] text-gray-800')}>$878.63</Text>
+          </View>
+          <View style={tw('mt-3 flex-row justify-between rounded-md bg-brand p-3')}>
+            <Text style={tw('text-xs font-bold text-white')}>Total</Text>
+            <Text style={tw('text-xs font-bold text-white')}>$10,778.63</Text>
+          </View>
+        </View>
+      </View>
+
+      <Text style={tw('mt-auto text-center text-[8px] text-gray-400')}>
+        Styled entirely with Tailwind classes, no StyleSheet in sight
+      </Text>
+    </Page>
+  </Document>
+);
+
+ReactPDF.render(doc);`;
+
+export default tailwind;

--- a/apps/site/package.json
+++ b/apps/site/package.json
@@ -20,6 +20,7 @@
     "@react-pdf/math": "^5.0.1",
     "@react-pdf/mermaid": "^5.0.1",
     "@react-pdf/renderer": "^4.8.0",
+    "@react-pdf/tailwind": "^0.1.0",
     "@react-pdf/ui": "^0.1.0",
     "@uiw/react-codemirror": "^4.25.11",
     "codemirror": "^6.0.2",

--- a/apps/site/yarn.lock
+++ b/apps/site/yarn.lock
@@ -1169,6 +1169,14 @@
     bidi-js "^1.0.2"
     unicode-properties "^1.4.1"
 
+"@react-pdf/tailwind@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@react-pdf/tailwind/-/tailwind-0.1.0.tgz#51a7aa4439b46826fd92912bbc7c1a457c2d734e"
+  integrity sha512-GUDesmIu+h4ZVQ21C1aXLjCFhpAzh/oFZy8OUUyddwlJnfD8oDoBaeALbWITLRk3vaxLxHP+cxdi2j21PEKDKw==
+  dependencies:
+    "@react-pdf/types" "^2.13.1"
+    tailwindcss "^4.1.12"
+
 "@react-pdf/types@^2.13.1":
   version "2.13.1"
   resolved "https://registry.yarnpkg.com/@react-pdf/types/-/types-2.13.1.tgz#d753d54ce53824ca137582544d2ec0b6c2f61961"
@@ -3606,7 +3614,7 @@ svg-arc-to-cubic-bezier@^3.0.0, svg-arc-to-cubic-bezier@^3.2.0:
   resolved "https://registry.yarnpkg.com/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz#390c450035ae1c4a0104d90650304c3bc814abe6"
   integrity sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==
 
-tailwindcss@4.3.3, tailwindcss@^4.0.0:
+tailwindcss@4.3.3, tailwindcss@^4.0.0, tailwindcss@^4.1.12:
   version "4.3.3"
   resolved "https://registry.yarnpkg.com/tailwindcss/-/tailwindcss-4.3.3.tgz#c006861611c213c1877893ab5b23daa16be2bb55"
   integrity sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,7 +30,8 @@
     "@react-pdf/renderer": ">=4.8.0",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
     "@react-pdf/math": ">=5.0.0",
-    "@react-pdf/mermaid": ">=5.0.0"
+    "@react-pdf/mermaid": ">=5.0.0",
+    "@react-pdf/tailwind": ">=0.1.0"
   },
   "devDependencies": {
     "@react-pdf/renderer": "^4.8.1"
@@ -40,6 +41,9 @@
       "optional": true
     },
     "@react-pdf/mermaid": {
+      "optional": true
+    },
+    "@react-pdf/tailwind": {
       "optional": true
     }
   }

--- a/packages/ui/src/render/render.ts
+++ b/packages/ui/src/render/render.ts
@@ -23,6 +23,7 @@ const joinFiles = (files: PlaygroundFile[]) =>
 const lazyModules: Record<string, () => Promise<unknown>> = {
   '@react-pdf/math': () => import('@react-pdf/math'),
   '@react-pdf/mermaid': () => import('@react-pdf/mermaid'),
+  '@react-pdf/tailwind': () => import('@react-pdf/tailwind'),
 };
 
 const loaded: Record<string, unknown> = {};


### PR DESCRIPTION
Adds a `Tailwind` page to the v4 docs covering installation, `createTw` usage, theme customization, and the supported class subset, plus a live playground example wired into the site's example index under "Advanced".

To make the playground actually run Tailwind snippets, `@react-pdf/ui` now lists `@react-pdf/tailwind` as an optional peer dependency and lazily imports it on demand, matching how `@react-pdf/math` and `@react-pdf/mermaid` are already handled. Consumers who never import it install nothing extra; if it's missing, the existing "cannot import" playground error surfaces as before. Includes a patch changeset for `@react-pdf/ui`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)