### PR TITLE
fix: bump pdfkit to 0.20.2 for tracer-safe standard fonts

### DIFF
--- a/.changeset/bump-pdfkit-standard-fonts.md
+++ b/.changeset/bump-pdfkit-standard-fonts.md
@@ -1,0 +1,6 @@
+---
+'@react-pdf/font': patch
+'@react-pdf/renderer': patch
+---
+
+Bump pdfkit to 0.20.2 so file tracers and bundlers pick up the CommonJS standard-font modules the Node build actually loads, instead of failing at first render with `Cannot find module .../standard-fonts/Helvetica.cjs` in traced deployments (e.g. Next.js standalone output).

--- a/packages/font/package.json
+++ b/packages/font/package.json
@@ -26,7 +26,7 @@
     "@react-pdf/types": "^2.14.0",
     "fontkit": "^2.0.2",
     "is-url": "^1.2.4",
-    "pdfkit": "0.20.1"
+    "pdfkit": "0.20.2"
   },
   "files": [
     "lib"

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -33,7 +33,7 @@
     "@react-pdf/types": "^2.14.0",
     "events": "^3.3.0",
     "object-assign": "^4.1.1",
-    "pdfkit": "0.20.1",
+    "pdfkit": "0.20.2",
     "prop-types": "^15.6.2",
     "queue": "^6.0.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -766,8 +766,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.18.6"
 
-"@babel/plugin-transform-react-jsx-development@^7.18.6", "@babel/plugin-transform-react-jsx-self@^7.23.3":
-  name "@babel/plugin-transform-react-jsx-development"
+"@babel/plugin-transform-react-jsx-development@^7.18.6":
+  version "7.23.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.23.3.tgz#ed3e7dadde046cce761a8e3cf003a13d1a7972d9"
+  integrity sha512-qXRvbeKDSfwnlJnanVRp0SfuWE5DQhwQr5xtLBzp56Wabyo+4CMosF6Kfp+eOD/4FYpql64XVJ2W0pVLlJZxOQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.22.5"
+
+"@babel/plugin-transform-react-jsx-self@^7.23.3":
   version "7.23.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.23.3.tgz#ed3e7dadde046cce761a8e3cf003a13d1a7972d9"
   integrity sha512-qXRvbeKDSfwnlJnanVRp0SfuWE5DQhwQr5xtLBzp56Wabyo+4CMosF6Kfp+eOD/4FYpql64XVJ2W0pVLlJZxOQ==
@@ -8096,10 +8102,10 @@ pdfjs-dist@^5.6.205:
     "@napi-rs/canvas" "^0.1.96"
     node-readable-to-web-readable-stream "^0.4.2"
 
-pdfkit@0.20.1:
-  version "0.20.1"
-  resolved "https://registry.yarnpkg.com/pdfkit/-/pdfkit-0.20.1.tgz#ee79aea058992dbe38e75cbc508c76a621b29f70"
-  integrity sha512-1rRXK6x5o8I/3dBrBzXfxibpHpkfCnIA7EBAES7pEpGFc/65inMLlA8SalGWpJfal7BGekxeLf6A30IOpQpc5Q==
+pdfkit@0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/pdfkit/-/pdfkit-0.20.2.tgz#6a979d812c75b6bc1b554a0641f699228cc94e61"
+  integrity sha512-Q/w03ICAQyXfHNfTsg1udp0ADerdBN0s7a6XSPL7J7Ro6ABnafoBOCDBstIO9U02mvzHEV8HrvFIw5iV5ejIRA==
   dependencies:
     "@noble/ciphers" "^1.3.0"
     "@noble/hashes" "^1.8.0"
@@ -9482,7 +9488,16 @@ string-argv@0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.1.tgz#95e2fbec0427ae19184935f816d74aaa4c5c19da"
   integrity sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -9582,7 +9597,14 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -10553,7 +10575,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -10566,6 +10588,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## What

Bumps the exact `pdfkit` pin in `@react-pdf/font` and `@react-pdf/renderer` from `0.20.1` to `0.20.2`, with a patch changeset for both packages. The lockfile regeneration also let yarn re-normalize one previously merged babel entry.

## Why

pdfkit 0.20.0/0.20.1 map `#standard-fonts/*` to `.cjs` under the `require` condition but `.mjs` under `default`. Node resolves the `.cjs` files at runtime, while file tracers and bundlers — e.g. `@vercel/nft`, which builds Next.js `output: 'standalone'` deployments — resolve the `.mjs` twins. The traced output therefore omits the modules the Node build actually lazy-loads, the build succeeds, and the first server-side render throws:

```
Error: Cannot find module '/app/node_modules/pdfkit/js/standard-fonts/Helvetica.cjs'
```

Helvetica is the default font, so any document without registered fonts hits this immediately. We hit this in production after upgrading `@react-pdf/renderer` 4.5.1 → 4.9.0 (the 4.8.0 fork→upstream pdfkit swap): guest receipt PDFs 500'd in the deployed container while local dev and the build itself were green.

pdfkit 0.20.2 fixes this upstream (foliojs/pdfkit#1782) by resolving the subpath to one file under every condition, so tracers pack what runtime loads. `0.20.1 → 0.20.2` is patch-only with no API change.

Verified in our Next.js standalone deployment: with 0.20.2 (via npm `overrides`) the traced output contains all 14 `standard-fonts/*.cjs` files and server-side rendering works; with 0.20.1 it contains none of them.

Note this is unrelated to #3532 (`TypeError: Invalid URL` from `import.meta.url` under ESBuild-to-CJS transpilation) — different mechanism, not fixed by this bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Z4s94hfd1MWA6TnLmRXEb
