### PR TITLE
fix(site): fetch renderer changelog instead of reading it off disk

### DIFF
--- a/apps/site/lib/changelog/changelog.ts
+++ b/apps/site/lib/changelog/changelog.ts
@@ -1,8 +1,9 @@
-import { readFileSync } from 'node:fs';
-import path from 'node:path';
-
 export const CHANGELOG_URL =
   'https://github.com/diegomura/react-pdf/blob/master/packages/renderer/CHANGELOG.md';
+
+/** Fetched rather than read off disk: Vercel builds this app from apps/site alone. */
+const CHANGELOG_RAW_URL =
+  'https://raw.githubusercontent.com/diegomura/react-pdf/master/packages/renderer/CHANGELOG.md';
 
 /** Releases shown on the page; older ones live in the full changelog on GitHub. */
 export const RELEASE_LIMIT = 30;
@@ -88,10 +89,9 @@ async function fetchReleaseDates(): Promise<Record<string, string>> {
 }
 
 export async function getReleases(): Promise<Release[]> {
-  const markdown = readFileSync(
-    path.join(process.cwd(), '../../packages/renderer/CHANGELOG.md'),
-    'utf8',
-  );
+  const res = await fetch(CHANGELOG_RAW_URL, { next: { revalidate: 86400 } });
+  if (!res.ok) throw new Error(`Changelog fetch failed: ${res.status}`);
+  const markdown = await res.text();
   const dates = await fetchReleaseDates();
 
   return parseChangelog(markdown)


### PR DESCRIPTION
Vercel builds `apps/site` with that folder as the project root directory, so the sibling `packages/renderer/CHANGELOG.md` is not present at prerender time and `/changelog` failed the production build with `ENOENT`. This happens even with *Include source files outside of the Root Directory* enabled and the whole repo cloned.

`getReleases` now fetches the changelog from `raw.githubusercontent.com` instead of reading it off disk. Release dates still come from the npm registry, as before.

Side benefit: the page is served with `revalidate: 86400` from the inner `fetch`, so a background regeneration in a lambda used to be a latent `ENOENT` too. Over the network it works in both places.

Verified on the preview deployment: build passes, all 97 pages generate, and `/changelog` renders real releases rather than an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)