### PR TITLE
docs(site): document the conformance Document prop

### DIFF
--- a/apps/site/.gitignore
+++ b/apps/site/.gitignore
@@ -3,3 +3,4 @@
 out/
 next-env.d.ts
 *.tsbuildinfo
+.env*.local

--- a/apps/site/content/docs/v4/components/document.mdx
+++ b/apps/site/content/docs/v4/components/document.mdx
@@ -17,6 +17,7 @@ This component represents the PDF document itself. It _must_ be the root of your
 | creator    |              Sets creator info on the document's metadata               |                                  _String_ | _"react-pdf"_ |
 | producer   |              Sets producer info on the document's metadata              |                                  _String_ | _"react-pdf"_ |
 | pdfVersion |                 Sets PDF version for generated document                 |                                  _String_ |       _"1.3"_ |
+| conformance | Produces PDF/A output with the given conformance level. [See more](/docs/v4/components/document#conformance-type) | [PDFConformance](/docs/v4/components/document#conformance-type) |   _undefined_ |
 | language   |                        Sets PDF default language                        |                                  _String_ |   _undefined_ |
 | pageMode   |       Specifying how the document should be displayed when opened       |     [PageMode](/docs/v4/components/document#pagemode-type) |     _useNone_ |
 | pageLayout |        This controls how (some) PDF viewers choose to show pages        | [PageLayout](/docs/v4/components/document#pagelayout-type) |  _singlePage_ |
@@ -39,6 +40,21 @@ This component represents the PDF document itself. It _must_ be the root of your
 | fullScreen     | Full-screen mode, with no menu bar, window controls, or any other window visible |
 | useOC          |                       Optional content group panel visible                       |
 | useAttachments |                            Attachments panel visible                             |
+
+### Conformance type
+
+`conformance` produces an archival PDF/A file: the document gets XMP conformance metadata and an sRGB OutputIntent, and `pdfVersion` defaults to what the chosen level requires (`1.4` for PDF/A-1, `1.7` for PDF/A-2 and PDF/A-3) unless you set it yourself.
+
+| Value      |               Description               |
+|------------|:---------------------------------------:|
+| PDF/A-1    |  Alias of `PDF/A-1b`, based on PDF 1.4  |
+| PDF/A-1b   |    PDF/A-1 level B conformance          |
+| PDF/A-2    |  Alias of `PDF/A-2b`, based on PDF 1.7  |
+| PDF/A-2b   |    PDF/A-2 level B conformance          |
+| PDF/A-3    |  Alias of `PDF/A-3b`, based on PDF 1.7  |
+| PDF/A-3b   |    PDF/A-3 level B conformance          |
+
+Only b-level (visual appearance) conformance is supported. PDF/A requires every font to be embedded, so register your own fonts with `Font.register` — documents using the built-in standard 14 fonts will not fully validate.
 
 ### Permissions type
 


### PR DESCRIPTION
Documents `conformance`, the `Document` prop added in renderer 4.9.0 (#3529): a table row plus a `Conformance type` section listing the six PDF/A values, the rule that `pdfVersion` defaults to what the level requires (1.4 for PDF/A-1, 1.7 for PDF/A-2/3), and the caveat that fonts must be registered for a document to fully validate. Also adds `.env*.local` to `apps/site/.gitignore` so local Next.js env files stop showing up as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)