### PR TITLE
docs(site): drop the playground example from the Tailwind page

### DIFF
--- a/apps/site/content/docs/v4/tailwind.mdx
+++ b/apps/site/content/docs/v4/tailwind.mdx
@@ -40,8 +40,6 @@ const MyDocument = () => (
 );
 ```
 
-<Example name="tailwind" />
-
 The returned `tw` function takes a space-separated class string and returns a react-pdf `Style` object. Unknown classes are skipped with a console warning, emitted once per distinct class.
 
 ## createTw


### PR DESCRIPTION
Removes the `<Example name="tailwind" />` embed from the Tailwind docs page, leaving the usage code block and the rest of the prose. The `tailwind` playground example itself is untouched and still reachable from the playground's Advanced group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)